### PR TITLE
feat: add dynamic entity enricher

### DIFF
--- a/.github/workflows/hypertrace-ingester/docker-compose.yml
+++ b/.github/workflows/hypertrace-ingester/docker-compose.yml
@@ -47,6 +47,8 @@ services:
       - REPLICATION_FACTOR=1
       - ENTITY_SERVICE_HOST_CONFIG=hypertrace
       - ENTITY_SERVICE_PORT_CONFIG=9001
+      - ATTRIBUTE_SERVICE_HOST_CONFIG=hypertrace
+      - ATTRIBUTE_SERVICE_PORT_CONFIG=9001
       - NUM_STREAM_THREADS=1
       - PRE_CREATE_TOPICS=true
       - PRODUCER_VALUE_SERDE=org.hypertrace.core.kafkastreams.framework.serdes.GenericAvroSerde

--- a/.snyk
+++ b/.snyk
@@ -32,4 +32,8 @@ ignore:
     - '*':
         reason: no available replacement
         expires: 2020-12-31T00:00:00.000Z
+  SNYK-JAVA-IONETTY-1042268:
+    - '*':
+        reason: no available replacement
+        expires: 2020-12-31T00:00:00.000Z
 patch: {}

--- a/hypertrace-trace-enricher/helm/templates/trace-enricher-config.yaml
+++ b/hypertrace-trace-enricher/helm/templates/trace-enricher-config.yaml
@@ -35,4 +35,15 @@ data:
           port = 50061
         }
       }
+
+      EntitySpanEnricher {
+        entity.service.config = {
+          host = entity-service
+          port = 50061
+        }
+        attribute.service.config = {
+          host = attribute-service
+          port = 9012
+        }
+      }
     }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
