### PR TITLE
chore: Controlled logging in RabbitMqResolver

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/RabbitMqBackendResolver.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/RabbitMqBackendResolver.java
@@ -17,6 +17,9 @@ public class RabbitMqBackendResolver extends AbstractBackendResolver {
 
   @Override
   public Optional<Entity> resolveEntity(Event event, StructuredTraceGraph structuredTraceGraph) {
+    if (!MessagingSemanticConventionUtils.isRabbitMqBackend(event)) {
+      return Optional.empty();
+    }
     Optional<String> routingKey = MessagingSemanticConventionUtils.getRabbitMqRoutingKey(event);
 
     if (routingKey.isEmpty() || StringUtils.isEmpty(routingKey.get())) {

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/messaging/MessagingSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/messaging/MessagingSemanticConventionUtils.java
@@ -26,7 +26,15 @@ public class MessagingSemanticConventionUtils {
    * @return Routing key for Rabbit mq messaging system
    */
   public static Optional<String> getRabbitMqRoutingKey(Event event) {
+    if (!isRabbitMqBackend(event)) {
+      return Optional.empty();
+    }
     return Optional.ofNullable(SpanAttributeUtils.getFirstAvailableStringAttribute(
         event, RABBITMQ_ROUTING_KEYS));
+  }
+
+  public static boolean isRabbitMqBackend(Event event) {
+    return SpanAttributeUtils.containsAttributeKey(event, RawSpanConstants.getValue(RabbitMq.RABBIT_MQ_ROUTING_KEY))
+        || SpanAttributeUtils.containsAttributeKey(event, OtelMessagingSemanticConventions.RABBITMQ_ROUTING_KEY.getValue());
   }
 }

--- a/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/messaging/OtelMessagingSemanticConventionUtilsTest.java
+++ b/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/messaging/OtelMessagingSemanticConventionUtilsTest.java
@@ -3,13 +3,15 @@ package org.hypertrace.semantic.convention.utils.messaging;
 import java.util.Map;
 import java.util.Optional;
 import org.hypertrace.core.semantic.convention.constants.messaging.OtelMessagingSemanticConventions;
-import org.hypertrace.semantic.convention.utils.SemanticConventionTestUtil;
 import org.hypertrace.core.datamodel.Attributes;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.span.constants.RawSpanConstants;
 import org.hypertrace.core.span.constants.v1.RabbitMq;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.hypertrace.semantic.convention.utils.SemanticConventionTestUtil.buildAttributeValue;
+import static org.hypertrace.semantic.convention.utils.SemanticConventionTestUtil.buildAttributes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -25,26 +27,49 @@ public class OtelMessagingSemanticConventionUtilsTest {
     Event e = mock(Event.class);
     // otel format
     String routingKey = "otelRoutingKey";
-    Attributes attributes = SemanticConventionTestUtil.buildAttributes(
-        Map.of(OtelMessagingSemanticConventions.RABBITMQ_ROUTING_KEY.getValue(), SemanticConventionTestUtil.buildAttributeValue(routingKey)));
+    Attributes attributes = buildAttributes(
+        Map.of(OtelMessagingSemanticConventions.RABBITMQ_ROUTING_KEY.getValue(), buildAttributeValue(routingKey)));
     when(e.getAttributes()).thenReturn(attributes);
     Optional<String> v = MessagingSemanticConventionUtils.getRabbitMqRoutingKey(e);
     assertEquals(routingKey, v.get());
 
     // other format
     routingKey = "otherRoutingKey";
-    attributes = SemanticConventionTestUtil.buildAttributes(
-        Map.of(RawSpanConstants.getValue(RabbitMq.RABBIT_MQ_ROUTING_KEY), SemanticConventionTestUtil
-            .buildAttributeValue(routingKey)));
+    attributes = buildAttributes(
+        Map.of(RawSpanConstants.getValue(RabbitMq.RABBIT_MQ_ROUTING_KEY), buildAttributeValue(routingKey)));
     when(e.getAttributes()).thenReturn(attributes);
     v = MessagingSemanticConventionUtils.getRabbitMqRoutingKey(e);
     assertEquals(routingKey, v.get());
 
     // routing key absent
-    attributes = SemanticConventionTestUtil.buildAttributes(
-        Map.of("span.kind", SemanticConventionTestUtil.buildAttributeValue("client")));
+    attributes = buildAttributes(
+        Map.of("span.kind", buildAttributeValue("client")));
     when(e.getAttributes()).thenReturn(attributes);
     v = MessagingSemanticConventionUtils.getRabbitMqRoutingKey(e);
     assertTrue(v.isEmpty());
+  }
+
+  @Test
+  public void testIsRabbitMqBackend() {
+    Event e = mock(Event.class);
+    // otel format
+    String routingKey = "otelRoutingKey";
+    Attributes attributes = buildAttributes(
+        Map.of(OtelMessagingSemanticConventions.RABBITMQ_ROUTING_KEY.getValue(), buildAttributeValue(routingKey)));
+    when(e.getAttributes()).thenReturn(attributes);
+    boolean v = MessagingSemanticConventionUtils.isRabbitMqBackend(e);
+    assertTrue(v);
+    // other format
+    routingKey = "otherRoutingKey";
+    attributes = buildAttributes(
+        Map.of(RawSpanConstants.getValue(RabbitMq.RABBIT_MQ_ROUTING_KEY), buildAttributeValue(routingKey)));
+    when(e.getAttributes()).thenReturn(attributes);
+    v = MessagingSemanticConventionUtils.isRabbitMqBackend(e);
+    assertTrue(v);
+    // not present
+    attributes = buildAttributes(Map.of());
+    when(e.getAttributes()).thenReturn(attributes);
+    v = MessagingSemanticConventionUtils.isRabbitMqBackend(e);
+    Assertions.assertFalse(v);
   }
 }


### PR DESCRIPTION
Log warning messages in RabbitMqResolver, only when there is some identifying attribute for RabbitMq is present. 