### PR TITLE
GRPC authority header seems to not have host component sometimes.

### DIFF
--- a/hypertrace-ingester/build.gradle.kts
+++ b/hypertrace-ingester/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
   implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.9")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.9")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.8")
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.9")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.12")
   implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.1.14")
   implementation("com.typesafe:config:1.4.0")
 

--- a/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
+++ b/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
@@ -60,7 +60,7 @@ sourceSets {
 dependencies {
   api("com.google.protobuf:protobuf-java-util:3.13.0")
 
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.9")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.12")
   implementation(project(":span-normalizer:raw-span-constants"))
   implementation(project(":span-normalizer:span-normalizer-constants"))
   implementation("org.hypertrace.entity.service:entity-service-api:0.1.23")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/build.gradle.kts
@@ -9,7 +9,7 @@ tasks.test {
 
 dependencies {
   implementation(project(":hypertrace-trace-enricher:enriched-span-constants"))
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.9")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.12")
 
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("org.apache.commons:commons-lang3:3.11")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   implementation(project(":semantic-convention-utils"))
   implementation(project(":hypertrace-trace-enricher:trace-reader"))
 
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.9")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.12")
   implementation("org.hypertrace.entity.service:entity-service-client:0.1.23")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.18")
 

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
@@ -153,29 +153,29 @@ public class ApiBoundaryTypeAttributeEnricher extends AbstractTraceEnricher {
 
   private Optional<String> getSanitizedHostValue(String value) {
     if (StringUtils.isNotBlank(value)) {
-      String host = sanitizeHostValue(value);
-      if (!LOCALHOST.equalsIgnoreCase(host)) {
-        return Optional.of(host);
+      Optional<String> host = sanitizeHostValue(value);
+      if (host.isPresent() && !LOCALHOST.equalsIgnoreCase(host.get())) {
+        return host;
       }
     }
     return Optional.empty();
   }
 
-  private String sanitizeHostValue(String host) {
+  private Optional<String> sanitizeHostValue(String host) {
     if (host.contains(COLON) && !host.startsWith(COLON)) {
-      return COLON_SPLITTER.splitToList(host).get(0);
+      return Optional.ofNullable(COLON_SPLITTER.splitToList(host).get(0));
     }
 
     // the value is a URL, just return the authority part of it.
     try {
       URI uri = new URI(host);
       if (uri.getScheme() != null) {
-        return uri.getHost();
+        return Optional.ofNullable(uri.getHost());
       }
-      return host;
+      return Optional.of(host);
     } catch (URISyntaxException ignore) {
       // ignore
-      return host;
+      return Optional.empty();
     }
   }
 }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricherTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricherTest.java
@@ -145,6 +145,16 @@ public class ApiBoundaryTypeAttributeEnricherTest extends AbstractAttributeEnric
   }
 
   @Test
+  public void testEnrichEventWithIncompleteAuthorityHeader() {
+    // Try with :port since that seems to be a valid value for some authority headers.
+    addEnrichedAttributeToEvent(innerEntrySpan,
+        RawSpanConstants.getValue(org.hypertrace.core.span.constants.v1.Http.HTTP_REQUEST_AUTHORITY_HEADER),
+        AttributeValueCreator.create(":9000"));
+    target.enrichEvent(trace, innerEntrySpan);
+    Assertions.assertNull(EnrichedSpanUtils.getHostHeader(innerEntrySpan));
+  }
+
+  @Test
   public void testEnrichEventWithHostHeader() {
     addEnrichedAttributeToEvent(innerEntrySpan,
         RawSpanConstants.getValue(org.hypertrace.core.span.constants.v1.Http.HTTP_HOST),

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
   }
 
   implementation(project(":hypertrace-trace-enricher:hypertrace-trace-enricher-impl"))
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.9")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.12")
   implementation("org.hypertrace.core.flinkutils:flink-utils:0.1.6")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.18")
   implementation("org.hypertrace.entity.service:entity-service-client:0.1.23")

--- a/hypertrace-trace-enricher/hypertrace-trace-visualizer/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-visualizer/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.9")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.12")
 
   implementation("org.json:json:20201115")
   implementation("org.apache.commons:commons-lang3:3.11")

--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.9")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.12")
   implementation("org.hypertrace.core.attribute.service:attribute-service-api:0.8.7")
   implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.8.7")
   implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.8.7")

--- a/hypertrace-view-generator/hypertrace-view-generator-api/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator-api/build.gradle.kts
@@ -12,6 +12,6 @@ sourceSets {
 }
 
 dependencies {
-  api( "org.apache.avro:avro:1.9.2")
+  api( "org.apache.avro:avro:1.10.1")
 }
 

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 
   // TODO: migrate in core
   implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.1.19")
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.10")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.12")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.18")
   
   implementation("org.hypertrace.entity.service:entity-service-api:0.1.21")

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
   
   implementation("org.hypertrace.entity.service:entity-service-api:0.1.21")
 
-  implementation("org.apache.avro:avro:1.9.2")
+  implementation("org.apache.avro:avro:1.10.1")
   implementation("org.apache.commons:commons-lang3:3.11")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")

--- a/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
+++ b/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
@@ -35,7 +35,7 @@ tasks.test {
 
 dependencies {
     implementation(project(":span-normalizer:span-normalizer-api"))
-    implementation("org.hypertrace.core.datamodel:data-model:0.1.10")
+    implementation("org.hypertrace.core.datamodel:data-model:0.1.12")
     implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.18")
     implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.18")
 

--- a/semantic-convention-utils/build.gradle.kts
+++ b/semantic-convention-utils/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation(project(":span-normalizer:raw-span-constants"))
     implementation(project(":span-normalizer:span-normalizer-constants"))
 
-    implementation("org.hypertrace.core.datamodel:data-model:0.1.9")
+    implementation("org.hypertrace.core.datamodel:data-model:0.1.12")
     implementation("org.hypertrace.entity.service:entity-service-client:0.1.23")
 
     implementation("org.apache.commons:commons-lang3:3.11")

--- a/span-normalizer/span-normalizer-api/build.gradle.kts
+++ b/span-normalizer/span-normalizer-api/build.gradle.kts
@@ -52,5 +52,5 @@ sourceSets {
 }
 dependencies {
   api("com.google.api.grpc:proto-google-common-protos:1.12.0")
-  api( "org.apache.avro:avro:1.9.2")
+  api( "org.apache.avro:avro:1.10.1")
 }

--- a/span-normalizer/span-normalizer/build.gradle.kts
+++ b/span-normalizer/span-normalizer/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
   implementation(project(":span-normalizer:span-normalizer-constants"))
   implementation(project(":semantic-convention-utils"))
 
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.10")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.12")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.18")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.18")
   implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.13")


### PR DESCRIPTION
Due to this, the host header was being set as `:port`, which isn't right.
Fixing the bug to ignore such host header so that the span will be resolved
based on the servicename that comes in the span.