### PR TITLE
Optimisation: Share state between view-generators 

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraph.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraph.java
@@ -32,7 +32,7 @@ public class ApiTraceGraph {
   private static final String UNKNOWN_SPAN_KIND_VALUE =
       EnrichedSpanConstants.getValue(AttributeValue.ATTRIBUTE_VALUE_UNKNOWN);
 
-  private final List<ApiNode<Event>> nodeList;
+  private List<ApiNode<Event>> nodeList;
   private final List<ApiNodeEventEdge> apiNodeEventEdgeList;
   private final StructuredTrace trace;
   private final Map<String, Integer> eventIdToIndexInTrace;

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraph.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraph.java
@@ -32,16 +32,20 @@ public class ApiTraceGraph {
   private static final String UNKNOWN_SPAN_KIND_VALUE =
       EnrichedSpanConstants.getValue(AttributeValue.ATTRIBUTE_VALUE_UNKNOWN);
 
-  private List<ApiNode<Event>> nodeList;
-  private List<ApiNodeEventEdge> apiNodeEventEdgeList;
-  private StructuredTrace trace;
-  private Map<String, Integer> eventIdToIndexInTrace;
+  private final List<ApiNode<Event>> nodeList;
+  private final List<ApiNodeEventEdge> apiNodeEventEdgeList;
+  private final StructuredTrace trace;
+  private final Map<String, Integer> eventIdToIndexInTrace;
 
   public ApiTraceGraph(StructuredTrace trace) {
     this.trace = trace;
     nodeList = new ArrayList<>();
     apiNodeEventEdgeList = new ArrayList<>();
     eventIdToIndexInTrace = buildEventIdToIndexInTrace(trace);
+  }
+
+  public StructuredTrace getTrace() {
+    return trace;
   }
 
   public List<ApiNode<Event>> getNodeList() {

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/BaseViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/BaseViewGenerator.java
@@ -68,10 +68,10 @@ public abstract class BaseViewGenerator<OUT extends GenericRecord>
     DataflowMetricUtils.reportArrivalLagAndInsertTimestamp(trace, viewGeneratorArrivalTimer,
         VIEW_GENERATION_ARRIVAL_TIME);
     TraceState traceState = ViewGeneratorState.getTraceState(trace);
-    Map<String, Entity> entityMap = traceState.entityMap;
-    Map<ByteBuffer, Event> eventMap = traceState.eventMap;
-    Map<ByteBuffer, List<ByteBuffer>> parentToChildrenEventIds = traceState.parentToChildrenEventIds;
-    Map<ByteBuffer, ByteBuffer> childToParentEventIds = traceState.childToParentEventIds;
+    Map<String, Entity> entityMap = Collections.unmodifiableMap(traceState.entityMap);
+    Map<ByteBuffer, Event> eventMap = Collections.unmodifiableMap(traceState.eventMap);
+    Map<ByteBuffer, List<ByteBuffer>> parentToChildrenEventIds = Collections.unmodifiableMap(traceState.parentToChildrenEventIds);
+    Map<ByteBuffer, ByteBuffer> childToParentEventIds = Collections.unmodifiableMap(traceState.childToParentEventIds);
 
     return generateView(
         trace,

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/BaseViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/BaseViewGenerator.java
@@ -68,10 +68,10 @@ public abstract class BaseViewGenerator<OUT extends GenericRecord>
     DataflowMetricUtils.reportArrivalLagAndInsertTimestamp(trace, viewGeneratorArrivalTimer,
         VIEW_GENERATION_ARRIVAL_TIME);
     TraceState traceState = ViewGeneratorState.getTraceState(trace);
-    Map<String, Entity> entityMap = Collections.unmodifiableMap(traceState.entityMap);
-    Map<ByteBuffer, Event> eventMap = Collections.unmodifiableMap(traceState.eventMap);
-    Map<ByteBuffer, List<ByteBuffer>> parentToChildrenEventIds = Collections.unmodifiableMap(traceState.parentToChildrenEventIds);
-    Map<ByteBuffer, ByteBuffer> childToParentEventIds = Collections.unmodifiableMap(traceState.childToParentEventIds);
+    Map<String, Entity> entityMap = Collections.unmodifiableMap(traceState.getEntityMap());
+    Map<ByteBuffer, Event> eventMap = Collections.unmodifiableMap(traceState.getEventMap());
+    Map<ByteBuffer, List<ByteBuffer>> parentToChildrenEventIds = Collections.unmodifiableMap(traceState.getParentToChildrenEventIds());
+    Map<ByteBuffer, ByteBuffer> childToParentEventIds = Collections.unmodifiableMap(traceState.getChildToParentEventIds());
 
     return generateView(
         trace,

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/RawServiceViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/RawServiceViewGenerator.java
@@ -29,7 +29,8 @@ public class RawServiceViewGenerator extends BaseViewGenerator<RawServiceView> {
     List<RawServiceView> list = new ArrayList<>();
 
     // Construct ApiTraceGraph and look at all the head spans within each ApiNode
-    ApiTraceGraph apiTraceGraph = new ApiTraceGraph(structuredTrace);
+    ApiTraceGraph apiTraceGraph = ViewGeneratorState.getApiTraceGraph(structuredTrace);
+
     apiTraceGraph = apiTraceGraph.build();
     List<ApiNode<Event>> apiNodes = apiTraceGraph.getNodeList();
     for (ApiNode<Event> apiNode : apiNodes) {

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/RawServiceViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/RawServiceViewGenerator.java
@@ -31,7 +31,6 @@ public class RawServiceViewGenerator extends BaseViewGenerator<RawServiceView> {
     // Construct ApiTraceGraph and look at all the head spans within each ApiNode
     ApiTraceGraph apiTraceGraph = ViewGeneratorState.getApiTraceGraph(structuredTrace);
 
-    apiTraceGraph = apiTraceGraph.build();
     List<ApiNode<Event>> apiNodes = apiTraceGraph.getNodeList();
     for (ApiNode<Event> apiNode : apiNodes) {
       Event event = apiNode.getHeadEvent();

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/ServiceCallViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/ServiceCallViewGenerator.java
@@ -63,7 +63,7 @@ public class ServiceCallViewGenerator extends BaseViewGenerator<ServiceCallView>
       Map<ByteBuffer, Event> eventMap,
       Map<ByteBuffer, List<ByteBuffer>> parentToChildrenEventIds,
       Map<ByteBuffer, ByteBuffer> childToParentEventIds) {
-    ApiTraceGraph apiTraceGraph = new ApiTraceGraph(structuredTrace).build();
+    ApiTraceGraph apiTraceGraph = ViewGeneratorState.getApiTraceGraph(structuredTrace);
 
     // Scenario #1: Go through the apiNode edges and create a record for each edge. Should be easy
     // to get to the events

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/ViewGeneratorState.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/ViewGeneratorState.java
@@ -34,8 +34,7 @@ public class ViewGeneratorState {
   }
 
   private static boolean isDifferentTrace(StructuredTrace cached, StructuredTrace trace) {
-    return !cached.getCustomerId().equals(trace.getCustomerId())
-        || !cached.getTraceId().equals(trace.getTraceId());
+    return cached != trace;
   }
 
   public static class TraceState {

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/ViewGeneratorState.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/ViewGeneratorState.java
@@ -1,0 +1,77 @@
+package org.hypertrace.viewgenerator.generators;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.hypertrace.core.datamodel.Entity;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.EventRef;
+import org.hypertrace.core.datamodel.EventRefType;
+import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.traceenricher.trace.util.ApiTraceGraph;
+
+public class ViewGeneratorState {
+
+  private static final ThreadLocal<TraceState> traceStateThreadLocal = new ThreadLocal<>();
+  private static final ThreadLocal<ApiTraceGraph> apiTraceGraphThreadLocal = new ThreadLocal<>();
+
+  public static ApiTraceGraph getApiTraceGraph(StructuredTrace trace) {
+    if (apiTraceGraphThreadLocal.get() == null
+        || isDifferentTrace(apiTraceGraphThreadLocal.get().getTrace(), trace)) {
+      apiTraceGraphThreadLocal.set(new ApiTraceGraph(trace).build());
+    }
+    return apiTraceGraphThreadLocal.get();
+  }
+
+  public static TraceState getTraceState(StructuredTrace trace) {
+    if (traceStateThreadLocal.get() == null
+        || isDifferentTrace(traceStateThreadLocal.get().trace, trace)) {
+      traceStateThreadLocal.set(new TraceState(trace));
+    }
+    return traceStateThreadLocal.get();
+  }
+
+  private static boolean isDifferentTrace(StructuredTrace cached, StructuredTrace trace) {
+    return !cached.getCustomerId().equals(trace.getCustomerId())
+        || !cached.getTraceId().equals(trace.getTraceId());
+  }
+
+  public static class TraceState {
+    private final StructuredTrace trace;
+    final Map<String, Entity> entityMap = new HashMap<>();
+    final Map<ByteBuffer, Event> eventMap = new HashMap<>();
+    final Map<ByteBuffer, List<ByteBuffer>> parentToChildrenEventIds = new HashMap<>();
+    final Map<ByteBuffer, ByteBuffer> childToParentEventIds = new HashMap<>();
+
+    public TraceState(StructuredTrace trace) {
+      this.trace = trace;
+      for (Entity entity : trace.getEntityList()) {
+        entityMap.put(entity.getEntityId(), entity);
+      }
+      for (Event event : trace.getEventList()) {
+        eventMap.put(event.getEventId(), event);
+      }
+
+      for (Event event : trace.getEventList()) {
+        ByteBuffer childEventId = event.getEventId();
+        List<EventRef> eventRefs = eventMap.get(childEventId).getEventRefList();
+        if (eventRefs != null) {
+          eventRefs.stream()
+              .filter(eventRef -> EventRefType.CHILD_OF == eventRef.getRefType())
+              .forEach(
+                  eventRef -> {
+                    ByteBuffer parentEventId = eventRef.getEventId();
+                    if (!parentToChildrenEventIds.containsKey(parentEventId)) {
+                      parentToChildrenEventIds.put(parentEventId, new ArrayList<>());
+                    }
+                    parentToChildrenEventIds.get(parentEventId).add(childEventId);
+                    childToParentEventIds.put(childEventId, parentEventId);
+                  });
+        }
+        // expected only 1 childOf relationship
+      }
+    }
+  }
+}

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/ViewGeneratorStateTest.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/ViewGeneratorStateTest.java
@@ -44,6 +44,9 @@ public class ViewGeneratorStateTest {
     assertNotNull(traceState);
     assertEquals(trace, traceState.getTrace());
 
+    TraceState sameTraceState = ViewGeneratorState.getTraceState(trace);
+    assertEquals(sameTraceState, traceState);
+
     StructuredTrace modifiedTrace = getTestTrace(customerId, traceId1);
     modifiedTrace.setEntityList(Arrays.asList(
         Entity.newBuilder()
@@ -53,13 +56,13 @@ public class ViewGeneratorStateTest {
             .setEntityType("service")
             .build()));
 
-    // same instance should still be returned
-    TraceState sameTraceState = ViewGeneratorState.getTraceState(modifiedTrace);
-    assertEquals(traceState, sameTraceState);
+    // same trace id but different object should result in rebuilding of trace state
+    TraceState differentTraceState1 = ViewGeneratorState.getTraceState(modifiedTrace);
+    assertNotEquals(traceState, differentTraceState1);
 
     StructuredTrace differentTrace = getTestTrace(customerId, traceId2);
-    TraceState differentTraceState = ViewGeneratorState.getTraceState(differentTrace);
-    assertEquals(differentTrace, differentTraceState.getTrace());
+    TraceState differentTraceState2 = ViewGeneratorState.getTraceState(differentTrace);
+    assertEquals(differentTrace, differentTraceState2.getTrace());
   }
 
   @Test
@@ -68,6 +71,9 @@ public class ViewGeneratorStateTest {
     ApiTraceGraph apiTraceGraph = ViewGeneratorState.getApiTraceGraph(trace);
     assertNotNull(apiTraceGraph);
 
+    ApiTraceGraph sameApiTraceGraph = ViewGeneratorState.getApiTraceGraph(trace);
+    assertEquals(sameApiTraceGraph, apiTraceGraph);
+
     StructuredTrace modifiedTrace = getTestTrace(customerId, traceId1);
     modifiedTrace.setEntityList(Arrays.asList(
         Entity.newBuilder()
@@ -77,13 +83,14 @@ public class ViewGeneratorStateTest {
             .setEntityType("service")
             .build()));
 
-    // same instance should still be returned
-    ApiTraceGraph sameApiTraceGraph = ViewGeneratorState.getApiTraceGraph(modifiedTrace);
-    assertEquals(apiTraceGraph, sameApiTraceGraph);
+
+    // same trace id but different object should result in rebuilding of trace state
+    ApiTraceGraph differentApiTraceGraph1 = ViewGeneratorState.getApiTraceGraph(modifiedTrace);
+    assertNotEquals(apiTraceGraph, differentApiTraceGraph1);
 
     StructuredTrace differentTrace = getTestTrace(customerId, traceId2);
-    ApiTraceGraph differentApiTraceGraph = ViewGeneratorState.getApiTraceGraph(differentTrace);
-    assertNotEquals(apiTraceGraph, differentApiTraceGraph);
+    ApiTraceGraph differentApiTraceGraph2 = ViewGeneratorState.getApiTraceGraph(differentTrace);
+    assertNotEquals(apiTraceGraph, differentApiTraceGraph2);
   }
 
   private StructuredTrace getTestTrace(String customerId, ByteBuffer traceId) {

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/ViewGeneratorStateTest.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/ViewGeneratorStateTest.java
@@ -1,0 +1,130 @@
+package org.hypertrace.viewgenerator.generators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import org.hypertrace.core.datamodel.Entity;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.EventRef;
+import org.hypertrace.core.datamodel.EventRefType;
+import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.traceenricher.trace.util.ApiTraceGraph;
+import org.hypertrace.viewgenerator.generators.ViewGeneratorState.TraceState;
+import org.junit.jupiter.api.Test;
+
+public class ViewGeneratorStateTest {
+
+  ByteBuffer span1 = ByteBuffer.wrap(("span-1".getBytes())), span2 = ByteBuffer.wrap(("span-2".getBytes()));
+  String customerId = "customer-1";
+  ByteBuffer traceId1 = ByteBuffer.wrap(("trace-1".getBytes())), traceId2 = ByteBuffer.wrap(("trace-2".getBytes()));
+
+  @Test
+  public void testTraceState() {
+    TraceState traceState = new TraceState(getTestTrace(customerId, traceId1));
+    assertEquals(1, traceState.getEntityMap().size());
+    assertEquals(2, traceState.getEventMap().size());
+    assertEquals(1, traceState.getChildToParentEventIds().size());
+    assertEquals(1, traceState.getParentToChildrenEventIds().size());
+
+    assertTrue(traceState.getParentToChildrenEventIds().containsKey(span1));
+    assertEquals(1, traceState.getParentToChildrenEventIds().get(span1).size());
+    assertTrue(traceState.getChildToParentEventIds().containsKey(span2));
+    assertEquals(span1, traceState.getChildToParentEventIds().get(span2));
+  }
+
+  @Test
+  public void testGetTraceState() {
+    StructuredTrace trace = getTestTrace(customerId, traceId1);
+    TraceState traceState = ViewGeneratorState.getTraceState(trace);
+    assertNotNull(traceState);
+    assertEquals(trace, traceState.getTrace());
+
+    StructuredTrace modifiedTrace = getTestTrace(customerId, traceId1);
+    modifiedTrace.setEntityList(Arrays.asList(
+        Entity.newBuilder()
+            .setCustomerId(customerId)
+            .setEntityId("entity-2")
+            .setEntityName("entity-2")
+            .setEntityType("service")
+            .build()));
+
+    // same instance should still be returned
+    TraceState sameTraceState = ViewGeneratorState.getTraceState(modifiedTrace);
+    assertEquals(traceState, sameTraceState);
+
+    StructuredTrace differentTrace = getTestTrace(customerId, traceId2);
+    TraceState differentTraceState = ViewGeneratorState.getTraceState(differentTrace);
+    assertEquals(differentTrace, differentTraceState.getTrace());
+  }
+
+  @Test
+  public void testGetApiTraceGraph() {
+    StructuredTrace trace = getTestTrace(customerId, traceId1);
+    ApiTraceGraph apiTraceGraph = ViewGeneratorState.getApiTraceGraph(trace);
+    assertNotNull(apiTraceGraph);
+
+    StructuredTrace modifiedTrace = getTestTrace(customerId, traceId1);
+    modifiedTrace.setEntityList(Arrays.asList(
+        Entity.newBuilder()
+            .setCustomerId(customerId)
+            .setEntityId("entity-2")
+            .setEntityName("entity-2")
+            .setEntityType("service")
+            .build()));
+
+    // same instance should still be returned
+    ApiTraceGraph sameApiTraceGraph = ViewGeneratorState.getApiTraceGraph(modifiedTrace);
+    assertEquals(apiTraceGraph, sameApiTraceGraph);
+
+    StructuredTrace differentTrace = getTestTrace(customerId, traceId2);
+    ApiTraceGraph differentApiTraceGraph = ViewGeneratorState.getApiTraceGraph(differentTrace);
+    assertNotEquals(apiTraceGraph, differentApiTraceGraph);
+  }
+
+  private StructuredTrace getTestTrace(String customerId, ByteBuffer traceId) {
+    return StructuredTrace.newBuilder()
+        .setCustomerId(customerId)
+        .setTraceId(traceId)
+        .setStartTimeMillis(20)
+        .setEndTimeMillis(30)
+        .setEntityList(Arrays.asList(
+            Entity.newBuilder()
+                .setCustomerId(customerId)
+                .setEntityId("entity-1")
+                .setEntityName("entity-1")
+                .setEntityType("service")
+                .build()))
+        .setEventList(Arrays.asList(
+            Event.newBuilder()
+                .setCustomerId(customerId)
+                .setEventId(ByteBuffer.wrap(("span-1".getBytes())))
+                .setEventName("span-1")
+                .build(),
+            Event.newBuilder()
+                .setCustomerId(customerId)
+                .setEventId(ByteBuffer.wrap(("span-2".getBytes())))
+                .setEventName("span-2")
+                .setEventRefList(Arrays.asList(
+                    EventRef.newBuilder()
+                        .setTraceId(traceId)
+                        .setRefType(EventRefType.CHILD_OF)
+                        .setEventId(ByteBuffer.wrap(("span-1".getBytes())))
+                        .build()
+                ))
+                .build()
+        ))
+        .setEntityEdgeList(Collections.EMPTY_LIST)
+        .setEntityEventEdgeList(Collections.EMPTY_LIST)
+        .setEventEdgeList(Collections.EMPTY_LIST)
+        .setEntityEntityGraph(null)
+        .setEventEventGraph(null)
+        .setEntityEventGraph(null)
+        .setMetrics(null)
+        .build();
+  }
+}


### PR DESCRIPTION
Currently we run, all the view-generators in individual services. 
Although we do have a possibility of running view generator together in a single service using `MultiViewGeneratorLauncher`,
though that won't be very optimal due to repeated operations amongst the view-generators. 

This pr tries to optimise that by caching shared state in a threadlocal, thus ensuring that for a given Trace, those operations are performed once. 

Note: this changes should not affect in the case when view-generators have to be individually deployed