### PR TITLE
fix: catch errors thrown during enrichment

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/AbstractTraceEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/AbstractTraceEnricher.java
@@ -72,11 +72,7 @@ public abstract class AbstractTraceEnricher implements Enricher {
 
   protected void addEnrichedAttributes(
       Event event,
-      List<Pair<String, AttributeValue>> attributes,
       Map<String, AttributeValue> attributesToEnrich) {
-    attributes.forEach(
-        attributePair ->
-            addEnrichedAttribute(event, attributePair.getKey(), attributePair.getValue()));
     attributesToEnrich.forEach((key, value) -> addEnrichedAttribute(event, key, value));
   }
 

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/AbstractTraceEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/AbstractTraceEnricher.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.tuple.Pair;
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Attributes;
 import org.hypertrace.core.datamodel.Edge;
@@ -71,8 +70,7 @@ public abstract class AbstractTraceEnricher implements Enricher {
   }
 
   protected void addEnrichedAttributes(
-      Event event,
-      Map<String, AttributeValue> attributesToEnrich) {
+      Event event, Map<String, AttributeValue> attributesToEnrich) {
     attributesToEnrich.forEach((key, value) -> addEnrichedAttribute(event, key, value));
   }
 

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/EnrichmentProcessor.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/EnrichmentProcessor.java
@@ -43,7 +43,14 @@ public class EnrichmentProcessor {
         trace, enrichmentArrivalTimer, ENRICHMENT_ARRIVAL_TIME);
     AvroToJsonLogger.log(LOG, "Structured Trace before all the enrichment is: {}", trace);
     for (Enricher enricher : enrichers) {
-      applyEnricher(enricher, trace);
+      try {
+        applyEnricher(enricher, trace);
+      } catch (Exception e) {
+        LOG.error(
+            "Could not apply the enricher: {} to the trace with traceId: {}",
+            enricher.getClass().getCanonicalName(),
+            HexUtils.getHex(trace.getTraceId()));
+      }
     }
     AvroToJsonLogger.log(LOG, "Structured Trace after all the enrichment is: {}", trace);
   }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/BackendEntityEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/BackendEntityEnricher.java
@@ -1,8 +1,7 @@
 package org.hypertrace.traceenricher.enrichment.enrichers;
 
 import com.typesafe.config.Config;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -140,63 +139,51 @@ public class BackendEntityEnricher extends AbstractTraceEnricher {
       return;
     }
 
-    Map<String, org.hypertrace.core.datamodel.AttributeValue> attributes =
-        backendInfo.getAttributes();
     addEntity(trace, event, avroEntity);
-    addEnrichedAttributes(event, getAttributesToEnrich(backend), attributes);
+    addEnrichedAttributes(event, getAttributesToEnrich(backend));
+    addEnrichedAttributes(event, backendInfo.getAttributes());
   }
 
