### PR TITLE
fix: omit null valued attributes rather than erroring

### DIFF
--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -7,9 +7,9 @@ plugins {
 
 dependencies {
   implementation("org.hypertrace.core.datamodel:data-model:0.1.9")
-  implementation("org.hypertrace.core.attribute.service:attribute-service-api:0.6.1")
-  implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.6.1")
-  implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.6.1")
+  implementation("org.hypertrace.core.attribute.service:attribute-service-api:0.8.6-SNAPSHOT")
+  implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.8.6-SNAPSHOT")
+  implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.8.6-SNAPSHOT")
   implementation("org.hypertrace.entity.service:entity-type-service-rx-client:0.2.5")
   implementation("org.hypertrace.entity.service:entity-data-service-rx-client:0.2.5")
   implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.3.2")

--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -7,9 +7,9 @@ plugins {
 
 dependencies {
   implementation("org.hypertrace.core.datamodel:data-model:0.1.9")
-  implementation("org.hypertrace.core.attribute.service:attribute-service-api:0.8.6-SNAPSHOT")
-  implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.8.6-SNAPSHOT")
-  implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.8.6-SNAPSHOT")
+  implementation("org.hypertrace.core.attribute.service:attribute-service-api:0.8.7")
+  implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.8.7")
+  implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.8.7")
   implementation("org.hypertrace.entity.service:entity-type-service-rx-client:0.2.5")
   implementation("org.hypertrace.entity.service:entity-data-service-rx-client:0.2.5")
   implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.3.2")

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/AttributeValueConverter.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/AttributeValueConverter.java
@@ -1,30 +1,32 @@
 package org.hypertrace.trace.reader.entities;
 
+import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import org.hypertrace.core.attribute.service.v1.LiteralValue;
 import org.hypertrace.entity.data.service.v1.AttributeValue;
 import org.hypertrace.entity.data.service.v1.Value;
 
 class AttributeValueConverter {
-  static Single<AttributeValue> convertToAttributeValue(LiteralValue literalValue) {
+  static Maybe<AttributeValue> convertToAttributeValue(LiteralValue literalValue) {
     switch (literalValue.getValueCase()) {
       case STRING_VALUE:
-        return attributeValueSingle(Value.newBuilder().setString(literalValue.getStringValue()));
+        return attributeValueMaybe(Value.newBuilder().setString(literalValue.getStringValue()));
       case BOOLEAN_VALUE:
-        return attributeValueSingle(Value.newBuilder().setBoolean(literalValue.getBooleanValue()));
+        return attributeValueMaybe(Value.newBuilder().setBoolean(literalValue.getBooleanValue()));
       case FLOAT_VALUE:
-        return attributeValueSingle(Value.newBuilder().setDouble(literalValue.getFloatValue()));
+        return attributeValueMaybe(Value.newBuilder().setDouble(literalValue.getFloatValue()));
       case INT_VALUE:
-        return attributeValueSingle(Value.newBuilder().setLong(literalValue.getIntValue()));
+        return attributeValueMaybe(Value.newBuilder().setLong(literalValue.getIntValue()));
       case VALUE_NOT_SET:
+        return Maybe.empty();
       default:
-        return Single.error(
+        return Maybe.error(
             new UnsupportedOperationException(
                 "Unexpected literal value case: " + literalValue.getValueCase()));
     }
   }
 
-  private static Single<AttributeValue> attributeValueSingle(Value.Builder value) {
-    return Single.just(AttributeValue.newBuilder().setValue(value).build());
+  private static Maybe<AttributeValue> attributeValueMaybe(Value.Builder value) {
+    return Maybe.just(AttributeValue.newBuilder().setValue(value).build());
   }
 }

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/AttributeValueConverter.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/AttributeValueConverter.java
@@ -1,12 +1,15 @@
 package org.hypertrace.trace.reader.entities;
 
 import io.reactivex.rxjava3.core.Maybe;
-import io.reactivex.rxjava3.core.Single;
 import org.hypertrace.core.attribute.service.v1.LiteralValue;
 import org.hypertrace.entity.data.service.v1.AttributeValue;
 import org.hypertrace.entity.data.service.v1.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class AttributeValueConverter {
+  private static final Logger LOG = LoggerFactory.getLogger(AttributeValueConverter.class);
+
   static Maybe<AttributeValue> convertToAttributeValue(LiteralValue literalValue) {
     switch (literalValue.getValueCase()) {
       case STRING_VALUE:
@@ -20,9 +23,8 @@ class AttributeValueConverter {
       case VALUE_NOT_SET:
         return Maybe.empty();
       default:
-        return Maybe.error(
-            new UnsupportedOperationException(
-                "Unexpected literal value case: " + literalValue.getValueCase()));
+        LOG.error("Unexpected literal value case: " + literalValue.getValueCase());
+        return Maybe.empty();
     }
   }
 

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReader.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReader.java
@@ -117,7 +117,7 @@ class DefaultTraceEntityReader implements TraceEntityReader {
     return this.traceAttributeReader
         .getSpanValue(trace, span, attributeMetadata.getScopeString(), attributeMetadata.getKey())
         .onErrorComplete()
-        .flatMapSingle(AttributeValueConverter::convertToAttributeValue)
+        .flatMap(AttributeValueConverter::convertToAttributeValue)
         .map(value -> Map.entry(attributeMetadata.getKey(), value));
   }
 

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/AttributeValueConverterTest.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/AttributeValueConverterTest.java
@@ -10,7 +10,7 @@ import static org.hypertrace.trace.reader.entities.AttributeValueUtil.doubleAttr
 import static org.hypertrace.trace.reader.entities.AttributeValueUtil.longAttributeValue;
 import static org.hypertrace.trace.reader.entities.AttributeValueUtil.stringAttributeValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hypertrace.core.attribute.service.v1.LiteralValue;
 import org.junit.jupiter.api.Test;
@@ -48,9 +48,7 @@ class AttributeValueConverterTest {
   }
 
   @Test
-  void errorsOnUnknownValue() {
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> convertToAttributeValue(LiteralValue.getDefaultInstance()).blockingGet());
+  void emptyOnUnknownValue() {
+    assertTrue(convertToAttributeValue(LiteralValue.getDefaultInstance()).isEmpty().blockingGet());
   }
 }


### PR DESCRIPTION
This change is part of the support for https://github.com/hypertrace/hypertrace/issues/126 - it adds support for entity formation when an associated attribute for an entity is missing. If the associated id or name is missing, the entity is not formed. If a regular attribute is missing, it is just omitted from the attribute map.