### PR TITLE
feat: add trace entity reader

### DIFF
--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.3.0")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.0")
   implementation("io.reactivex.rxjava3:rxjava:3.0.6")
-  implementation("com.google.guava:guava:30.0-jre")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
   testImplementation("org.mockito:mockito-core:3.3.3")

--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -10,7 +10,12 @@ dependencies {
   implementation("org.hypertrace.core.attribute.service:attribute-service-api:0.6.1")
   implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.6.1")
   implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.6.1")
+  implementation("org.hypertrace.entity.service:entity-type-service-rx-client:0.2.5")
+  implementation("org.hypertrace.entity.service:entity-data-service-rx-client:0.2.5")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.3.0")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.0")
   implementation("io.reactivex.rxjava3:rxjava:3.0.6")
+  implementation("com.google.guava:guava:30.0-jre")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
   testImplementation("org.mockito:mockito-core:3.3.3")

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/AvroBackedValueSource.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/AvroBackedValueSource.java
@@ -1,4 +1,4 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
 import java.util.Optional;
 import javax.annotation.Nullable;

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/DefaultTraceAttributeReader.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/DefaultTraceAttributeReader.java
@@ -1,6 +1,6 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
-import static org.hypertrace.trace.reader.ValueSource.TRACE_SCOPE;
+import static org.hypertrace.trace.reader.attributes.ValueSource.TRACE_SCOPE;
 
 import io.reactivex.rxjava3.core.Single;
 import org.hypertrace.core.attribute.service.cachingclient.CachingAttributeClient;
@@ -10,13 +10,13 @@ import org.hypertrace.core.attribute.service.v1.LiteralValue;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.StructuredTrace;
 
