### PR TITLE
feat: adding two new backend entity type and its resolver  - kafka, and sqs

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/BackendType.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/BackendType.java
@@ -1,5 +1,5 @@
 package org.hypertrace.traceenricher.enrichment.enrichers;
 
 public enum BackendType {
-  UNKNOWN, HTTP, HTTPS, GRPC, REDIS, MONGO, JDBC, RABBIT_MQ, KAFKA, AWS_SQS
+  UNKNOWN, HTTP, HTTPS, GRPC, REDIS, MONGO, JDBC, RABBIT_MQ, KAFKA, SQS
 }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/BackendType.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/BackendType.java
@@ -1,5 +1,5 @@
 package org.hypertrace.traceenricher.enrichment.enrichers;
 
 public enum BackendType {
-  UNKNOWN, HTTP, HTTPS, GRPC, REDIS, MONGO, JDBC, RABBIT_MQ
+  UNKNOWN, HTTP, HTTPS, GRPC, REDIS, MONGO, JDBC, RABBIT_MQ, KAFKA
 }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/BackendType.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/BackendType.java
@@ -1,5 +1,5 @@
 package org.hypertrace.traceenricher.enrichment.enrichers;
 
 public enum BackendType {
-  UNKNOWN, HTTP, HTTPS, GRPC, REDIS, MONGO, JDBC, RABBIT_MQ, KAFKA
+  UNKNOWN, HTTP, HTTPS, GRPC, REDIS, MONGO, JDBC, RABBIT_MQ, KAFKA, AWS_SQS
 }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendEntityResolver.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendEntityResolver.java
@@ -21,6 +21,7 @@ public class BackendEntityResolver extends AbstractBackendResolver {
         new JdbcBackendResolver(),
         new RabbitMqBackendResolver(),
         new KafkaBackendResolver(),
+        new SqsBackendResolver(),
         new ClientSpanEndpointResolver()
     );
   }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendEntityResolver.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendEntityResolver.java
@@ -20,6 +20,7 @@ public class BackendEntityResolver extends AbstractBackendResolver {
         new MongoBackendResolver(),
         new JdbcBackendResolver(),
         new RabbitMqBackendResolver(),
+        new KafkaBackendResolver(),
         new ClientSpanEndpointResolver()
     );
   }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/KafkaBackendResolver.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/KafkaBackendResolver.java
@@ -1,0 +1,35 @@
+package org.hypertrace.traceenricher.enrichment.enrichers.resolver.backend;
+
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.shared.StructuredTraceGraph;
+import org.hypertrace.entity.data.service.v1.Entity;
+import org.hypertrace.semantic.convention.utils.messaging.MessagingSemanticConventionUtils;
+import org.hypertrace.traceenricher.enrichment.enrichers.BackendType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class KafkaBackendResolver extends AbstractBackendResolver {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(KafkaBackendResolver.class);
+
+  @Override
+  public Optional<Entity> resolveEntity(Event event, StructuredTraceGraph structuredTraceGraph) {
+    if (!MessagingSemanticConventionUtils.isKafkaBackend(event)) {
+      return Optional.empty();
+    }
+
+    Optional<String> backendURI = MessagingSemanticConventionUtils.getKafkaBackendURI(event);
+
+    if (backendURI.isEmpty() || StringUtils.isEmpty(backendURI.get())) {
+      LOGGER.warn("Unable to infer a kafka backend from event: {}", event);
+      return Optional.empty();
+    }
+
+    Entity.Builder entityBuilder = getBackendEntityBuilder(
+        BackendType.KAFKA, backendURI.get(), event);
+    return Optional.of(entityBuilder.build());
+  }
+}

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/KafkaBackendResolver.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/KafkaBackendResolver.java
@@ -27,7 +27,11 @@ public class KafkaBackendResolver extends AbstractBackendResolver {
       LOGGER.warn("Unable to infer a kafka backend from event: {}", event);
       return Optional.empty();
     }
