### PR TITLE
optimised docker e2e test with GH action

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
-          fetch-depth: 10
+          fetch-depth: 0
           submodules: recursive
       - name: Cache Gradle
         uses: actions/cache@v1

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -3,42 +3,24 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
   pull_request:
   # workflow_dispatch will let us manually trigger the workflow from GitHub actions dashboard.
-  # See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
-  # See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
+  # See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow 
   workflow_dispatch:
 
 jobs:
   build-on-linux:
-    strategy:
-      matrix:
-        docker-version: [19.03]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Build and run Docker images
     steps:
-      - name: Update Packages
-        run: sudo apt-get update -yqq --fix-missing
-      - name: Install Docker
-        uses: docker-practice/actions-setup-docker@master
-        with:
-          docker_version: ${{ matrix.docker-version }}
-          docker_buildx: false
-      - name: Cache docker
-        uses: actions/cache@v1
-        with:
-          path: ~/.docker
-          key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
-          restore-keys: ${{ runner.os }}-docker
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 10
           submodules: recursive
-      - name: Install JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 14
       - name: Cache Gradle
         uses: actions/cache@v1
         with:

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build-on-linux:
+       # Ubuntu-20.04 runner comes with docker 19.03 and OpenJDK 11 and we are using that here. 
     runs-on: ubuntu-20.04
     name: Build and run Docker images
     steps:


### PR DESCRIPTION
## Description
While trying POC on GitHub action we realised that docker 19.03 and Java 11 are part of runner that comes with Ubuntu-20.04 already has those requirements satisfied. (ref: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md)



### Testing
NA

### Documentation
- https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md