-class DefaultTraceReader implements TraceReader {
+class DefaultTraceAttributeReader implements TraceAttributeReader {
 
   private final CachingAttributeClient attributeClient;
   private final ValueResolver valueResolver;
   private final AttributeProjectionRegistry projectionRegistry;
 
-  DefaultTraceReader(CachingAttributeClient attributeClient) {
+  DefaultTraceAttributeReader(CachingAttributeClient attributeClient) {
     this.attributeClient = attributeClient;
     this.projectionRegistry = new AttributeProjectionRegistry();
     this.valueResolver = ValueResolver.build(this.attributeClient, this.projectionRegistry);

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/DefaultValueCoercer.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/DefaultValueCoercer.java
@@ -1,4 +1,4 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
 import static java.util.Objects.requireNonNull;
 

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/DefaultValueResolver.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/DefaultValueResolver.java
@@ -1,4 +1,4 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
 import static io.reactivex.rxjava3.core.Single.zip;
 

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/SpanValueSource.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/SpanValueSource.java
@@ -1,4 +1,4 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
 import java.util.Objects;
 import java.util.Optional;

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/TraceAttributeReader.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/TraceAttributeReader.java
@@ -1,4 +1,4 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
 import io.reactivex.rxjava3.core.Single;
 import org.hypertrace.core.attribute.service.cachingclient.CachingAttributeClient;
@@ -6,13 +6,13 @@ import org.hypertrace.core.attribute.service.v1.LiteralValue;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.StructuredTrace;
 
-public interface TraceReader {
+public interface TraceAttributeReader {
   Single<LiteralValue> getSpanValue(
       StructuredTrace trace, Event span, String attributeScope, String attributeKey);
 
   Single<LiteralValue> getTraceValue(StructuredTrace trace, String attributeKey);
 
-  static TraceReader build(CachingAttributeClient attributeClient) {
-    return new DefaultTraceReader(attributeClient);
+  static TraceAttributeReader build(CachingAttributeClient attributeClient) {
+    return new DefaultTraceAttributeReader(attributeClient);
   }
 }

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/TraceValueSource.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/TraceValueSource.java
@@ -1,4 +1,4 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
 import java.util.Objects;
 import java.util.Optional;

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/ValueCoercer.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/ValueCoercer.java
@@ -1,4 +1,4 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
 import java.util.Optional;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/ValueResolver.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/ValueResolver.java
@@ -1,4 +1,4 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
 import io.reactivex.rxjava3.core.Single;
 import org.hypertrace.core.attribute.service.cachingclient.CachingAttributeClient;

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/ValueSource.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/ValueSource.java
@@ -1,4 +1,4 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
 import java.util.Optional;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/AttributeValueConverter.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/AttributeValueConverter.java
@@ -6,8 +6,7 @@ import org.hypertrace.entity.data.service.v1.AttributeValue;
 import org.hypertrace.entity.data.service.v1.Value;
 
 class AttributeValueConverter {
-
-  public Single<AttributeValue> convert(LiteralValue literalValue) {
+  static Single<AttributeValue> convertToAttributeValue(LiteralValue literalValue) {
     switch (literalValue.getValueCase()) {
       case STRING_VALUE:
         return attributeValueSingle(Value.newBuilder().setString(literalValue.getStringValue()));
@@ -25,7 +24,7 @@ class AttributeValueConverter {
     }
   }
 
-  private Single<AttributeValue> attributeValueSingle(Value.Builder value) {
+  private static Single<AttributeValue> attributeValueSingle(Value.Builder value) {
     return Single.just(AttributeValue.newBuilder().setValue(value).build());
   }
 }

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/AttributeValueConverter.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/AttributeValueConverter.java
@@ -1,0 +1,31 @@
+package org.hypertrace.trace.reader.entities;
+
+import io.reactivex.rxjava3.core.Single;
+import org.hypertrace.core.attribute.service.v1.LiteralValue;
+import org.hypertrace.entity.data.service.v1.AttributeValue;
+import org.hypertrace.entity.data.service.v1.Value;
+
+class AttributeValueConverter {
+
+  public Single<AttributeValue> convert(LiteralValue literalValue) {
+    switch (literalValue.getValueCase()) {
+      case STRING_VALUE:
+        return attributeValueSingle(Value.newBuilder().setString(literalValue.getStringValue()));
+      case BOOLEAN_VALUE:
+        return attributeValueSingle(Value.newBuilder().setBoolean(literalValue.getBooleanValue()));
+      case FLOAT_VALUE:
+        return attributeValueSingle(Value.newBuilder().setDouble(literalValue.getFloatValue()));
+      case INT_VALUE:
+        return attributeValueSingle(Value.newBuilder().setLong(literalValue.getIntValue()));
+      case VALUE_NOT_SET:
+      default:
+        return Single.error(
+            new UnsupportedOperationException(
+                "Unexpected literal value case: " + literalValue.getValueCase()));
+    }
+  }
+
+  private Single<AttributeValue> attributeValueSingle(Value.Builder value) {
+    return Single.just(AttributeValue.newBuilder().setValue(value).build());
+  }
+}

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/AvroEntityConverter.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/AvroEntityConverter.java
@@ -1,0 +1,134 @@
+package org.hypertrace.trace.reader.entities;
+
+import static java.util.Objects.nonNull;
+
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
+import java.util.Map;
+import java.util.Map.Entry;
+import javax.annotation.Nonnull;
+import org.hypertrace.core.datamodel.AttributeValue;
+import org.hypertrace.core.datamodel.Attributes;
+import org.hypertrace.core.datamodel.Entity;
+import org.hypertrace.entity.data.service.v1.AttributeValueList;
+import org.hypertrace.entity.data.service.v1.AttributeValueMap;
+import org.hypertrace.entity.data.service.v1.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class AvroEntityConverter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AvroEntityConverter.class);
+
+  public Single<Entity> convertToAvroEntity(
+      @Nonnull String tenantId, @Nonnull org.hypertrace.entity.data.service.v1.Entity entity) {
+    return this.convertAttributes(entity.getAttributesMap())
+        .map(
+            attributes ->
+                Entity.newBuilder()
+                    .setEntityType(entity.getEntityType())
+                    .setEntityId(entity.getEntityId())
+                    .setCustomerId(tenantId)
+                    .setEntityName(entity.getEntityName())
+                    .setAttributes(attributes)
+                    .build());
+  }
+
+  private Single<Attributes> convertAttributes(
+      Map<String, org.hypertrace.entity.data.service.v1.AttributeValue> attributeMap) {
+
+    return Observable.fromIterable(attributeMap.entrySet())
+        .flatMapMaybe(
+            entry ->
+                this.convertAttributeValue(entry.getValue())
+                    .doOnError(error -> LOG.error("Dropping attribute on conversion", error))
+                    .onErrorComplete()
+                    .map(value -> Map.entry(entry.getKey(), value)))
+        .toMap(Entry::getKey, Entry::getValue)
+        .map(convertedMap -> Attributes.newBuilder().setAttributeMap(convertedMap).build());
+  }
+
+  private Single<AttributeValue> convertAttributeValue(
+      org.hypertrace.entity.data.service.v1.AttributeValue value) {
+    switch (value.getTypeCase()) {
+      case VALUE:
+        return this.convertValue(value.getValue());
+      case VALUE_LIST:
+        return this.convertValueList(value.getValueList());
+      case VALUE_MAP:
+        return this.convertValueMap(value.getValueMap());
+      case TYPE_NOT_SET:
+      default:
+        return Single.error(
+            new UnsupportedOperationException(
+                "Unhandled attribute value type: " + value.getTypeCase()));
+    }
+  }
+
+  private Single<AttributeValue> convertValueList(AttributeValueList valueList) {
+    return Observable.fromIterable(valueList.getValuesList())
+        .concatMapSingle(this::convertAttributeValue)
+        .switchMapSingle(
+            value ->
+                nonNull(value.getValue())
+                    ? Single.just(value)
+                    : Single.error(
+                        new UnsupportedOperationException(
+                            "Avro value lists do not support nested lists or maps")))
+        .map(AttributeValue::getValue) // Unwrap and flatten
+        .toList()
+        .map(list -> AttributeValue.newBuilder().setValueList(list).build());
+  }
+
+  private Single<AttributeValue> convertValueMap(AttributeValueMap valueMap) {
+    return Observable.fromIterable(valueMap.getValuesMap().entrySet())
+        .concatMapSingle(
+            entry ->
+                this.convertAttributeValue(entry.getValue())
+                    .flatMap(
+                        value ->
+                            nonNull(value.getValue())
+                                ? Single.just(value)
+                                : Single.error(
+                                    new UnsupportedOperationException(
+                                        "Avro value maps do not support nested lists or maps")))
+                    .map(AttributeValue::getValue) // Unwrap and flatten
+                    .map(value -> Map.entry(entry.getKey(), value)))
+        .toMap(Entry::getKey, Entry::getValue)
+        .map(map -> AttributeValue.newBuilder().setValueMap(map).build());
+  }
+
+  private Single<AttributeValue> convertValue(Value value) {
+    switch (value.getTypeCase()) {
+      case STRING:
+        return this.buildAttributeStringValueSingle(value.getString());
+      case INT:
+        return this.buildAttributeStringValueSingle(String.valueOf(value.getInt()));
+      case LONG:
+        return this.buildAttributeStringValueSingle(String.valueOf(value.getLong()));
+      case DOUBLE:
+        return this.buildAttributeStringValueSingle(String.valueOf(value.getDouble()));
+      case FLOAT:
+        return this.buildAttributeStringValueSingle(String.valueOf(value.getFloat()));
+      case TIMESTAMP:
+        return this.buildAttributeStringValueSingle(String.valueOf(value.getTimestamp()));
+      case BOOLEAN:
+        return this.buildAttributeStringValueSingle(String.valueOf(value.getBoolean()));
+      case BYTES:
+        return Single.just(
+            AttributeValue.newBuilder()
+                .setBinaryValue(value.getBytes().asReadOnlyByteBuffer())
+                .build());
+      case CUSTOM:
+      case TYPE_NOT_SET:
+      default:
+        return Single.error(
+            new UnsupportedOperationException(
+                "Unhandled entity attribute type: " + value.getTypeCase()));
+    }
+  }
+
+  private Single<AttributeValue> buildAttributeStringValueSingle(String value) {
+    return Single.just(AttributeValue.newBuilder().setValue(value).build());
+  }
+}

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReader.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReader.java
@@ -1,0 +1,130 @@
+package org.hypertrace.trace.reader.entities;
+
+import static io.reactivex.rxjava3.core.Maybe.zip;
+
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.hypertrace.core.attribute.service.cachingclient.CachingAttributeClient;
+import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
+import org.hypertrace.core.attribute.service.v1.AttributeType;
+import org.hypertrace.core.datamodel.Entity;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.entity.data.service.rxclient.EntityDataClient;
+import org.hypertrace.entity.data.service.v1.AttributeValue;
+import org.hypertrace.entity.data.service.v1.AttributeValue.TypeCase;
+import org.hypertrace.entity.data.service.v1.Value;
+import org.hypertrace.entity.type.service.rxclient.EntityTypeClient;
+import org.hypertrace.entity.type.service.v2.EntityType;
+import org.hypertrace.trace.reader.attributes.TraceAttributeReader;
+
+class DefaultTraceEntityReader implements TraceEntityReader {
+
+  private final EntityTypeClient entityTypeClient;
+  private final EntityDataClient entityDataClient;
+  private final CachingAttributeClient attributeClient;
+  private final TraceAttributeReader traceAttributeReader;
+  private final AvroEntityConverter avroEntityConverter;
+  private final AttributeValueConverter attributeValueConverter;
+
+  DefaultTraceEntityReader(
+      EntityTypeClient entityTypeClient,
+      EntityDataClient entityDataClient,
+      CachingAttributeClient attributeClient,
+      TraceAttributeReader traceAttributeReader,
+      AvroEntityConverter avroEntityConverter,
+      AttributeValueConverter attributeValueConverter) {
+    this.entityTypeClient = entityTypeClient;
+    this.entityDataClient = entityDataClient;
+    this.attributeClient = attributeClient;
+    this.traceAttributeReader = traceAttributeReader;
+    this.avroEntityConverter = avroEntityConverter;
+    this.attributeValueConverter = attributeValueConverter;
+  }
+
+  @Override
+  public Maybe<Entity> getAssociatedEntityForSpan(
+      String entityType, StructuredTrace trace, Event span) {
+    return this.entityTypeClient
+        .get(entityType)
+        .flatMapMaybe(entityTypeDefinition -> this.getOrCreateAvroEntity(entityTypeDefinition, trace, span));
+  }
+
+  @Override
+  public Single<Map<String, Entity>> getAssociatedEntitiesForSpan(
+      StructuredTrace trace, Event span) {
+
+    return this.entityTypeClient
+        .getAll()
+        .flatMapMaybe(entityType -> this.getOrCreateAvroEntity(entityType, trace, span))
+        .toMap(Entity::getEntityType)
+        .map(Collections::unmodifiableMap);
+  }
+
+  private Maybe<Entity> getOrCreateAvroEntity(
+      EntityType entityType, StructuredTrace trace, Event span) {
+    return this.buildEntity(entityType, trace, span)
+        .flatMapSingle(this.entityDataClient::getOrCreateEntity)
+        .flatMapSingle(
+            entity -> this.avroEntityConverter.convertToAvroEntity(span.getCustomerId(), entity));
+  }
+
+  private Maybe<org.hypertrace.entity.data.service.v1.Entity> buildEntity(
+      EntityType entityType, StructuredTrace trace, Event span) {
+    Maybe<Map<String, AttributeValue>> attributes =
+        this.resolveAllAttributes(entityType.getAttributeScope(), trace, span).cache();
+
+    Maybe<String> id =
+        attributes.mapOptional(map -> this.extractString(map, entityType.getIdAttributeKey()));
+
+    Maybe<String> name =
+        attributes.mapOptional(map -> this.extractString(map, entityType.getNameAttributeKey()));
+
+    return zip(
+        id,
+        name,
+        attributes,
+        (resolvedId, resolvedName, resolvedAttributeMap) ->
+            org.hypertrace.entity.data.service.v1.Entity.newBuilder()
+                .setEntityId(resolvedId)
+                .setEntityType(entityType.getName())
+                .setEntityName(resolvedName)
+                .putAllIdentifyingAttributes(resolvedAttributeMap)
+                .putAllAttributes(resolvedAttributeMap)
+                .build());
+  }
+
+  private Maybe<Map<String, AttributeValue>> resolveAllAttributes(
+      String scope, StructuredTrace trace, Event span) {
+    return this.attributeClient
+        .getAllInScope(scope)
+        .flattenAsObservable(list -> list)
+        .filter(attributeMetadata -> attributeMetadata.getType().equals(AttributeType.ATTRIBUTE))
+        .flatMapMaybe(attributeMetadata -> this.resolveAttribute(attributeMetadata, trace, span))
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue))
+        .toMaybe();
+  }
+
+  private Maybe<Entry<String, AttributeValue>> resolveAttribute(
+      AttributeMetadata attributeMetadata, StructuredTrace trace, Event span) {
+    return this.traceAttributeReader
+        .getSpanValue(trace, span, attributeMetadata.getScopeString(), attributeMetadata.getKey())
+        .onErrorComplete()
+        .flatMapSingle(this.attributeValueConverter::convert)
+        .map(value -> Map.entry(attributeMetadata.getKey(), value));
+  }
+
+  private Optional<String> extractString(
+      Map<String, AttributeValue> attributeValueMap, String key) {
+    return Optional.ofNullable(attributeValueMap.get(key))
+        .filter(value -> value.getTypeCase().equals(TypeCase.VALUE))
+        .map(AttributeValue::getValue)
+        .filter(value -> value.getTypeCase().equals(Value.TypeCase.STRING))
+        .map(Value::getString);
+  }
+}

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/TraceEntityReader.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/TraceEntityReader.java
@@ -1,0 +1,15 @@
+package org.hypertrace.trace.reader.entities;
+
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.util.Map;
+import org.hypertrace.core.datamodel.Entity;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.StructuredTrace;
+
+public interface TraceEntityReader {
+
+  Maybe<Entity> getAssociatedEntityForSpan(String entityType, StructuredTrace trace, Event span);
+
+  Single<Map<String, Entity>> getAssociatedEntitiesForSpan(StructuredTrace trace, Event span);
+}

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/TraceEntityReader.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/TraceEntityReader.java
@@ -25,8 +25,6 @@ public interface TraceEntityReader {
         entityTypeClient,
         entityDataClient,
         attributeClient,
-        TraceAttributeReader.build(attributeClient),
-        new AvroEntityConverter(),
-        new AttributeValueConverter());
+        TraceAttributeReader.build(attributeClient));
   }
 }

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/TraceEntityReader.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/TraceEntityReader.java
@@ -3,13 +3,30 @@ package org.hypertrace.trace.reader.entities;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import java.util.Map;
+import org.hypertrace.core.attribute.service.cachingclient.CachingAttributeClient;
 import org.hypertrace.core.datamodel.Entity;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.entity.data.service.rxclient.EntityDataClient;
+import org.hypertrace.entity.type.service.rxclient.EntityTypeClient;
+import org.hypertrace.trace.reader.attributes.TraceAttributeReader;
 
 public interface TraceEntityReader {
 
   Maybe<Entity> getAssociatedEntityForSpan(String entityType, StructuredTrace trace, Event span);
 
   Single<Map<String, Entity>> getAssociatedEntitiesForSpan(StructuredTrace trace, Event span);
+
+  static TraceEntityReader build(
+      EntityTypeClient entityTypeClient,
+      EntityDataClient entityDataClient,
+      CachingAttributeClient attributeClient) {
+    return new DefaultTraceEntityReader(
+        entityTypeClient,
+        entityDataClient,
+        attributeClient,
+        TraceAttributeReader.build(attributeClient),
+        new AvroEntityConverter(),
+        new AttributeValueConverter());
+  }
 }

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/TraceEntityReaderBuilder.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/TraceEntityReaderBuilder.java
@@ -1,0 +1,62 @@
+package org.hypertrace.trace.reader.entities;
+
+import io.grpc.Channel;
+import org.hypertrace.core.attribute.service.cachingclient.CachingAttributeClient;
+import org.hypertrace.entity.data.service.rxclient.EntityDataClient;
+import org.hypertrace.entity.type.service.rxclient.EntityTypeClient;
+import org.hypertrace.trace.reader.attributes.TraceAttributeReader;
+
+public class TraceEntityReaderBuilder {
+  /**
+   * Instantiates a new builder which reuses existing clients
+   *
+   * @param entityTypeClient
+   * @param entityDataClient
+   * @param attributeClient
+   * @return TraceEntityReaderBuilder
+   */
+  public static TraceEntityReaderBuilder usingClients(
+      EntityTypeClient entityTypeClient,
+      EntityDataClient entityDataClient,
+      CachingAttributeClient attributeClient) {
+    return new TraceEntityReaderBuilder(entityTypeClient, entityDataClient, attributeClient);
+  }
+
+  /**
+   * Instantiates a new builder which creates default configured caches for connections to each
+   * service.
+   *
+   * @param entityDataChannel
+   * @param entityTypeChannel
+   * @param attributeChannel
+   * @return TraceEntityReaderBuilder
+   */
+  public static TraceEntityReaderBuilder usingChannels(
+      Channel entityDataChannel, Channel entityTypeChannel, Channel attributeChannel) {
+    return new TraceEntityReaderBuilder(
+        EntityTypeClient.builder(entityTypeChannel).build(),
+        EntityDataClient.builder(entityDataChannel).build(),
+        CachingAttributeClient.builder(attributeChannel).build());
+  }
+
+  private final EntityTypeClient entityTypeClient;
+  private final EntityDataClient entityDataClient;
+  private final CachingAttributeClient attributeClient;
+
+  private TraceEntityReaderBuilder(
+      EntityTypeClient entityTypeClient,
+      EntityDataClient entityDataClient,
+      CachingAttributeClient attributeClient) {
+    this.entityTypeClient = entityTypeClient;
+    this.entityDataClient = entityDataClient;
+    this.attributeClient = attributeClient;
+  }
+
+  public TraceEntityReader build() {
+    return new DefaultTraceEntityReader(
+        this.entityTypeClient,
+        this.entityDataClient,
+        this.attributeClient,
+        TraceAttributeReader.build(this.attributeClient));
+  }
+}

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/AvroUtil.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/AvroUtil.java
@@ -1,8 +1,11 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Attributes;
 import org.hypertrace.core.datamodel.Event;
@@ -34,11 +37,28 @@ public class AvroUtil {
   }
 
   public static Attributes buildAttributesWithKeyValue(String key, String value) {
-    return Attributes.newBuilder().setAttributeMap(Map.of(key, buildAttributeValue(value))).build();
+    return buildAttributesWithKeyValues(Map.of(key, value));
+  }
+
+  public static Attributes buildAttributesWithKeyValues(Map<String, String> valueMap) {
+    Map<String, AttributeValue> convertedValueMap =
+        valueMap.entrySet().stream()
+            .map(entry -> Map.entry(entry.getKey(), buildAttributeValue(entry.getValue())))
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+    return Attributes.newBuilder().setAttributeMap(convertedValueMap).build();
   }
 
   public static AttributeValue buildAttributeValue(String value) {
     return AttributeValue.newBuilder().setValue(value).build();
+  }
+
+  public static AttributeValue buildAttributeValueList(List<String> valueList) {
+    return AttributeValue.newBuilder().setValueList(valueList).build();
+  }
+
+  public static AttributeValue buildAttributeValueMap(Map<String, String> valueMap) {
+    return AttributeValue.newBuilder().setValueMap(valueMap).build();
   }
 
   public static MetricValue buildMetricValue(double value) {

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/DefaultTraceAttributeReaderTest.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/DefaultTraceAttributeReaderTest.java
@@ -1,9 +1,9 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
-import static org.hypertrace.trace.reader.AvroUtil.buildAttributesWithKeyValue;
-import static org.hypertrace.trace.reader.AvroUtil.defaultedEventBuilder;
-import static org.hypertrace.trace.reader.AvroUtil.defaultedStructuredTraceBuilder;
-import static org.hypertrace.trace.reader.LiteralValueUtil.stringLiteral;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.buildAttributesWithKeyValue;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.defaultedEventBuilder;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.defaultedStructuredTraceBuilder;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.stringLiteral;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -23,14 +23,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class DefaultTraceReaderTest {
+class DefaultTraceAttributeReaderTest {
 
   @Mock CachingAttributeClient mockAttributeClient;
-  private TraceReader traceReader;
+  private TraceAttributeReader traceAttributeReader;
 
   @BeforeEach
   void beforeEach() {
-    this.traceReader = TraceReader.build(this.mockAttributeClient);
+    this.traceAttributeReader = TraceAttributeReader.build(this.mockAttributeClient);
   }
 
   @Test
@@ -51,7 +51,7 @@ class DefaultTraceReaderTest {
 
     assertEquals(
         stringLiteral("attrValue"),
-        this.traceReader
+        this.traceAttributeReader
             .getSpanValue(mock(StructuredTrace.class), span, "TEST_SCOPE", "key")
             .blockingGet());
   }
@@ -73,6 +73,6 @@ class DefaultTraceReaderTest {
             .build();
 
     assertEquals(
-        stringLiteral("attrValue"), this.traceReader.getTraceValue(trace, "key").blockingGet());
+        stringLiteral("attrValue"), this.traceAttributeReader.getTraceValue(trace, "key").blockingGet());
   }
 }

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/DefaultValueCoercerTest.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/DefaultValueCoercerTest.java
@@ -1,9 +1,9 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
-import static org.hypertrace.trace.reader.LiteralValueUtil.booleanLiteral;
-import static org.hypertrace.trace.reader.LiteralValueUtil.doubleLiteral;
-import static org.hypertrace.trace.reader.LiteralValueUtil.longLiteral;
-import static org.hypertrace.trace.reader.LiteralValueUtil.stringLiteral;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.booleanLiteral;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.doubleLiteral;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.longLiteral;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.stringLiteral;
 
 import java.util.Optional;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/DefaultValueResolverTest.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/DefaultValueResolverTest.java
@@ -1,11 +1,11 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
-import static org.hypertrace.trace.reader.AvroUtil.buildAttributesWithKeyValue;
-import static org.hypertrace.trace.reader.AvroUtil.buildMetricsWithKeyValue;
-import static org.hypertrace.trace.reader.AvroUtil.defaultedEventBuilder;
-import static org.hypertrace.trace.reader.AvroUtil.defaultedStructuredTraceBuilder;
-import static org.hypertrace.trace.reader.LiteralValueUtil.longLiteral;
-import static org.hypertrace.trace.reader.LiteralValueUtil.stringLiteral;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.buildAttributesWithKeyValue;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.buildMetricsWithKeyValue;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.defaultedEventBuilder;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.defaultedStructuredTraceBuilder;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.longLiteral;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.stringLiteral;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/LiteralValueUtil.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/LiteralValueUtil.java
@@ -1,4 +1,4 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
 import org.hypertrace.core.attribute.service.v1.LiteralValue;
 

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/SpanValueSourceTest.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/SpanValueSourceTest.java
@@ -1,11 +1,11 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
-import static org.hypertrace.trace.reader.AvroUtil.buildAttributesWithKeyValue;
-import static org.hypertrace.trace.reader.AvroUtil.buildMetricsWithKeyValue;
-import static org.hypertrace.trace.reader.AvroUtil.defaultedEventBuilder;
-import static org.hypertrace.trace.reader.LiteralValueUtil.doubleLiteral;
-import static org.hypertrace.trace.reader.LiteralValueUtil.longLiteral;
-import static org.hypertrace.trace.reader.LiteralValueUtil.stringLiteral;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.buildAttributesWithKeyValue;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.buildMetricsWithKeyValue;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.defaultedEventBuilder;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.doubleLiteral;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.longLiteral;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.stringLiteral;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/TraceValueSourceTest.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/TraceValueSourceTest.java
@@ -1,11 +1,11 @@
-package org.hypertrace.trace.reader;
+package org.hypertrace.trace.reader.attributes;
 
-import static org.hypertrace.trace.reader.AvroUtil.buildAttributesWithKeyValue;
-import static org.hypertrace.trace.reader.AvroUtil.buildMetricsWithKeyValue;
-import static org.hypertrace.trace.reader.AvroUtil.defaultedStructuredTraceBuilder;
-import static org.hypertrace.trace.reader.LiteralValueUtil.doubleLiteral;
-import static org.hypertrace.trace.reader.LiteralValueUtil.longLiteral;
-import static org.hypertrace.trace.reader.LiteralValueUtil.stringLiteral;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.buildAttributesWithKeyValue;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.buildMetricsWithKeyValue;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.defaultedStructuredTraceBuilder;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.doubleLiteral;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.longLiteral;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.stringLiteral;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/AttributeValueConverterTest.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/AttributeValueConverterTest.java
@@ -1,0 +1,54 @@
+package org.hypertrace.trace.reader.entities;
+
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.booleanLiteral;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.doubleLiteral;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.longLiteral;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.stringLiteral;
+import static org.hypertrace.trace.reader.entities.AttributeValueUtil.booleanAttributeValue;
+import static org.hypertrace.trace.reader.entities.AttributeValueUtil.doubleAttributeValue;
+import static org.hypertrace.trace.reader.entities.AttributeValueUtil.longAttributeValue;
+import static org.hypertrace.trace.reader.entities.AttributeValueUtil.stringAttributeValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.hypertrace.core.attribute.service.v1.LiteralValue;
+import org.junit.jupiter.api.Test;
+
+class AttributeValueConverterTest {
+
+  private final AttributeValueConverter CONVERTER = new AttributeValueConverter();
+
+  @Test
+  void convertsStringValue() {
+    assertEquals(
+        stringAttributeValue("foo"), CONVERTER.convert(stringLiteral("foo")).blockingGet());
+    assertEquals(stringAttributeValue(""), CONVERTER.convert(stringLiteral("")).blockingGet());
+  }
+
+  @Test
+  void convertsBooleanValue() {
+    assertEquals(
+        booleanAttributeValue(true), CONVERTER.convert(booleanLiteral(true)).blockingGet());
+    assertEquals(
+        booleanAttributeValue(false), CONVERTER.convert(booleanLiteral(false)).blockingGet());
+  }
+
+  @Test
+  void convertsIntValue() {
+    assertEquals(longAttributeValue(0), CONVERTER.convert(longLiteral(0)).blockingGet());
+    assertEquals(longAttributeValue(100), CONVERTER.convert(longLiteral(100)).blockingGet());
+  }
+
+  @Test
+  void convertsFloatValue() {
+    assertEquals(doubleAttributeValue(10.4), CONVERTER.convert(doubleLiteral(10.4)).blockingGet());
+    assertEquals(doubleAttributeValue(-3.5), CONVERTER.convert(doubleLiteral(-3.5)).blockingGet());
+  }
+
+  @Test
+  void errorsOnUnknownValue() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> CONVERTER.convert(LiteralValue.getDefaultInstance()).blockingGet());
+  }
+}

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/AttributeValueConverterTest.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/AttributeValueConverterTest.java
@@ -4,6 +4,7 @@ import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.booleanLit
 import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.doubleLiteral;
 import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.longLiteral;
 import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.stringLiteral;
+import static org.hypertrace.trace.reader.entities.AttributeValueConverter.convertToAttributeValue;
 import static org.hypertrace.trace.reader.entities.AttributeValueUtil.booleanAttributeValue;
 import static org.hypertrace.trace.reader.entities.AttributeValueUtil.doubleAttributeValue;
 import static org.hypertrace.trace.reader.entities.AttributeValueUtil.longAttributeValue;
@@ -16,39 +17,40 @@ import org.junit.jupiter.api.Test;
 
 class AttributeValueConverterTest {
 
-  private final AttributeValueConverter CONVERTER = new AttributeValueConverter();
-
   @Test
   void convertsStringValue() {
     assertEquals(
-        stringAttributeValue("foo"), CONVERTER.convert(stringLiteral("foo")).blockingGet());
-    assertEquals(stringAttributeValue(""), CONVERTER.convert(stringLiteral("")).blockingGet());
+        stringAttributeValue("foo"), convertToAttributeValue(stringLiteral("foo")).blockingGet());
+    assertEquals(
+        stringAttributeValue(""), convertToAttributeValue(stringLiteral("")).blockingGet());
   }
 
   @Test
   void convertsBooleanValue() {
     assertEquals(
-        booleanAttributeValue(true), CONVERTER.convert(booleanLiteral(true)).blockingGet());
+        booleanAttributeValue(true), convertToAttributeValue(booleanLiteral(true)).blockingGet());
     assertEquals(
-        booleanAttributeValue(false), CONVERTER.convert(booleanLiteral(false)).blockingGet());
+        booleanAttributeValue(false), convertToAttributeValue(booleanLiteral(false)).blockingGet());
   }
 
   @Test
   void convertsIntValue() {
-    assertEquals(longAttributeValue(0), CONVERTER.convert(longLiteral(0)).blockingGet());
-    assertEquals(longAttributeValue(100), CONVERTER.convert(longLiteral(100)).blockingGet());
+    assertEquals(longAttributeValue(0), convertToAttributeValue(longLiteral(0)).blockingGet());
+    assertEquals(longAttributeValue(100), convertToAttributeValue(longLiteral(100)).blockingGet());
   }
 
   @Test
   void convertsFloatValue() {
-    assertEquals(doubleAttributeValue(10.4), CONVERTER.convert(doubleLiteral(10.4)).blockingGet());
-    assertEquals(doubleAttributeValue(-3.5), CONVERTER.convert(doubleLiteral(-3.5)).blockingGet());
+    assertEquals(
+        doubleAttributeValue(10.4), convertToAttributeValue(doubleLiteral(10.4)).blockingGet());
+    assertEquals(
+        doubleAttributeValue(-3.5), convertToAttributeValue(doubleLiteral(-3.5)).blockingGet());
   }
 
   @Test
   void errorsOnUnknownValue() {
     assertThrows(
         UnsupportedOperationException.class,
-        () -> CONVERTER.convert(LiteralValue.getDefaultInstance()).blockingGet());
+        () -> convertToAttributeValue(LiteralValue.getDefaultInstance()).blockingGet());
   }
 }

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/AttributeValueUtil.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/AttributeValueUtil.java
@@ -1,0 +1,83 @@
+package org.hypertrace.trace.reader.entities;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.hypertrace.entity.data.service.v1.AttributeValue;
+import org.hypertrace.entity.data.service.v1.AttributeValueList;
+import org.hypertrace.entity.data.service.v1.AttributeValueMap;
+import org.hypertrace.entity.data.service.v1.Value;
+
+public class AttributeValueUtil {
+
+  public static AttributeValue stringAttributeValue(String stringValue) {
+    return AttributeValue.newBuilder().setValue(Value.newBuilder().setString(stringValue)).build();
+  }
+
+  public static AttributeValue stringListAttributeValue(String... stringValues) {
+    List<AttributeValue> values =
+        Arrays.stream(stringValues)
+            .map(AttributeValueUtil::stringAttributeValue)
+            .collect(Collectors.toList());
+    return AttributeValue.newBuilder()
+        .setValueList(AttributeValueList.newBuilder().addAllValues(values))
+        .build();
+  }
+
+  public static AttributeValue stringMapAttributeValue(Map<String, String> values) {
+    Map<String, AttributeValue> convertedValueMap =
+        values.entrySet().stream()
+            .map(entry -> Map.entry(entry.getKey(), stringAttributeValue(entry.getValue())))
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+    return AttributeValue.newBuilder()
+        .setValueMap(AttributeValueMap.newBuilder().putAllValues(convertedValueMap))
+        .build();
+  }
+
+  public static AttributeValue longAttributeValue(long longValue) {
+    return AttributeValue.newBuilder().setValue(Value.newBuilder().setLong(longValue)).build();
+  }
+
+  public static AttributeValue longListAttributeValue(Long... longValues) {
+    List<AttributeValue> values =
+        Arrays.stream(longValues)
+            .map(AttributeValueUtil::longAttributeValue)
+            .collect(Collectors.toList());
+    return AttributeValue.newBuilder()
+        .setValueList(AttributeValueList.newBuilder().addAllValues(values))
+        .build();
+  }
+
+  public static AttributeValue doubleAttributeValue(double doubleValue) {
+    return AttributeValue.newBuilder().setValue(Value.newBuilder().setDouble(doubleValue)).build();
+  }
+
+  public static AttributeValue doubleListAttributeValue(Double... doubleValues) {
+    List<AttributeValue> values =
+        Arrays.stream(doubleValues)
+            .map(AttributeValueUtil::doubleAttributeValue)
+            .collect(Collectors.toList());
+    return AttributeValue.newBuilder()
+        .setValueList(AttributeValueList.newBuilder().addAllValues(values))
+        .build();
+  }
+
+  public static AttributeValue booleanAttributeValue(boolean booleanValue) {
+    return AttributeValue.newBuilder()
+        .setValue(Value.newBuilder().setBoolean(booleanValue))
+        .build();
+  }
+
+  public static AttributeValue booleanListAttributeValue(Boolean... booleanValues) {
+    List<AttributeValue> values =
+        Arrays.stream(booleanValues)
+            .map(AttributeValueUtil::booleanAttributeValue)
+            .collect(Collectors.toList());
+    return AttributeValue.newBuilder()
+        .setValueList(AttributeValueList.newBuilder().addAllValues(values))
+        .build();
+  }
+}

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/AvroEntityConverterTest.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/AvroEntityConverterTest.java
@@ -1,0 +1,119 @@
+package org.hypertrace.trace.reader.entities;
+
+import static org.hypertrace.trace.reader.attributes.AvroUtil.buildAttributeValue;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.buildAttributeValueList;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.buildAttributeValueMap;
+import static org.hypertrace.trace.reader.entities.AttributeValueUtil.booleanAttributeValue;
+import static org.hypertrace.trace.reader.entities.AttributeValueUtil.booleanListAttributeValue;
+import static org.hypertrace.trace.reader.entities.AttributeValueUtil.doubleAttributeValue;
+import static org.hypertrace.trace.reader.entities.AttributeValueUtil.doubleListAttributeValue;
+import static org.hypertrace.trace.reader.entities.AttributeValueUtil.longAttributeValue;
+import static org.hypertrace.trace.reader.entities.AttributeValueUtil.longListAttributeValue;
+import static org.hypertrace.trace.reader.entities.AttributeValueUtil.stringAttributeValue;
+import static org.hypertrace.trace.reader.entities.AttributeValueUtil.stringListAttributeValue;
+import static org.hypertrace.trace.reader.entities.AttributeValueUtil.stringMapAttributeValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import org.hypertrace.core.datamodel.Attributes;
+import org.hypertrace.core.datamodel.Entity;
+import org.junit.jupiter.api.Test;
+
+class AvroEntityConverterTest {
+  private static final AvroEntityConverter CONVERTER = new AvroEntityConverter();
+  private static final String TENANT_ID = "tenant-id";
+  private static final org.hypertrace.entity.data.service.v1.Entity BASIC_ENTITY =
+      org.hypertrace.entity.data.service.v1.Entity.newBuilder()
+          .setEntityType("entity-type")
+          .setEntityId("entity-id")
+          .setEntityName("entity-name")
+          .build();
+
+  private static final Entity BASIC_AVRO_ENTITY =
+      Entity.newBuilder()
+          .setEntityType("entity-type")
+          .setEntityId("entity-id")
+          .setEntityName("entity-name")
+          .setCustomerId(TENANT_ID)
+          .build();
+
+  @Test
+  void convertsPrimitives() {
+    org.hypertrace.entity.data.service.v1.Entity inputEntity =
+        BASIC_ENTITY.toBuilder()
+            .putAttributes("string", stringAttributeValue("string-value"))
+            .putAttributes("long", longAttributeValue(42))
+            .putAttributes("double", doubleAttributeValue(10.2))
+            .putAttributes("boolean", booleanAttributeValue(true))
+            .build();
+
+    Entity expectedAvroEntity =
+        Entity.newBuilder(BASIC_AVRO_ENTITY)
+            .setAttributesBuilder(
+                Attributes.newBuilder()
+                    .setAttributeMap(
+                        Map.of(
+                            "string",
+                            buildAttributeValue("string-value"),
+                            "long",
+                            buildAttributeValue("42"),
+                            "double",
+                            buildAttributeValue("10.2"),
+                            "boolean",
+                            buildAttributeValue("true"))))
+            .build();
+
+    assertEquals(
+        expectedAvroEntity, CONVERTER.convertToAvroEntity(TENANT_ID, inputEntity).blockingGet());
+  }
+
+  @Test
+  void convertsAttributeLists() {
+    org.hypertrace.entity.data.service.v1.Entity inputEntity =
+        BASIC_ENTITY.toBuilder()
+            .putAttributes("string-list", stringListAttributeValue("s-v-1", "s-v-2"))
+            .putAttributes("long-list", longListAttributeValue(42L, 30L))
+            .putAttributes("double-list", doubleListAttributeValue(10.2, 30.3))
+            .putAttributes("boolean-list", booleanListAttributeValue(true, false))
+            .build();
+
+    Entity expectedAvroEntity =
+        Entity.newBuilder(BASIC_AVRO_ENTITY)
+            .setAttributesBuilder(
+                Attributes.newBuilder()
+                    .setAttributeMap(
+                        Map.of(
+                            "string-list",
+                            buildAttributeValueList(List.of("s-v-1", "s-v-2")),
+                            "long-list",
+                            buildAttributeValueList(List.of("42", "30")),
+                            "double-list",
+                            buildAttributeValueList(List.of("10.2", "30.3")),
+                            "boolean-list",
+                            buildAttributeValueList(List.of("true", "false")))))
+            .build();
+
+    assertEquals(
+        expectedAvroEntity, CONVERTER.convertToAvroEntity(TENANT_ID, inputEntity).blockingGet());
+  }
+
+  @Test
+  void convertsAttributeMaps() {
+    org.hypertrace.entity.data.service.v1.Entity inputEntity =
+        BASIC_ENTITY.toBuilder()
+            .putAttributes("map", stringMapAttributeValue(Map.of("map-key-1", "map-value-1")))
+            .build();
+
+    Entity expectedAvroEntity =
+        Entity.newBuilder(BASIC_AVRO_ENTITY)
+            .setAttributesBuilder(
+                Attributes.newBuilder()
+                    .setAttributeMap(
+                        Map.of("map", buildAttributeValueMap(Map.of("map-key-1", "map-value-1")))))
+            .build();
+
+    assertEquals(
+        expectedAvroEntity, CONVERTER.convertToAvroEntity(TENANT_ID, inputEntity).blockingGet());
+  }
+}

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/AvroEntityConverterTest.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/AvroEntityConverterTest.java
@@ -12,6 +12,7 @@ import static org.hypertrace.trace.reader.entities.AttributeValueUtil.longListAt
 import static org.hypertrace.trace.reader.entities.AttributeValueUtil.stringAttributeValue;
 import static org.hypertrace.trace.reader.entities.AttributeValueUtil.stringListAttributeValue;
 import static org.hypertrace.trace.reader.entities.AttributeValueUtil.stringMapAttributeValue;
