### PR TITLE
Rename attribute key from jaeger.servicename to servicename 

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/resources/missing-downstream-entry-spans/after-enrichment.json
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/resources/missing-downstream-entry-spans/after-enrichment.json
@@ -40,7 +40,7 @@
       "attributes": {
         "org.hypertrace.core.datamodel.Attributes": {
           "attribute_map": {
-            "jaeger.servicename": {
+            "servicename": {
               "value": {
                 "string": "api_01"
               },
@@ -169,7 +169,7 @@
       "attributes": {
         "org.hypertrace.core.datamodel.Attributes": {
           "attribute_map": {
-            "jaeger.servicename": {
+            "servicename": {
               "value": {
                 "string": "api_01"
               },
@@ -296,7 +296,7 @@
       "attributes": {
         "org.hypertrace.core.datamodel.Attributes": {
           "attribute_map": {
-            "jaeger.servicename": {
+            "servicename": {
               "value": {
                 "string": "api_01"
               },
@@ -423,7 +423,7 @@
       "attributes": {
         "org.hypertrace.core.datamodel.Attributes": {
           "attribute_map": {
-            "jaeger.servicename": {
+            "servicename": {
               "value": {
                 "string": "api_02"
               },
@@ -550,7 +550,7 @@
       "attributes": {
         "org.hypertrace.core.datamodel.Attributes": {
           "attribute_map": {
-            "jaeger.servicename": {
+            "servicename": {
               "value": {
                 "string": "api_03"
               },
@@ -685,7 +685,7 @@
       "attributes": {
         "org.hypertrace.core.datamodel.Attributes": {
           "attribute_map": {
-            "jaeger.servicename": {
+            "servicename": {
               "value": {
                 "string": "api_03"
               },

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/resources/missing-downstream-entry-spans/before-enrichment.json
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/resources/missing-downstream-entry-spans/before-enrichment.json
@@ -15,7 +15,7 @@
       "attributes": {
         "org.hypertrace.core.datamodel.Attributes": {
           "attribute_map": {
-            "jaeger.servicename": {
+            "servicename": {
               "value": {
                 "string": "api_01"
               },
@@ -101,7 +101,7 @@
       "attributes": {
         "org.hypertrace.core.datamodel.Attributes": {
           "attribute_map": {
-            "jaeger.servicename": {
+            "servicename": {
               "value": {
                 "string": "api_01"
               },
@@ -192,7 +192,7 @@
       "attributes": {
         "org.hypertrace.core.datamodel.Attributes": {
           "attribute_map": {
-            "jaeger.servicename": {
+            "servicename": {
               "value": {
                 "string": "api_01"
               },
@@ -283,7 +283,7 @@
       "attributes": {
         "org.hypertrace.core.datamodel.Attributes": {
           "attribute_map": {
-            "jaeger.servicename": {
+            "servicename": {
               "value": {
                 "string": "api_02"
               },
@@ -374,7 +374,7 @@
       "attributes": {
         "org.hypertrace.core.datamodel.Attributes": {
           "attribute_map": {
-            "jaeger.servicename": {
+            "servicename": {
               "value": {
                 "string": "api_03"
               },
@@ -465,7 +465,7 @@
       "attributes": {
         "org.hypertrace.core.datamodel.Attributes": {
           "attribute_map": {
-            "jaeger.servicename": {
+            "servicename": {
               "value": {
                 "string": "api_03"
               },

--- a/span-normalizer/raw-span-constants/src/main/proto/org/hypertrace/core/span/constants/v1/span_attribute.proto
+++ b/span-normalizer/raw-span-constants/src/main/proto/org/hypertrace/core/span/constants/v1/span_attribute.proto
@@ -174,5 +174,5 @@ enum TracerAttribute {
 
 enum JaegerAttribute {
     JAEGER_ATTRIBUTE_UNSPECIFIED = 0 [(string_value) = "unspecified"];
-    JAEGER_ATTRIBUTE_SERVICE_NAME = 1 [(string_value) = "jaeger.servicename"];
+    JAEGER_ATTRIBUTE_SERVICE_NAME = 1 [(string_value) = "servicename"];
 }

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
 public class JaegerSpanNormalizer implements SpanNormalizer<Span, RawSpan> {
   private static final Logger LOG = LoggerFactory.getLogger(JaegerSpanNormalizer.class);
 
-  /** */
+  /** Service name can be sent against this key as well */
   public static final String OLD_JAEGER_SERVICENAME_KEY = "jaeger.servicename";
 
   /** Config for providing the tag key in which the tenant id will be given in the span. */


### PR DESCRIPTION
Any consumers of this attribute will now read service name from https://github.com/hypertrace/data-model/blob/main/data-model/src/main/avro/Event.avdl#L61

This attribute key will just surface in the ui under attribute list

<img width="1327" alt="Screenshot 2020-11-10 at 7 11 10 PM" src="https://user-images.githubusercontent.com/6513075/98682595-1b92da00-238a-11eb-9107-151104ee536a.png">