-
+    /*
+    todo: should we clean protocol constants for rabbit_mq, mongo?
+    this is not added into enriched spans constants proto as there want be http.url
+    with kafka://bootstrap.9092
+    * */
     Entity.Builder entityBuilder = getBackendEntityBuilder(
         BackendType.KAFKA, backendURI.get(), event);
     return Optional.of(entityBuilder.build());

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/SqsBackendResolver.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/SqsBackendResolver.java
@@ -1,0 +1,35 @@
+package org.hypertrace.traceenricher.enrichment.enrichers.resolver.backend;
+
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.shared.StructuredTraceGraph;
+import org.hypertrace.entity.data.service.v1.Entity;
+import org.hypertrace.semantic.convention.utils.messaging.MessagingSemanticConventionUtils;
+import org.hypertrace.traceenricher.enrichment.enrichers.BackendType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class SqsBackendResolver extends AbstractBackendResolver {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SqsBackendResolver.class);
+
+  @Override
+  public Optional<Entity> resolveEntity(Event event, StructuredTraceGraph structuredTraceGraph) {
+    if (!MessagingSemanticConventionUtils.isSqsBackend(event)) {
+      return Optional.empty();
+    }
+
+    Optional<String> backendURI = MessagingSemanticConventionUtils.getSqsBackendURI(event);
+
+    if (backendURI.isEmpty() || StringUtils.isEmpty(backendURI.get())) {
+      LOGGER.warn("Unable to infer a SQS backend from event: {}", event);
+      return Optional.empty();
+    }
+
+    Entity.Builder entityBuilder = getBackendEntityBuilder(
+        BackendType.AWS_SQS, backendURI.get(), event);
+    return Optional.of(entityBuilder.build());
+  }
+}

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/SqsBackendResolver.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/SqsBackendResolver.java
@@ -27,9 +27,13 @@ public class SqsBackendResolver extends AbstractBackendResolver {
       LOGGER.warn("Unable to infer a SQS backend from event: {}", event);
       return Optional.empty();
     }
-
+    /*
+    todo: should we clean protocol constants for rabbit_mq, mongo?
+    this is not added into enriched spans constants proto as there want be http.url
+    with sqs://xyz:2323.
+    * */
     Entity.Builder entityBuilder = getBackendEntityBuilder(
-        BackendType.AWS_SQS, backendURI.get(), event);
+        BackendType.SQS, backendURI.get(), event);
     return Optional.of(entityBuilder.build());
   }
 }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/KafkaBackendResolverTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/KafkaBackendResolverTest.java
@@ -1,0 +1,66 @@
+package org.hypertrace.traceenricher.enrichment.enrichers.resolver.backend;
+
+import static org.mockito.Mockito.mock;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Map;
+import org.hypertrace.core.datamodel.AttributeValue;
+import org.hypertrace.core.datamodel.Attributes;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.EventRef;
+import org.hypertrace.core.datamodel.EventRefType;
+import org.hypertrace.core.datamodel.MetricValue;
+import org.hypertrace.core.datamodel.Metrics;
+import org.hypertrace.core.datamodel.shared.StructuredTraceGraph;
+import org.hypertrace.entity.data.service.v1.Entity;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * Unit Test for {@link KafkaBackendResolver}
+ */
+public class KafkaBackendResolverTest {
+
+  private KafkaBackendResolver kafkaBackendResolver;
+  private StructuredTraceGraph structuredTraceGraph;
+
+  @BeforeEach
+  public void setup() {
+    kafkaBackendResolver = new KafkaBackendResolver();
+    structuredTraceGraph = mock(StructuredTraceGraph.class);
+  }
+
+  @Test
+  public void TestBackendEventResolution() {
+    String broker = "kafka-test.hypertrace.com:9092";
+    String host = broker.split(":")[0];
+    Entity entity = kafkaBackendResolver.resolveEntity(getKafkaBackendEvent(broker), structuredTraceGraph).get();
+    Assertions.assertEquals(host, entity.getEntityName());
+  }
+
+  private Event getKafkaBackendEvent(String broker) {
+    Event event =  Event.newBuilder().setCustomerId("customer1")
+        .setEventId(ByteBuffer.wrap("bdf03dfabf5c70f9".getBytes()))
+        .setEntityIdList(Arrays.asList("4bfca8f7-4974-36a4-9385-dd76bf5c8824")).setEnrichedAttributes(
+            Attributes.newBuilder().setAttributeMap(
+                Map.of("SPAN_TYPE", AttributeValue.newBuilder().setValue("EXIT").build())).build())
+        .setAttributes(Attributes.newBuilder().setAttributeMap(Map
+            .of("messaging.system", AttributeValue.newBuilder().setValue("kafka").build(),
+                "messaging.url", AttributeValue.newBuilder().setValue(broker).build(),
+                "span.kind", AttributeValue.newBuilder().setValue("client").build(),
+                "FLAGS", AttributeValue.newBuilder().setValue("0").build())).build())
+        .setEventName("rabbitmq.connection").setStartTimeMillis(1566869077746L)
+        .setEndTimeMillis(1566869077750L).setMetrics(Metrics.newBuilder()
+            .setMetricMap(Map.of("Duration", MetricValue.newBuilder().setValue(4.0).build())).build())
+        .setEventRefList(Arrays.asList(
+            EventRef.newBuilder().setTraceId(ByteBuffer.wrap("random_trace_id".getBytes()))
+                .setEventId(ByteBuffer.wrap("random_event_id".getBytes()))
+                .setRefType(EventRefType.CHILD_OF).build())).build();
+
+
+    return event;
+  }
+}

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/db/DbSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/db/DbSemanticConventionUtils.java
@@ -208,6 +208,10 @@ public class DbSemanticConventionUtils {
     return SpanSemanticConventionUtils.getURIForOtelFormat(event);
   }
 