@@ -11,6 +11,7 @@ tasks.test {
 dependencies {
   implementation(project(":hypertrace-trace-enricher:enriched-span-constants"))
   implementation(project(":hypertrace-trace-enricher:hypertrace-trace-enricher-api"))
+  implementation(project(":hypertrace-trace-enricher:trace-reader"))
 
   implementation("org.hypertrace.core.datamodel:data-model:0.1.9")
   implementation(project(":span-normalizer:raw-span-constants"))
@@ -22,6 +23,7 @@ dependencies {
   implementation("org.apache.commons:commons-lang3:3.10")
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("net.sf.uadetector:uadetector-resources:2014.10")
+  implementation("io.reactivex.rxjava3:rxjava:3.0.6")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
   testImplementation("org.mockito:mockito-core:3.3.3")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/EntitySpanEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/EntitySpanEnricher.java
@@ -1,0 +1,45 @@
+package org.hypertrace.traceenricher.enrichment.enrichers;
+
+import com.typesafe.config.Config;
+import io.grpc.Channel;
+import io.grpc.ManagedChannelBuilder;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.entity.data.service.client.EntityDataServiceClientProvider;
+import org.hypertrace.entity.service.client.config.EntityServiceClientConfig;
+import org.hypertrace.trace.reader.entities.TraceEntityReader;
+import org.hypertrace.trace.reader.entities.TraceEntityReaderBuilder;
+import org.hypertrace.traceenricher.enrichment.AbstractTraceEnricher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EntitySpanEnricher extends AbstractTraceEnricher {
+  private static final Logger LOG = LoggerFactory.getLogger(EntitySpanEnricher.class);
+  private TraceEntityReader entityReader;
+
+  @Override
+  public void enrichEvent(StructuredTrace trace, Event event) {
+    try {
+      this.entityReader.getAssociatedEntitiesForSpan(trace, event).blockingSubscribe();
+    } catch (Throwable t) {
+      LOG.error("Failed to enrich entities on span", t);
+    }
+  }
+
+  @Override
+  public void init(Config enricherConfig, EntityDataServiceClientProvider provider) {
+    EntityServiceClientConfig esConfig = EntityServiceClientConfig.from(enricherConfig);
+    Channel esChannel =
+        ManagedChannelBuilder.forAddress(esConfig.getHost(), esConfig.getPort())
+            .usePlaintext()
+            .build();
+    Channel asChannel =
+        ManagedChannelBuilder.forAddress(
+                enricherConfig.getString("attribute.service.config.host"),
+                enricherConfig.getInt("attribute.service.config.port"))
+            .usePlaintext()
+            .build();
+    this.entityReader =
+        TraceEntityReaderBuilder.usingChannels(esChannel, esChannel, asChannel).build();
+  }
+}

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/src/main/resources/configs/common/application.conf
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/src/main/resources/configs/common/application.conf
@@ -24,7 +24,7 @@ kafka.streams.config = {
 }
 
 enricher {
-  names = ["SpanTypeAttributeEnricher", "ApiStatusEnricher", "EndpointEnricher", "TransactionNameEnricher", "ApiBoundaryTypeAttributeEnricher", "ErrorsAndExceptionsEnricher", "BackendEntityEnricher", "HttpAttributeEnricher", "DefaultServiceEntityEnricher", "UserAgentSpanEnricher"]
+  names = ["SpanTypeAttributeEnricher", "ApiStatusEnricher", "EndpointEnricher", "TransactionNameEnricher", "ApiBoundaryTypeAttributeEnricher", "ErrorsAndExceptionsEnricher", "BackendEntityEnricher", "HttpAttributeEnricher", "DefaultServiceEntityEnricher", "UserAgentSpanEnricher", "EntitySpanEnricher"]
 
   DefaultServiceEntityEnricher {
     class = "org.hypertrace.traceenricher.enrichment.enrichers.DefaultServiceEntityEnricher"
@@ -87,6 +87,22 @@ enricher {
       host = ${?ENTITY_SERVICE_HOST_CONFIG}
       port = 50061
       port = ${?ENTITY_SERVICE_PORT_CONFIG}
+    }
+  }
+
+  EntitySpanEnricher {
+    class = "org.hypertrace.traceenricher.enrichment.enrichers.EntitySpanEnricher"
+    entity.service.config = {
+      host = localhost
+      host = ${?ENTITY_SERVICE_HOST_CONFIG}
+      port = 50061
+      port = ${?ENTITY_SERVICE_PORT_CONFIG}
+    }
+    attribute.service.config = {
+      host = localhost
+      host = ${?ATTRIBUTE_SERVICE_HOST_CONFIG}
+      port = 9012
+      port = ${?ATTRIBUTE_SERVICE_PORT_CONFIG}
     }
   }
 }

--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -12,8 +12,8 @@ dependencies {
   implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.6.1")
   implementation("org.hypertrace.entity.service:entity-type-service-rx-client:0.2.5")
   implementation("org.hypertrace.entity.service:entity-data-service-rx-client:0.2.5")
-  implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.3.0")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.0")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.3.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.2")
   implementation("io.reactivex.rxjava3:rxjava:3.0.6")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/DefaultValueResolver.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/DefaultValueResolver.java
@@ -85,8 +85,9 @@ class DefaultValueResolver implements ValueResolver {
   private Single<LiteralValue> resolveProjection(ValueSource valueSource, Projection projection) {
     switch (projection.getValueCase()) {
       case ATTRIBUTE_ID:
-        return this.attributeClient
-            .get(projection.getAttributeId())
+        return valueSource
+            .executionContext()
+            .wrapSingle(() -> this.attributeClient.get(projection.getAttributeId()))
             .flatMap(attributeMetadata -> this.resolve(valueSource, attributeMetadata));
       case LITERAL:
         return Single.just(projection.getLiteral());

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/SpanValueSource.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/SpanValueSource.java
@@ -6,6 +6,7 @@ import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.core.attribute.service.v1.LiteralValue;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.core.grpcutils.client.rx.GrpcRxExecutionContext;
 
 class SpanValueSource extends AvroBackedValueSource {
 
@@ -37,6 +38,11 @@ class SpanValueSource extends AvroBackedValueSource {
     return TRACE_SCOPE.equals(scope)
         ? Optional.of(ValueSource.forTrace(this.trace))
         : Optional.of(this);
+  }
+
+  @Override
+  public GrpcRxExecutionContext executionContext() {
+    return GrpcRxExecutionContext.forTenantContext(this.span.getCustomerId());
   }
 
   @Override

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/TraceValueSource.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/TraceValueSource.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.core.attribute.service.v1.LiteralValue;
 import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.core.grpcutils.client.rx.GrpcRxExecutionContext;
 
 class TraceValueSource extends AvroBackedValueSource {
 
@@ -31,6 +32,11 @@ class TraceValueSource extends AvroBackedValueSource {
   @Override
   public Optional<ValueSource> sourceForScope(String scope) {
     return TRACE_SCOPE.equals(scope) ? Optional.of(this) : Optional.empty();
+  }
+
+  @Override
+  public GrpcRxExecutionContext executionContext() {
+    return GrpcRxExecutionContext.forTenantContext(this.trace.getCustomerId());
   }
 
   @Override

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/ValueSource.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/ValueSource.java
@@ -5,6 +5,7 @@ import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.core.attribute.service.v1.LiteralValue;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.core.grpcutils.client.rx.GrpcRxExecutionContext;
 
 interface ValueSource {
   Optional<LiteralValue> getAttribute(String key, AttributeKind attributeKind);
@@ -12,6 +13,8 @@ interface ValueSource {
   Optional<LiteralValue> getMetric(String key, AttributeKind attributeKind);
 
   Optional<ValueSource> sourceForScope(String scope);
+
+  GrpcRxExecutionContext executionContext();
 
   static ValueSource forSpan(StructuredTrace trace, Event span) {
     return new SpanValueSource(trace, span, DefaultValueCoercer.INSTANCE);


### PR DESCRIPTION
This adds the dynamic entity enricher to the enrichment pipeline, which uses the trace reader to register any entities based on configs looked up from the entity service. These definitions will be built out in time to support adding more entities via config rather than code, potentially customized to specific tenants.