### PR TITLE
OTel Semantics: Some minor changes here & there

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
@@ -12,6 +12,7 @@ import org.hypertrace.core.datamodel.shared.SpanAttributeUtils;
 import org.hypertrace.core.datamodel.shared.StructuredTraceGraph;
 import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;
 import org.hypertrace.core.span.constants.RawSpanConstants;
+import org.hypertrace.semantic.convention.utils.http.OTelHttpSemanticConventions;
 import org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants;
 import org.hypertrace.traceenricher.enrichedspan.constants.utils.EnrichedSpanUtils;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.Api;
@@ -55,7 +56,8 @@ public class ApiBoundaryTypeAttributeEnricher extends AbstractTraceEnricher {
       // In the cases where there are sidecar proxies, the host header might be set to localhost
       // while the original host will be moved to x-forwarded headers. Hence, read them too.
       X_FORWARDED_HOST_HEADER,
-      X_FORWARDED_HOST_METADATA
+      X_FORWARDED_HOST_METADATA,
+      OTelHttpSemanticConventions.HTTP_HOST.getValue()
   );
   private static final String LOCALHOST = "localhost";
 

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiStatusEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiStatusEnricher.java
@@ -12,6 +12,8 @@ import org.hypertrace.core.span.constants.v1.Envoy;
 import org.hypertrace.core.span.constants.v1.Grpc;
 import org.hypertrace.core.span.constants.v1.Http;
 import org.hypertrace.core.span.constants.v1.OTSpanTag;
+import org.hypertrace.semantic.convention.utils.http.OTelHttpSemanticConventions;
+import org.hypertrace.semantic.convention.utils.rpc.OTelRpcSemanticConventions;
 import org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants;
 import org.hypertrace.traceenricher.enrichedspan.constants.utils.EnrichedSpanUtils;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.Api;
@@ -109,6 +111,7 @@ public class ApiStatusEnricher extends AbstractTraceEnricher {
     grpcStatusCodeKeys.add(RawSpanConstants.getValue(CensusResponse.CENSUS_RESPONSE_STATUS_CODE));
     grpcStatusCodeKeys.add(RawSpanConstants.getValue(Grpc.GRPC_STATUS_CODE));
     grpcStatusCodeKeys.add(RawSpanConstants.getValue(CensusResponse.CENSUS_RESPONSE_CENSUS_STATUS_CODE));
+    grpcStatusCodeKeys.add(OTelRpcSemanticConventions.GRPC_STATUS_CODE.getValue());
     return grpcStatusCodeKeys;
   }
 
@@ -116,6 +119,7 @@ public class ApiStatusEnricher extends AbstractTraceEnricher {
     List<String> httpStatusCodeKeys = new ArrayList<>();
     httpStatusCodeKeys.add(RawSpanConstants.getValue(OTSpanTag.OT_SPAN_TAG_HTTP_STATUS_CODE));
     httpStatusCodeKeys.add(RawSpanConstants.getValue(Http.HTTP_RESPONSE_STATUS_CODE));
+    httpStatusCodeKeys.add(OTelHttpSemanticConventions.HTTP_STATUS_CODE.getValue());
     return httpStatusCodeKeys;
   }
 

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricherTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricherTest.java
@@ -9,6 +9,7 @@ import org.hypertrace.core.datamodel.eventfields.grpc.RequestMetadata;
 import org.hypertrace.core.datamodel.shared.StructuredTraceGraph;
 import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;
 import org.hypertrace.core.span.constants.RawSpanConstants;
+import org.hypertrace.semantic.convention.utils.http.OTelHttpSemanticConventions;
 import org.hypertrace.traceenricher.enrichedspan.constants.utils.EnrichedSpanUtils;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.BoundaryTypeValue;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.CommonAttribute;