-  private List<Pair<String, org.hypertrace.core.datamodel.AttributeValue>> getAttributesToEnrich(
+  private Map<String, org.hypertrace.core.datamodel.AttributeValue> getAttributesToEnrich(
       Entity backend) {
-    List<Pair<String, org.hypertrace.core.datamodel.AttributeValue>> attributePairs =
-        new ArrayList<>(
-            List.of(
-                Pair.of(
-                    EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_ID),
-                    AttributeValueCreator.create(backend.getEntityId())),
-                Pair.of(
-                    EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_NAME),
-                    AttributeValueCreator.create(backend.getEntityName())),
-                Pair.of(
-                    EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_HOST),
-                    createAttributeValue(
-                        backend
-                            .getAttributesMap()
-                            .get(
-                                EntityConstants.getValue(
-                                    BackendAttribute.BACKEND_ATTRIBUTE_HOST)))),
-                Pair.of(
-                    EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PORT),
-                    createAttributeValue(
-                        backend
-                            .getAttributesMap()
-                            .get(
-                                EntityConstants.getValue(
-                                    BackendAttribute.BACKEND_ATTRIBUTE_PORT)))),
-                Pair.of(
-                    EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PROTOCOL),
-                    createAttributeValue(
-                        backend
-                            .getAttributesMap()
-                            .get(
-                                EntityConstants.getValue(
-                                    BackendAttribute.BACKEND_ATTRIBUTE_PROTOCOL)))),
-                Pair.of(
-                    EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_NAME),
-                    AttributeValueCreator.create(backend.getEntityName()))));
+    Map<String, org.hypertrace.core.datamodel.AttributeValue> attributes = new LinkedHashMap<>();
+
+    attributes.put(
+        EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_ID),
+        AttributeValueCreator.create(backend.getEntityId()));
+    attributes.put(
+        EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_NAME),
+        AttributeValueCreator.create(backend.getEntityName()));
+    attributes.put(
+        EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_HOST),
+        createAttributeValue(
+            backend
+                .getAttributesMap()
+                .get(EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_HOST))));
+    attributes.put(
+        EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PORT),
+        createAttributeValue(
+            backend
+                .getAttributesMap()
+                .get(EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PORT))));
+    attributes.put(
+        EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PROTOCOL),
+        createAttributeValue(
+            backend
+                .getAttributesMap()
+                .get(EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PROTOCOL))));
 
     AttributeValue path =
         backend
             .getAttributesMap()
             .get(EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PATH));
     if (path != null) {
-      attributePairs.add(
-          Pair.of(
-              EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PATH),
-              createAttributeValue(path)));
+      attributes.put(
+          EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PATH),
+          createAttributeValue(path));
     }
 
-    return attributePairs;
+    return attributes;
   }
 
   @Nullable

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -46,10 +46,16 @@ dependencies {
     implementation("com.google.guava:guava:30.1-jre") {
       because("Information Disclosure [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415] in com.google.guava:guava@29.0-android")
     }
+    runtimeOnly("io.netty:netty-codec-http2:4.1.60.Final") {
+      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
+    }
+    runtimeOnly("io.netty:netty-handler-proxy:4.1.60.Final") {
+      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
+    }
   }
 
   // Required for the GRPC clients.
-  runtimeOnly("io.grpc:grpc-netty-shaded:1.35.0")
+  runtimeOnly("io.grpc:grpc-netty:1.35.0")
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")

--- a/span-normalizer/span-normalizer/build.gradle.kts
+++ b/span-normalizer/span-normalizer/build.gradle.kts
@@ -7,11 +7,6 @@ plugins {
   id("org.hypertrace.jacoco-report-plugin")
 }
 
-repositories {
-  // Need this to fetch confluent's kafka-avro-serializer dependency
-  maven("http://packages.confluent.io/maven")
-}
-
 application {
   mainClass.set("org.hypertrace.core.serviceframework.PlatformServiceLauncher")
 }
@@ -19,7 +14,6 @@ application {
 hypertraceDocker {
   defaultImage {
     javaApplication {
-      serviceName.set("${project.name}")
       adminPort.set(8099)
     }
   }
@@ -27,7 +21,7 @@ hypertraceDocker {
 
 // Config for gw run to be able to run this locally. Just execute gw run here on Intellij or on the console.
 tasks.run<JavaExec> {
-  jvmArgs = listOf("-Dbootstrap.config.uri=file:$projectDir/src/main/resources/configs", "-Dservice.name=${project.name}")
+  jvmArgs = listOf("-Dservice.name=${project.name}")
 }
 
 tasks.test {
@@ -48,11 +42,11 @@ dependencies {
   // Required for the GRPC clients.
   runtimeOnly("io.grpc:grpc-netty:1.35.0")
   constraints {
-    runtimeOnly("io.netty:netty-codec-http2:4.1.59.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439")
+    runtimeOnly("io.netty:netty-codec-http2:4.1.60.Final") {
+      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
     }
-    runtimeOnly("io.netty:netty-handler-proxy:4.1.59.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439")
+    runtimeOnly("io.netty:netty-handler-proxy:4.1.60.Final") {
+      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
     }
   }
 


### PR DESCRIPTION
## Description
Add a catch clause to prevent crashing the entire enricher on a failed enrichment. Instead, end enrichment for that trace (as later enrichers may have depended on the failed enrichment) and proceed.