+import static org.hypertrace.trace.reader.entities.AvroEntityConverter.convertToAvroEntity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -21,7 +22,6 @@ import org.hypertrace.core.datamodel.Entity;
 import org.junit.jupiter.api.Test;
 
 class AvroEntityConverterTest {
-  private static final AvroEntityConverter CONVERTER = new AvroEntityConverter();
   private static final String TENANT_ID = "tenant-id";
   private static final org.hypertrace.entity.data.service.v1.Entity BASIC_ENTITY =
       org.hypertrace.entity.data.service.v1.Entity.newBuilder()
@@ -64,8 +64,7 @@ class AvroEntityConverterTest {
                             buildAttributeValue("true"))))
             .build();
 
-    assertEquals(
-        expectedAvroEntity, CONVERTER.convertToAvroEntity(TENANT_ID, inputEntity).blockingGet());
+    assertEquals(expectedAvroEntity, convertToAvroEntity(TENANT_ID, inputEntity).blockingGet());
   }
 
   @Test
@@ -94,8 +93,7 @@ class AvroEntityConverterTest {
                             buildAttributeValueList(List.of("true", "false")))))
             .build();
 
-    assertEquals(
-        expectedAvroEntity, CONVERTER.convertToAvroEntity(TENANT_ID, inputEntity).blockingGet());
+    assertEquals(expectedAvroEntity, convertToAvroEntity(TENANT_ID, inputEntity).blockingGet());
   }
 
   @Test