@@ -147,6 +148,15 @@ public class ApiBoundaryTypeAttributeEnricherTest extends AbstractAttributeEnric
   public void testEnrichEventWithHostHeader() {
     addEnrichedAttributeToEvent(innerEntrySpan,
         RawSpanConstants.getValue(org.hypertrace.core.span.constants.v1.Http.HTTP_HOST),
+        AttributeValueCreator.create("testHost"));
+    target.enrichEvent(trace, innerEntrySpan);
+    Assertions.assertEquals(EnrichedSpanUtils.getHostHeader(innerEntrySpan), "testHost");
+  }
+
+  @Test
+  public void testEnrichEventWithHostHeaderOTelFormat() {
+    addEnrichedAttributeToEvent(innerEntrySpan,
+        OTelHttpSemanticConventions.HTTP_HOST.getValue(),
         AttributeValueCreator.create("testHost"));
     target.enrichEvent(trace, innerEntrySpan);
     Assertions.assertEquals(EnrichedSpanUtils.getHostHeader(innerEntrySpan), "testHost");

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendEntityResolverTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendEntityResolverTest.java
@@ -451,6 +451,10 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
             .of(OTelDbSemanticConventions.DB_SYSTEM.getValue(), buildAttributeValue(
                 OTelDbSemanticConventions.REDIS_DB_SYSTEM_VALUE.getValue()),
                 OTelDbSemanticConventions.DB_CONNECTION_STRING.getValue(), buildAttributeValue("redis-cart:6379"),
+                OTelSpanSemanticConventions.NET_PEER_NAME.getValue(),
+                buildAttributeValue("redis-cart"),
+                OTelSpanSemanticConventions.NET_PEER_PORT.getValue(),
+                buildAttributeValue("6379"),
                 "span.kind", AttributeValue.newBuilder().setValue("client").build(),
                 "k8s.pod_id", buildAttributeValue("55636196-c840-11e9-a417-42010a8a0064"),
                 "docker.container_id", buildAttributeValue("ee85cf2cfc3b24613a3da411fdbd2f3eabbe729a5c86c5262971c8d8c29dad0f"),

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/JdbcBackendResolverTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/JdbcBackendResolverTest.java
@@ -23,6 +23,7 @@ import org.hypertrace.entity.data.service.client.EntityDataServiceClient;
 import org.hypertrace.entity.data.service.v1.Entity;
 import org.hypertrace.entity.service.constants.EntityConstants;
 import org.hypertrace.semantic.convention.utils.db.OTelDbSemanticConventions;
+import org.hypertrace.semantic.convention.utils.span.OTelSpanSemanticConventions;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.Backend;
 import org.hypertrace.traceenricher.enrichment.enrichers.BackendType;
 import org.hypertrace.traceenricher.util.Constants;
@@ -100,7 +101,11 @@ public class JdbcBackendResolverTest {
             Attributes.newBuilder().setAttributeMap(
                 Map.of("SPAN_TYPE", AttributeValue.newBuilder().setValue("EXIT").build())).build())
         .setAttributes(Attributes.newBuilder().setAttributeMap(Map.of(
-            OTelDbSemanticConventions.DB_CONNECTION_STRING.getValue(), buildAttributeValue("mysql://127.0.0.1:3306"),
+            OTelSpanSemanticConventions.NET_PEER_NAME.getValue(),
+            buildAttributeValue("127.0.0.1"),
+            OTelSpanSemanticConventions.NET_PEER_PORT.getValue(),
+            buildAttributeValue("3306"),
+            OTelDbSemanticConventions.DB_CONNECTION_STRING.getValue(), buildAttributeValue("service(localhost)\\db;;"),
             OTelDbSemanticConventions.DB_SYSTEM.getValue(), buildAttributeValue("mysql"),
             "span.kind", buildAttributeValue("client"),
             OTelDbSemanticConventions.DB_STATEMENT.getValue(), buildAttributeValue("SELECT * from example.user"),

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/ServiceCallViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/ServiceCallViewGenerator.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -16,11 +17,12 @@ import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Entity;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.core.datamodel.eventfields.http.Http;
+import org.hypertrace.core.datamodel.eventfields.http.Request;
 import org.hypertrace.core.datamodel.shared.ApiNode;
 import org.hypertrace.core.datamodel.shared.HexUtils;
 import org.hypertrace.core.datamodel.shared.SpanAttributeUtils;
 import org.hypertrace.core.span.constants.RawSpanConstants;
-import org.hypertrace.core.span.constants.v1.Http;
 import org.hypertrace.entity.constants.v1.BackendAttribute;
 import org.hypertrace.entity.service.constants.EntityConstants;
 import org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants;
@@ -320,13 +322,11 @@ public class ServiceCallViewGenerator extends BaseViewGenerator<ServiceCallView>
 
     // If this is a HTTP request, parse the http response status code.
     if (protocol == Protocol.PROTOCOL_HTTP || protocol == Protocol.PROTOCOL_HTTPS) {
+      Optional<Request> httpRequest = Optional.ofNullable(event.getHttp())
+          .map(org.hypertrace.core.datamodel.eventfields.http.Http::getRequest);
       // Set request related attributes.
-      builder.setRequestUrl(
-          getStringAttributeWithDefault(
-              event, RawSpanConstants.getValue(Http.HTTP_REQUEST_URL), null));
-      builder.setRequestMethod(
-          getStringAttributeWithDefault(
-              event, RawSpanConstants.getValue(Http.HTTP_REQUEST_METHOD), null));
+      builder.setRequestUrl(httpRequest.map(Request::getUrl).orElse(null));
+      builder.setRequestMethod(httpRequest.map(Request::getMethod).orElse(null));
     }
 
     String statusValue = EnrichedSpanUtils.getStatusCode(event);

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/db/DbSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/db/DbSemanticConventionUtils.java
@@ -170,12 +170,7 @@ public class DbSemanticConventionUtils {
    * @return backend uri based on otel format
    */
   public static Optional<String> getBackendURIForOtelFormat(Event event) {
-    if (SpanAttributeUtils.containsAttributeKey(event, OTEL_DB_CONNECTION_STRING)
-        && SpanSemanticConventionUtils.isValidUri(SpanAttributeUtils.getStringAttribute(event, OTEL_DB_CONNECTION_STRING))) {
-      return Optional.of(SpanAttributeUtils.getStringAttribute(event, OTEL_DB_CONNECTION_STRING));
-    } else {
-      return SpanSemanticConventionUtils.getURIForOtelFormat(event);
-    }
+    return SpanSemanticConventionUtils.getURIForOtelFormat(event);
   }
 
   /**
@@ -183,12 +178,7 @@ public class DbSemanticConventionUtils {
    * @return backend uri based on otel format
    */
   public static Optional<String> getBackendURIForOtelFormat(Map<String, AttributeValue> attributeValueMap) {
-    if (attributeValueMap.containsKey(OTEL_DB_CONNECTION_STRING)
-      && SpanSemanticConventionUtils.isValidUri(attributeValueMap.get(OTEL_DB_CONNECTION_STRING).getValue())) {
-      return Optional.of(attributeValueMap.get(OTEL_DB_CONNECTION_STRING).getValue());
-    } else {
-      return SpanSemanticConventionUtils.getURIForOtelFormat(attributeValueMap);
-    }
+    return SpanSemanticConventionUtils.getURIForOtelFormat(attributeValueMap);
   }
 
   /**

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/span/SpanSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/span/SpanSemanticConventionUtils.java
@@ -1,9 +1,5 @@
 package org.hypertrace.semantic.convention.utils.span;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
@@ -72,14 +68,5 @@ public class SpanSemanticConventionUtils {
           attributeValueMap.get(OTelSpanSemanticConventions.SPAN_KIND.getValue()).getValue());
     }
     return false;
-  }
-
-  public static boolean isValidUri(String uri) {
-    try {
-      new URI(uri);
-    } catch (URISyntaxException e) {
-      return false;
-    }
-    return true;
   }
 }

--- a/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/db/DbSemanticConventionUtilsTest.java
+++ b/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/db/DbSemanticConventionUtilsTest.java
@@ -26,26 +26,16 @@ public class DbSemanticConventionUtilsTest {
   @Test
   public void isMongoBackend() {
     Event e = mock(Event.class);
-    // otel format
-    Attributes attributes = SemanticConventionTestUtil.buildAttributes(
-        Map.of(
-            OTelDbSemanticConventions.DB_SYSTEM.getValue(),
-            SemanticConventionTestUtil.buildAttributeValue(OTelDbSemanticConventions.MONGODB_DB_SYSTEM_VALUE.getValue()),
-            OTelDbSemanticConventions.DB_CONNECTION_STRING.getValue(),
-            SemanticConventionTestUtil.buildAttributeValue("mongo:27017")));
-    when(e.getAttributes()).thenReturn(attributes);
-    boolean v = DbSemanticConventionUtils.isMongoBackend(e);
-    assertTrue(v);
 
     // otel format, dbsystem is not mongo
-    attributes = SemanticConventionTestUtil.buildAttributes(
+    Attributes attributes = SemanticConventionTestUtil.buildAttributes(
         Map.of(
             OTelDbSemanticConventions.DB_SYSTEM.getValue(),
             SemanticConventionTestUtil.buildAttributeValue(OTelDbSemanticConventions.MYSQL_DB_SYSTEM_VALUE.getValue()),
             OTelDbSemanticConventions.DB_CONNECTION_STRING.getValue(),
             SemanticConventionTestUtil.buildAttributeValue("mongo:27017")));
     when(e.getAttributes()).thenReturn(attributes);
-    v = DbSemanticConventionUtils.isMongoBackend(e);
+    boolean v = DbSemanticConventionUtils.isMongoBackend(e);
     assertFalse(v);
 
     attributes = SemanticConventionTestUtil.buildAttributes(
@@ -77,24 +67,13 @@ public class DbSemanticConventionUtilsTest {
   @Test
   public void testGetMongoURI() {
     Event e = mock(Event.class);
-    // otel format
-    Attributes attributes = SemanticConventionTestUtil.buildAttributes(
-        Map.of(
-            OTelDbSemanticConventions.DB_SYSTEM.getValue(),
-            SemanticConventionTestUtil.buildAttributeValue(OTelDbSemanticConventions.MONGODB_DB_SYSTEM_VALUE.getValue()),
-            OTelDbSemanticConventions.DB_CONNECTION_STRING.getValue(),
-            SemanticConventionTestUtil.buildAttributeValue("mongo:27017")));
-    when(e.getAttributes()).thenReturn(attributes);
-    Optional<String> v = DbSemanticConventionUtils.getMongoURI(e);
-    assertEquals("mongo:27017", v.get());
-
     // mongo url key is present
-    attributes = SemanticConventionTestUtil.buildAttributes(
+    Attributes attributes = SemanticConventionTestUtil.buildAttributes(
         Map.of(
             RawSpanConstants.getValue(Mongo.MONGO_URL),
             SemanticConventionTestUtil.buildAttributeValue("mongo:27017")));
     when(e.getAttributes()).thenReturn(attributes);
-    v = DbSemanticConventionUtils.getMongoURI(e);
+    Optional<String> v = DbSemanticConventionUtils.getMongoURI(e);
     assertEquals("mongo:27017", v.get());
 
     // mongo address is present
@@ -151,15 +130,6 @@ public class DbSemanticConventionUtilsTest {
     when(e.getAttributes()).thenReturn(attributes);
     Optional<String> v = DbSemanticConventionUtils.getRedisURI(e);
     assertEquals("127.0.0.1:4562", v.get());
-
-    // sql url not present, use db connection string
-    attributes = SemanticConventionTestUtil.buildAttributes(
-        Map.of(
-            OTelDbSemanticConventions.DB_CONNECTION_STRING.getValue(),
-            SemanticConventionTestUtil.buildAttributeValue("redis://127.0.0.1:4562")));
-    when(e.getAttributes()).thenReturn(attributes);
-    v = DbSemanticConventionUtils.getRedisURI(e);
-    assertEquals("redis://127.0.0.1:4562", v.get());
   }
 
   @Test
@@ -214,17 +184,6 @@ public class DbSemanticConventionUtilsTest {
     Optional<String> v = DbSemanticConventionUtils.getSqlURI(e);
     assertEquals("jdbc:mysql://mysql:3306/shop", v.get());
 
-    // sql url not present, use db connection string
-    attributes = SemanticConventionTestUtil.buildAttributes(
-        Map.of(
-            OTelDbSemanticConventions.DB_SYSTEM.getValue(),
-            SemanticConventionTestUtil.buildAttributeValue(OTelDbSemanticConventions.MYSQL_DB_SYSTEM_VALUE.getValue()),
-            OTelDbSemanticConventions.DB_CONNECTION_STRING.getValue(),
-            SemanticConventionTestUtil.buildAttributeValue("mysql://127.0.0.1:3306")));
-    when(e.getAttributes()).thenReturn(attributes);
-    v = DbSemanticConventionUtils.getSqlURI(e);
-    assertEquals("mysql://127.0.0.1:3306", v.get());
-
     // no sql related attributes present
     attributes = SemanticConventionTestUtil.buildAttributes(
         Map.of(
@@ -238,22 +197,14 @@ public class DbSemanticConventionUtilsTest {
   @Test
   public void testGetBackendURIForOtelFormat() {
     Event e = mock(Event.class);
-    // connection string is present
-    Attributes attributes = SemanticConventionTestUtil.buildAttributes(
-        Map.of(
-            OTelDbSemanticConventions.DB_CONNECTION_STRING.getValue(),
-            SemanticConventionTestUtil.buildAttributeValue("mysql://127.0.0.1:3306")));
-    when(e.getAttributes()).thenReturn(attributes);
-    Optional<String> v = DbSemanticConventionUtils.getBackendURIForOtelFormat(e);
-    assertEquals("mysql://127.0.0.1:3306", v.get());
 
     // only ip is present
-    attributes = SemanticConventionTestUtil.buildAttributes(
+    Attributes attributes = SemanticConventionTestUtil.buildAttributes(
         Map.of(
             OTelSpanSemanticConventions.NET_PEER_IP.getValue(),
             SemanticConventionTestUtil.buildAttributeValue("127.0.0.1")));
     when(e.getAttributes()).thenReturn(attributes);
-    v = DbSemanticConventionUtils.getBackendURIForOtelFormat(e);
+    Optional<String> v = DbSemanticConventionUtils.getBackendURIForOtelFormat(e);
     assertEquals("127.0.0.1", v.get());
 
     // ip & host present

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/FieldsGenerator.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/FieldsGenerator.java
@@ -43,6 +43,10 @@ public class FieldsGenerator {
         .forEach(k -> protocolFieldsGeneratorMap.put(k, rpcFieldsGenerator));
   }
 
+  /**
+   * @param eventBuilder
+   * @param attributeValueMap attribute key value, should be populated before-hand
+   */
   public void populateOtherFields(
       Event.Builder eventBuilder,
       final Map<String, AttributeValue> attributeValueMap) {

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java
@@ -52,10 +52,8 @@ import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.eventfields.http.Http;
 import org.hypertrace.core.datamodel.eventfields.http.Request;
 import org.hypertrace.core.span.constants.RawSpanConstants;
-import org.hypertrace.semantic.convention.utils.db.OTelDbSemanticConventions;
 import org.hypertrace.semantic.convention.utils.http.HttpSemanticConventionUtils;
 import org.hypertrace.semantic.convention.utils.http.OTelHttpSemanticConventions;
-import org.hypertrace.semantic.convention.utils.span.OTelSpanSemanticConventions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/fieldgenerators/SqlFieldsGeneratorTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/fieldgenerators/SqlFieldsGeneratorTest.java
@@ -16,6 +16,7 @@ import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.eventfields.sql.Sql;
 import org.hypertrace.core.span.constants.RawSpanConstants;
 import org.hypertrace.semantic.convention.utils.db.OTelDbSemanticConventions;
+import org.hypertrace.semantic.convention.utils.span.OTelSpanSemanticConventions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -78,13 +79,18 @@ public class SqlFieldsGeneratorTest {
     SqlFieldsGenerator sqlFieldsGenerator = new SqlFieldsGenerator();
 
     Event.Builder eventBuilder = Event.newBuilder();
-    Map<String, AttributeValue> map = Maps.newHashMap();
-    map.put(OTelDbSemanticConventions.DB_SYSTEM.getValue(),
-        AttributeValue.newBuilder().setValue(OTelDbSemanticConventions.MYSQL_DB_SYSTEM_VALUE.getValue()).build());
-    map.put(OTelDbSemanticConventions.DB_CONNECTION_STRING.getValue(),
-        AttributeValue.newBuilder().setValue("jdbc:mysql://mysql:3306/shop").build());
+
+    Map<String, AttributeValue> map = Map.of(
+        OTelDbSemanticConventions.DB_SYSTEM.getValue(),
+        AttributeValue.newBuilder().setValue(OTelDbSemanticConventions.MYSQL_DB_SYSTEM_VALUE.getValue()).build(),
+        OTelDbSemanticConventions.DB_CONNECTION_STRING.getValue(),
+        AttributeValue.newBuilder().setValue("jdbc:mysql://mysql:3306/shop").build(),
+        OTelSpanSemanticConventions.NET_PEER_NAME.getValue(),
+        AttributeValue.newBuilder().setValue("mysql.example.com").build(),
+        OTelSpanSemanticConventions.NET_PEER_PORT.getValue(),
+        AttributeValue.newBuilder().setValue("3306").build());
     sqlFieldsGenerator.populateOtherFields(eventBuilder, map);
     assertEquals(
-        "jdbc:mysql://mysql:3306/shop", eventBuilder.getSqlBuilder().getUrl());
+        "mysql.example.com:3306", eventBuilder.getSqlBuilder().getUrl());
   }
 }

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/fieldgenerators/SqlFieldsGeneratorTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/fieldgenerators/SqlFieldsGeneratorTest.java
@@ -84,7 +84,7 @@ public class SqlFieldsGeneratorTest {
         OTelDbSemanticConventions.DB_SYSTEM.getValue(),
         AttributeValue.newBuilder().setValue(OTelDbSemanticConventions.MYSQL_DB_SYSTEM_VALUE.getValue()).build(),
         OTelDbSemanticConventions.DB_CONNECTION_STRING.getValue(),
-        AttributeValue.newBuilder().setValue("jdbc:mysql://mysql:3306/shop").build(),
+        AttributeValue.newBuilder().setValue("Server=shopdb.example.com;Database=ShopDb;Uid=billing_user;TableCache=true;UseCompression=True;MinimumPoolSize=10;MaximumPoolSize=50;").build(),
         OTelSpanSemanticConventions.NET_PEER_NAME.getValue(),
         AttributeValue.newBuilder().setValue("mysql.example.com").build(),
         OTelSpanSemanticConventions.NET_PEER_PORT.getValue(),


### PR DESCRIPTION
Following changes has been done:
* Use first class field for http url, method in ServiceCallViewGenerator
* Do not use otel key db.connection_string for db url
* Add OTel status code in ApiStatusEnricher
* Add OTel http host key, in the list of HOST_HEADERS in ApiBoundaryType enricher