### PR TITLE
Limit the number of spans in a trace

### DIFF
--- a/raw-spans-grouper/helm/templates/raw-spans-grouper-config.yaml
+++ b/raw-spans-grouper/helm/templates/raw-spans-grouper-config.yaml
@@ -56,6 +56,14 @@ data:
 
     span.groupby.session.window.interval = {{ .Values.rawSpansGrouperConfig.span.groupby.internal }}
 
+    {{- if hasKey .Values.rawSpansGrouperConfig "maxSpanCount" }}
+    max.span.count = {
+    {{- range $k, $v := .Values.rawSpansGrouperConfig.maxSpanCount }}
+      {{ $k }} = {{ int $v }}
+    {{- end }}
+    }
+    {{- end }}
+
     {{- if hasKey .Values.rawSpansGrouperConfig "metrics" }}
     metrics {
       reporter {

--- a/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpanGrouperConstants.java
+++ b/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpanGrouperConstants.java
@@ -12,4 +12,6 @@ public class RawSpanGrouperConstants {
   public static final String TRACE_CREATION_TIME = "trace.creation.time";
   public static final String DATAFLOW_SAMPLING_PERCENT_CONFIG_KEY = "dataflow.metriccollection.sampling.percent";
   public static final String INFLIGHT_TRACE_MAX_SPAN_COUNT = "max.span.count";
+  public static final String DROPPED_SPANS_COUNTER = "hypertrace.dropped.spans";
+  public static final String TRUNCATED_TRACES_COUNTER = "hypertrace.truncated.traces";
 }

--- a/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpanGrouperConstants.java
+++ b/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpanGrouperConstants.java
@@ -11,4 +11,5 @@ public class RawSpanGrouperConstants {
   public static final String SPANS_PER_TRACE_METRIC = "spans_per_trace";
   public static final String TRACE_CREATION_TIME = "trace.creation.time";
   public static final String DATAFLOW_SAMPLING_PERCENT_CONFIG_KEY = "dataflow.metriccollection.sampling.percent";
+  public static final String INFLIGHT_TRACE_MAX_SPAN_COUNT = "max.span.count";
 }

--- a/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpansGroupingTransformer.java
+++ b/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpansGroupingTransformer.java
@@ -97,11 +97,11 @@ public class RawSpansGroupingTransformer implements
     RawSpans agg = rawSpans != null ? rawSpans.value() : RawSpans.newBuilder().build();
     if (maxSpanCountMap.containsKey(key.getTenantId()) && agg.getRawSpans().size() > maxSpanCountMap.get(key.getTenantId())) {
       if (logger.isDebugEnabled()) {
-        logger.debug("Number of spans in tenant_id={}, trace_id={} is {}",
+        logger.debug("Dropping span [{}] from tenant_id={}, trace_id={} after grouping {} spans",
+          value,
           key.getTenantId(),
           HexUtils.getHex(key.getTraceId()),
           agg.getRawSpans().size());
-        logger.debug("Dropping span [{}] from tenant_id={}, trace_id={}", value, key.getTenantId(), HexUtils.getHex(key.getTraceId()));
       }
       // increment the counter for dropped spans
       droppedSpansCounter.computeIfAbsent(key.getTenantId(),

--- a/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpansGroupingTransformer.java
+++ b/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpansGroupingTransformer.java
@@ -1,12 +1,14 @@
 package org.hypertrace.core.rawspansgrouper;
 
 import static org.hypertrace.core.rawspansgrouper.RawSpanGrouperConstants.DATAFLOW_SAMPLING_PERCENT_CONFIG_KEY;
+import static org.hypertrace.core.rawspansgrouper.RawSpanGrouperConstants.DROPPED_SPANS_COUNTER;
 import static org.hypertrace.core.rawspansgrouper.RawSpanGrouperConstants.INFLIGHT_TRACE_MAX_SPAN_COUNT;
 import static org.hypertrace.core.rawspansgrouper.RawSpanGrouperConstants.INFLIGHT_TRACE_STORE;
 import static org.hypertrace.core.rawspansgrouper.RawSpanGrouperConstants.OUTPUT_TOPIC_PRODUCER;
 import static org.hypertrace.core.rawspansgrouper.RawSpanGrouperConstants.RAW_SPANS_GROUPER_JOB_CONFIG;
 import static org.hypertrace.core.rawspansgrouper.RawSpanGrouperConstants.SPAN_GROUPBY_SESSION_WINDOW_INTERVAL_CONFIG_KEY;
 import static org.hypertrace.core.rawspansgrouper.RawSpanGrouperConstants.TRACE_EMIT_TRIGGER_STORE;
+import static org.hypertrace.core.rawspansgrouper.RawSpanGrouperConstants.TRUNCATED_TRACES_COUNTER;
 
 import com.typesafe.config.Config;
 import java.time.Duration;
@@ -56,11 +58,9 @@ public class RawSpansGroupingTransformer implements
   private Map<String, Long> maxSpanCountMap = new HashMap<>();
 
   // counter for number of spans dropped per tenant
-  private static final String DROPPED_SPANS_COUNTER = "hypertrace.dropped.spans";
   private static final ConcurrentMap<String, Counter> droppedSpansCounter = new ConcurrentHashMap<>();
 
   // counter for number of truncated traces per tenant
-  private static final String TRUNCATED_TRACES_COUNTER = "hypertrace.truncated.traces";
   private static final ConcurrentMap<String, Counter> truncatedTracesCounter = new ConcurrentHashMap<>();
 
   @Override

--- a/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpansGroupingTransformer.java
+++ b/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpansGroupingTransformer.java
@@ -95,7 +95,7 @@ public class RawSpansGroupingTransformer implements
   public KeyValue<String, StructuredTrace> transform(TraceIdentity key, RawSpan value) {
     ValueAndTimestamp<RawSpans> rawSpans = inflightTraceStore.get(key);
     RawSpans agg = rawSpans != null ? rawSpans.value() : RawSpans.newBuilder().build();
-    if (maxSpanCountMap.containsKey(key.getTenantId()) && agg.getRawSpans().size() > maxSpanCountMap.get(key.getTenantId())) {
+    if (maxSpanCountMap.containsKey(key.getTenantId()) && agg.getRawSpans().size() >= maxSpanCountMap.get(key.getTenantId())) {
       if (logger.isDebugEnabled()) {
         logger.debug("Dropping span [{}] from tenant_id={}, trace_id={} after grouping {} spans",
           value,

--- a/raw-spans-grouper/raw-spans-grouper/src/test/java/org/hypertrace/core/rawspansgrouper/RawSpansGrouperTest.java
+++ b/raw-spans-grouper/raw-spans-grouper/src/test/java/org/hypertrace/core/rawspansgrouper/RawSpansGrouperTest.java
@@ -80,6 +80,18 @@ public class RawSpansGrouperTest {
         .setCustomerId("tenant1").setEvent(createEvent("event-4", "tenant1")).build();
     RawSpan span5 = RawSpan.newBuilder().setTraceId(ByteBuffer.wrap("trace-2".getBytes()))
         .setCustomerId("tenant1").setEvent(createEvent("event-5", "tenant1")).build();
+    RawSpan span6 = RawSpan.newBuilder().setTraceId(ByteBuffer.wrap("trace-3".getBytes()))
+      .setCustomerId("tenant1").setEvent(createEvent("event-6", "tenant1")).build();
+    RawSpan span7 = RawSpan.newBuilder().setTraceId(ByteBuffer.wrap("trace-3".getBytes()))
+      .setCustomerId("tenant1").setEvent(createEvent("event-7", "tenant1")).build();
+    RawSpan span8 = RawSpan.newBuilder().setTraceId(ByteBuffer.wrap("trace-3".getBytes()))
+      .setCustomerId("tenant1").setEvent(createEvent("event-8", "tenant1")).build();
+    RawSpan span9 = RawSpan.newBuilder().setTraceId(ByteBuffer.wrap("trace-3".getBytes()))
+      .setCustomerId("tenant1").setEvent(createEvent("event-9", "tenant1")).build();
+    RawSpan span10 = RawSpan.newBuilder().setTraceId(ByteBuffer.wrap("trace-3".getBytes()))
+      .setCustomerId("tenant1").setEvent(createEvent("event-10", "tenant1")).build();
+    RawSpan span11 = RawSpan.newBuilder().setTraceId(ByteBuffer.wrap("trace-3".getBytes()))
+      .setCustomerId("tenant1").setEvent(createEvent("event-11", "tenant1")).build();
 
     inputTopic.pipeInput(createTraceIdentity(tenantId, "trace-1"), span1);
     inputTopic.pipeInput(createTraceIdentity(tenantId, "trace-2"), span4);
@@ -120,6 +132,18 @@ public class RawSpansGrouperTest {
     trace = (StructuredTrace) outputTopic.readValue();
     assertEquals(1, trace.getEventList().size());
     assertEquals(ByteBuffer.wrap("event-5".getBytes()), trace.getEventList().get(0).getEventId());
+
+    inputTopic.pipeInput(createTraceIdentity(tenantId, "trace-3"), span6);
+    inputTopic.pipeInput(createTraceIdentity(tenantId, "trace-3"), span7);
+    inputTopic.pipeInput(createTraceIdentity(tenantId, "trace-3"), span8);
+    inputTopic.pipeInput(createTraceIdentity(tenantId, "trace-3"), span9);
+    inputTopic.pipeInput(createTraceIdentity(tenantId, "trace-3"), span10);
+    inputTopic.pipeInput(createTraceIdentity(tenantId, "trace-3"), span11);
+    td.advanceWallClockTime(Duration.ofSeconds(35));
+
+    // trace should be truncated with 5 spans
+    trace = (StructuredTrace) outputTopic.readValue();
+    assertEquals(5, trace.getEventList().size());
   }
 
   private Event createEvent(String eventId, String tenantId) {

--- a/raw-spans-grouper/raw-spans-grouper/src/test/resources/configs/raw-spans-grouper/application.conf
+++ b/raw-spans-grouper/raw-spans-grouper/src/test/resources/configs/raw-spans-grouper/application.conf
@@ -23,6 +23,10 @@ kafka.streams.config = {
   value.subject.name.strategy = "io.confluent.kafka.serializers.subject.TopicRecordNameStrategy"
 }
 
+max.span.count = {
+  tenant1 = 5
+}
+
 span.groupby.session.window.interval = 5
 
 span.groupby.session.window.graceperiod.ms = 100


### PR DESCRIPTION
Added support for optional configuration to limit the number of spans in a trace. This config can be specified at per tenant level.
```
max.span.count = {
  eff27b72-622d-44d7-a0ca-1271a885a7a1 = 1000
}
```