@@ -113,7 +111,6 @@ class AvroEntityConverterTest {
                         Map.of("map", buildAttributeValueMap(Map.of("map-key-1", "map-value-1")))))
             .build();
 
-    assertEquals(
-        expectedAvroEntity, CONVERTER.convertToAvroEntity(TENANT_ID, inputEntity).blockingGet());
+    assertEquals(expectedAvroEntity, convertToAvroEntity(TENANT_ID, inputEntity).blockingGet());
   }
 }

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReaderTest.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReaderTest.java
@@ -1,0 +1,141 @@
+package org.hypertrace.trace.reader.entities;
+
+import static org.hypertrace.trace.reader.attributes.AvroUtil.buildAttributesWithKeyValues;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.defaultedEventBuilder;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.defaultedStructuredTraceBuilder;
+import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.stringLiteral;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+import java.util.Map;
+import org.hypertrace.core.attribute.service.cachingclient.CachingAttributeClient;
+import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
+import org.hypertrace.core.attribute.service.v1.AttributeType;
+import org.hypertrace.core.datamodel.Entity;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.entity.data.service.rxclient.EntityDataClient;
+import org.hypertrace.entity.type.service.rxclient.EntityTypeClient;
+import org.hypertrace.entity.type.service.v2.EntityType;
+import org.hypertrace.trace.reader.attributes.TraceAttributeReader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultTraceEntityReaderTest {
+  private static final String TENANT_ID = "tenant-id";
+  private static final String TEST_ENTITY_TYPE_NAME = "ENTITY_TYPE_1";
+  private static final String TEST_ENTITY_ID_ATTRIBUTE_KEY = "id";
+  private static final String TEST_ENTITY_NAME_ATTRIBUTE_KEY = "name";
+  private static final AttributeMetadata TEST_ENTITY_ID_ATTRIBUTE =
+      AttributeMetadata.newBuilder()
+          .setScopeString(TEST_ENTITY_TYPE_NAME)
+          .setKey(TEST_ENTITY_ID_ATTRIBUTE_KEY)
+          .setType(AttributeType.ATTRIBUTE)
+          .build();
+  private static final AttributeMetadata TEST_ENTITY_NAME_ATTRIBUTE =
+      AttributeMetadata.newBuilder()
+          .setScopeString(TEST_ENTITY_TYPE_NAME)
+          .setKey(TEST_ENTITY_NAME_ATTRIBUTE_KEY)
+          .setType(AttributeType.ATTRIBUTE)
+          .build();
+  private static final EntityType TEST_ENTITY_TYPE =
+      EntityType.newBuilder()
+          .setAttributeScope(TEST_ENTITY_TYPE_NAME)
+          .setName(TEST_ENTITY_TYPE_NAME)
+          .setIdAttributeKey(TEST_ENTITY_ID_ATTRIBUTE_KEY)
+          .setNameAttributeKey(TEST_ENTITY_NAME_ATTRIBUTE_KEY)
+          .build();
+
+  private static final StructuredTrace TEST_TRACE = defaultedStructuredTraceBuilder().build();
+  private static final Event TEST_SPAN = defaultedEventBuilder().setCustomerId(TENANT_ID).build();
+  private static final Entity BASIC_AVRO_ENTITY =
+      Entity.newBuilder()
+          .setEntityType(TEST_ENTITY_TYPE_NAME)
+          .setEntityId("id-value")
+          .setEntityName("name-value")
+          .setCustomerId(TENANT_ID)
+          .build();
+
+  @Mock EntityTypeClient mockTypeClient;
+  @Mock EntityDataClient mockDataClient;
+  @Mock CachingAttributeClient mockAttributeClient;
+  @Mock TraceAttributeReader mockAttributeReader;
+
+  private DefaultTraceEntityReader entityReader;
+
+  @BeforeEach
+  void beforeEach() {
+    this.entityReader =
+        new DefaultTraceEntityReader(
+            this.mockTypeClient,
+            this.mockDataClient,
+            this.mockAttributeClient,
+            this.mockAttributeReader,
+            new AvroEntityConverter(),
+            new AttributeValueConverter());
+  }
+
+  @Test
+  void canReadAnEntity() {
+    when(this.mockTypeClient.get(TEST_ENTITY_TYPE_NAME)).thenReturn(Single.just(TEST_ENTITY_TYPE));
+    when(this.mockAttributeClient.getAllInScope(TEST_ENTITY_TYPE_NAME))
+        .thenReturn(Single.just(List.of(TEST_ENTITY_ID_ATTRIBUTE, TEST_ENTITY_NAME_ATTRIBUTE)));
+    when(this.mockAttributeReader.getSpanValue(
+            TEST_TRACE, TEST_SPAN, TEST_ENTITY_TYPE_NAME, TEST_ENTITY_ID_ATTRIBUTE_KEY))
+        .thenReturn(Single.just(stringLiteral("id-value")));
+    when(this.mockAttributeReader.getSpanValue(
+            TEST_TRACE, TEST_SPAN, TEST_ENTITY_TYPE_NAME, TEST_ENTITY_NAME_ATTRIBUTE_KEY))
+        .thenReturn(Single.just(stringLiteral("name-value")));
+    when(this.mockDataClient.getOrCreateEntity(
+            any(org.hypertrace.entity.data.service.v1.Entity.class)))
+        .thenAnswer(invocation -> Single.just(invocation.getArgument(0)));
+    Entity expectedEntity =
+        Entity.newBuilder(BASIC_AVRO_ENTITY)
+            .setAttributes(
+                buildAttributesWithKeyValues(
+                    Map.of(
+                        TEST_ENTITY_ID_ATTRIBUTE_KEY, "id-value",
+                        TEST_ENTITY_NAME_ATTRIBUTE_KEY, "name-value")))
+            .build();
+    assertEquals(
+        expectedEntity,
+        this.entityReader
+            .getAssociatedEntityForSpan(TEST_ENTITY_TYPE_NAME, TEST_TRACE, TEST_SPAN)
+            .blockingGet());
+  }
+
+  @Test
+  void canReadAllEntities() {
+    when(this.mockTypeClient.getAll()).thenReturn(Observable.just(TEST_ENTITY_TYPE));
+    when(this.mockAttributeClient.getAllInScope(TEST_ENTITY_TYPE_NAME))
+        .thenReturn(Single.just(List.of(TEST_ENTITY_ID_ATTRIBUTE, TEST_ENTITY_NAME_ATTRIBUTE)));
+    when(this.mockAttributeReader.getSpanValue(
+            TEST_TRACE, TEST_SPAN, TEST_ENTITY_TYPE_NAME, TEST_ENTITY_ID_ATTRIBUTE_KEY))
+        .thenReturn(Single.just(stringLiteral("id-value")));
+    when(this.mockAttributeReader.getSpanValue(
+            TEST_TRACE, TEST_SPAN, TEST_ENTITY_TYPE_NAME, TEST_ENTITY_NAME_ATTRIBUTE_KEY))
+        .thenReturn(Single.just(stringLiteral("name-value")));
+    when(this.mockDataClient.getOrCreateEntity(
+            any(org.hypertrace.entity.data.service.v1.Entity.class)))
+        .thenAnswer(invocation -> Single.just(invocation.getArgument(0)));
+    Entity expectedEntity =
+        Entity.newBuilder(BASIC_AVRO_ENTITY)
+            .setAttributes(
+                buildAttributesWithKeyValues(
+                    Map.of(
+                        TEST_ENTITY_ID_ATTRIBUTE_KEY, "id-value",
+                        TEST_ENTITY_NAME_ATTRIBUTE_KEY, "name-value")))
+            .build();
+    assertEquals(
+        Map.of(TEST_ENTITY_TYPE_NAME, expectedEntity),
+        this.entityReader.getAssociatedEntitiesForSpan(TEST_TRACE, TEST_SPAN).blockingGet());
+  }
+}


### PR DESCRIPTION
## Description
The entity reader is a client library allowing reading entities from span and trace data on the fly. These will be reported back to entity service based on a caching configuration. Unlike our existing solutions for querying entities, this reader removes the responsibility of the caller to form entities in code, and instead is config driven allowing new entity types, tenant level configuration and modifying existing entity schemas without code changes.
 
### Testing
Unit tests added. This is new functionality be tested in an integration environment before usage.
 
### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
