### PR TITLE
refactor: add otel deployment env constant

### DIFF
--- a/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/deployment/OTelDeploymentSemanticConventions.java
+++ b/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/deployment/OTelDeploymentSemanticConventions.java
@@ -1,0 +1,16 @@
+package org.hypertrace.core.semantic.convention.constants.deployment;
+
+/** OTEL specific attributes for deployment */
+public enum OTelDeploymentSemanticConventions {
+  DEPLOYMENT_ENVIRONMENT("deployment.environment");
+
+  private final String value;
+
+  OTelDeploymentSemanticConventions(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+}


### PR DESCRIPTION
Based off of:
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/deployment_environment.md

A few questions when looking in this code (@rish691 I think you have the most context):
- Why are we using enums rather that static final constants? It seems like we're either using `.getValue()` everywhere or just saving them into constants anyway like
`  private static final String OTEL_NET_PEER_IP = OTelSpanSemanticConventions.NET_PEER_IP.getValue();`
- Given that we're not actually using this in enrichment today, are there any other expected changes here? It seems like the utils around this are just wrappers for the enrichers.