+  public static Optional<String> getBackendURIForOpenTracingFormat(Event event) {
+    return SpanSemanticConventionUtils.getURIforOpenTracingFormat(event);
+  }
+
   /**
    * @param attributeValueMap map of attribute key value
    * @return backend uri based on otel format

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/messaging/MessagingSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/messaging/MessagingSemanticConventionUtils.java
@@ -21,6 +21,7 @@ public class MessagingSemanticConventionUtils {
 
   private static final String MESSAGING_SYSTEM = OtelMessagingSemanticConventions.MESSAGING_SYSTEM.getValue();
   private static final String MESSAGING_URL = OtelMessagingSemanticConventions.MESSAGING_URL.getValue();
+  private static final String RABBITMQ_SYSTEM_VALUE = OtelMessagingSemanticConventions.RABBITMQ_MESSAGING_SYSTEM_VALUE.getValue();
   private static final String KAFKA_SYSTEM_VALUE = OtelMessagingSemanticConventions.KAFKA_MESSAGING_SYSTEM_VALUE.getValue();
   private static final String SQS_SYSTEM_VALUE = OtelMessagingSemanticConventions.AWS_SQS_MESSAGING_SYSTEM_VALUE.getValue();
 
@@ -43,6 +44,11 @@ public class MessagingSemanticConventionUtils {
   }
 
   public static boolean isRabbitMqBackend(Event event) {
+    if(SpanAttributeUtils.containsAttributeKey(event, MESSAGING_SYSTEM)) {
+      return RABBITMQ_SYSTEM_VALUE.equals(SpanAttributeUtils.getStringAttributeWithDefault(
+          event, MESSAGING_SYSTEM, StringUtils.EMPTY));
+    }
+
     return SpanAttributeUtils.containsAttributeKey(event, RawSpanConstants.getValue(RabbitMq.RABBIT_MQ_ROUTING_KEY))
         || SpanAttributeUtils.containsAttributeKey(event, OtelMessagingSemanticConventions.RABBITMQ_ROUTING_KEY.getValue());
   }

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/messaging/MessagingSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/messaging/MessagingSemanticConventionUtils.java
@@ -58,9 +58,14 @@ public class MessagingSemanticConventionUtils {
       return Optional.empty();
     }
 
-    if(SpanAttributeUtils.containsAttributeKey(event, MESSAGING_URL)) {
+    if (SpanAttributeUtils.containsAttributeKey(event, MESSAGING_URL)) {
       return Optional.of(SpanAttributeUtils.getStringAttribute(event, MESSAGING_URL));
     }
+
+    if (!DbSemanticConventionUtils.getBackendURIForOpenTracingFormat(event).isEmpty()) {
+      return DbSemanticConventionUtils.getBackendURIForOpenTracingFormat(event);
+    }
+
     return DbSemanticConventionUtils.getBackendURIForOtelFormat(event);
   }
 
@@ -81,6 +86,9 @@ public class MessagingSemanticConventionUtils {
       return Optional.of(SpanAttributeUtils.getStringAttribute(event, MESSAGING_URL));
     }
 
+    if (!DbSemanticConventionUtils.getBackendURIForOpenTracingFormat(event).isEmpty()) {
+      return DbSemanticConventionUtils.getBackendURIForOpenTracingFormat(event);
+    }
     return DbSemanticConventionUtils.getBackendURIForOtelFormat(event);
   }
 

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/messaging/MessagingSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/messaging/MessagingSemanticConventionUtils.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
+import org.checkerframework.checker.nullness.Opt;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.shared.SpanAttributeUtils;
 import org.hypertrace.core.span.constants.v1.SpanAttribute;
@@ -19,8 +20,9 @@ import org.hypertrace.core.span.constants.v1.RabbitMq;
 public class MessagingSemanticConventionUtils {
 
   private static final String MESSAGING_SYSTEM = OtelMessagingSemanticConventions.MESSAGING_SYSTEM.getValue();
-  private static final String KAFKA_SYSTEM_VALUE = OtelMessagingSemanticConventions.KAFKA_MESSAGING_SYSTEM_VALUE.getValue();
   private static final String MESSAGING_URL = OtelMessagingSemanticConventions.MESSAGING_URL.getValue();
+  private static final String KAFKA_SYSTEM_VALUE = OtelMessagingSemanticConventions.KAFKA_MESSAGING_SYSTEM_VALUE.getValue();
+  private static final String SQS_SYSTEM_VALUE = OtelMessagingSemanticConventions.AWS_SQS_MESSAGING_SYSTEM_VALUE.getValue();
 
   private static final List<String> RABBITMQ_ROUTING_KEYS =
       new ArrayList<>(Arrays.asList(
@@ -45,18 +47,42 @@ public class MessagingSemanticConventionUtils {
         || SpanAttributeUtils.containsAttributeKey(event, OtelMessagingSemanticConventions.RABBITMQ_ROUTING_KEY.getValue());
   }
 
+  public static Optional<String> getKafkaBackendURI(Event event) {
+    if (!isKafkaBackend(event)) {
+      return Optional.empty();
+    }
+
+    if(SpanAttributeUtils.containsAttributeKey(event, MESSAGING_URL)) {
+      return Optional.of(SpanAttributeUtils.getStringAttribute(event, MESSAGING_URL));
+    }
+    return DbSemanticConventionUtils.getBackendURIForOtelFormat(event);
+  }
+
   public static boolean isKafkaBackend(Event event) {
-    if(SpanAttributeUtils.containsAttributeKey(event, OtelMessagingSemanticConventions.KAFKA_MESSAGING_SYSTEM_VALUE.getValue())) {
+    if(SpanAttributeUtils.containsAttributeKey(event, MESSAGING_SYSTEM)) {
       return KAFKA_SYSTEM_VALUE.equals(SpanAttributeUtils.getStringAttributeWithDefault(
           event, MESSAGING_SYSTEM, StringUtils.EMPTY));
     }
     return false;
   }
 
-  public static Optional<String> getKafkaBackendURI(Event event) {
+  public static Optional<String> getSqsBackendURI(Event event) {
+    if (!isSqsBackend(event)) {
+      return Optional.empty();
+    }
+
     if(SpanAttributeUtils.containsAttributeKey(event, MESSAGING_URL)) {
       return Optional.of(SpanAttributeUtils.getStringAttribute(event, MESSAGING_URL));
     }
+
     return DbSemanticConventionUtils.getBackendURIForOtelFormat(event);
+  }
+
+  public static boolean isSqsBackend(Event event) {
+    if(SpanAttributeUtils.containsAttributeKey(event, MESSAGING_SYSTEM)) {
+      return SQS_SYSTEM_VALUE.equals(SpanAttributeUtils.getStringAttributeWithDefault(
+          event, MESSAGING_SYSTEM, StringUtils.EMPTY));
+    }
+    return false;
   }
 }

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/span/SpanSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/span/SpanSemanticConventionUtils.java
@@ -86,26 +86,6 @@ public class SpanSemanticConventionUtils {
    * @param attributeValueMap map of span data and attribute value
    * @return URI based on Open Tracing format
    */
