### PR TITLE
Correcting the dependency order for backend entity enricher

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/src/main/resources/configs/common/application.conf
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/src/main/resources/configs/common/application.conf
@@ -67,7 +67,7 @@ enricher {
       port = 50061
       port = ${?ENTITY_SERVICE_PORT_CONFIG}
     }
-    dependencies = ["EndpointEnricher"]
+    dependencies = ["DefaultServiceEntityEnricher", "EndpointEnricher"]
   }
 
   ApiStatusEnricher {
@@ -81,7 +81,7 @@ enricher {
 
   EndpointEnricher {
     class = "org.hypertrace.traceenricher.enrichment.enrichers.endpoint.EndpointEnricher"
-    dependencies = ["DefaultServiceEntityEnricher"]
+    dependencies = ["DefaultServiceEntityEnricher", "ApiBoundaryTypeAttributeEnricher"]
     entity.service.config = {
       host = localhost
       host = ${?ENTITY_SERVICE_HOST_CONFIG}

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/src/main/resources/configs/common/application.conf
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/src/main/resources/configs/common/application.conf
@@ -67,7 +67,7 @@ enricher {
       port = 50061
       port = ${?ENTITY_SERVICE_PORT_CONFIG}
     }
-    dependencies = ["DefaultServiceEntityEnricher"]
+    dependencies = ["EndpointEnricher"]
   }
 
   ApiStatusEnricher {
@@ -81,7 +81,7 @@ enricher {
 
   EndpointEnricher {
     class = "org.hypertrace.traceenricher.enrichment.enrichers.endpoint.EndpointEnricher"
-    dependencies = ["DefaultServiceEntityEnricher", "ApiBoundaryTypeAttributeEnricher"]
+    dependencies = ["DefaultServiceEntityEnricher"]
     entity.service.config = {
       host = localhost
       host = ${?ENTITY_SERVICE_HOST_CONFIG}


### PR DESCRIPTION
While working on the issue - https://github.com/hypertrace/hypertrace/issues/128, I have observed the following topology sort for enrichers.

![enricher-sorting-order](https://user-images.githubusercontent.com/53209990/103337132-51a62d80-4aa0-11eb-914d-ab978c965f93.jpg)

As we can see from the code - https://github.com/hypertrace/hypertrace-trace-enricher/blob/435d21caab170c5b8d207785204b61839089a599/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/BackendEntityEnricher.java#L112 - that backend entity enricher depended on attribute `ApiAttribute.API_ATTRIBUTE_ID` in EndpointEnricher. So, adding the dependency.