-  public static Optional<String> getURIforOpenTracingFormat(Map<String, AttributeValue> attributeValueMap) {
-    AttributeValue host = attributeValueMap.getOrDefault(
-        OT_PEER_HOSTNAME,
-        attributeValueMap.get(OT_PEER_IP));
-    if (null == host || StringUtils.isBlank(host.getValue())) {
-      return Optional.empty();
-    }
-    if (attributeValueMap.containsKey(OT_PEER_PORT)
-        && !StringUtils.isBlank(attributeValueMap.get(OT_PEER_PORT).getValue())) {
-      return Optional.of(String.format(
-          "%s:%s", host.getValue(),
-          attributeValueMap.get(OT_PEER_PORT).getValue()));
-    }
-    return Optional.of(host.getValue());
-  }
-
-  /**
-   * @param attributeValueMap map of span data and attribute value
-   * @return URI based on Open Tracing format
-   */
   public static boolean isClientSpanForOtelFormat(Map<String, AttributeValue> attributeValueMap) {
     if (attributeValueMap.containsKey(OTelSpanSemanticConventions.SPAN_KIND.getValue())) {
       return OTelSpanSemanticConventions.SPAN_KIND_CLIENT_VALUE.getValue().equalsIgnoreCase(

--- a/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/messaging/OtelMessagingSemanticConventions.java
+++ b/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/messaging/OtelMessagingSemanticConventions.java
@@ -9,6 +9,7 @@ public enum OtelMessagingSemanticConventions {
   RABBITMQ_MESSAGING_SYSTEM_VALUE("rabbitmq"),
   RABBITMQ_ROUTING_KEY("messaging.rabbitmq.routing_key"),
   KAFKA_MESSAGING_SYSTEM_VALUE("kafka"),
+  AWS_SQS_MESSAGING_SYSTEM_VALUE("sqs"),
   PRODUCER("PRODUCER"),
   CONSUMER("CONSUMER");
 

--- a/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/messaging/OtelMessagingSemanticConventions.java
+++ b/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/messaging/OtelMessagingSemanticConventions.java
@@ -8,6 +8,7 @@ public enum OtelMessagingSemanticConventions {
   MESSAGING_URL("messaging.url"),
   RABBITMQ_MESSAGING_SYSTEM_VALUE("rabbitmq"),
   RABBITMQ_ROUTING_KEY("messaging.rabbitmq.routing_key"),
+  KAFKA_MESSAGING_SYSTEM_VALUE("kafka"),
   PRODUCER("PRODUCER"),
   CONSUMER("CONSUMER");
 

--- a/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/messaging/OtelMessagingSemanticConventions.java
+++ b/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/messaging/OtelMessagingSemanticConventions.java
@@ -8,6 +8,7 @@ public enum OtelMessagingSemanticConventions {
   MESSAGING_URL("messaging.url"),
   RABBITMQ_MESSAGING_SYSTEM_VALUE("rabbitmq"),
   RABBITMQ_ROUTING_KEY("messaging.rabbitmq.routing_key"),
+  RABIT_MQ_MESSAGING_SYSTEM_VALUE("rabbitmq"),
   KAFKA_MESSAGING_SYSTEM_VALUE("kafka"),
   AWS_SQS_MESSAGING_SYSTEM_VALUE("sqs"),
   PRODUCER("PRODUCER"),

--- a/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/span/OpenTracingSpanSemanticConventions.java
+++ b/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/span/OpenTracingSpanSemanticConventions.java
@@ -1,0 +1,28 @@
+package org.hypertrace.core.semantic.convention.constants.span;
+
+/**
+ * Otel attributes for span
+ */
+public enum OpenTracingSpanSemanticConventions {
+  SPAN_KIND("span_kind"),
+  SPAN_KIND_SERVER_VALUE("server"),
+  SPAN_KIND_CLIENT_VALUE("client"),
+  SPAN_KIND_PRODUCER_VALUE("producer"),
+  SPAN_KIND_CONSUMER_VALUE("consumer"),
+  PEER_IPV4("peer.ipv4"),
+  PEER_IPV6("peer.ipv6"),
+  PEER_HOSTNAME("peer.hostname"),
+  PEER_PORT("peer.port"),
+  PEER_NAME("peer.service"),
+  PEER_ADDRESS("peer.address");
+
+  private final String value;
+
+  OpenTracingSpanSemanticConventions(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+}


### PR DESCRIPTION
## Description
This PR adds support for Apache Kafka and AWS SQS to be recognised as their own backend types. 

This is one of the steps towards this issue - https://github.com/hypertrace/hypertrace/issues/169. With support for Kafka, SQS, RabbitMQ(which can be extended to other messaging systems) we can categorise the backends supported by Hypertrace into `brokers`, `storage`, etc,. to make exploring backends much easier to the user. 
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added a test case for kafka backend resolver to check if the name of the backend entity is being correctly derived from the kafka broker url. A similar test case for SQS has also been included to make sure. 

### Checklist:
- [ ] My changes generate no new warnings - New warnings will be logged when trace enricher is unable to infer the backend types. 
- [x] I have added tests that prove my fix is effective or that my feature works

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
