### PR TITLE
feat: add support to trace reader to read resources

### DIFF
--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/SpanValueSourceTest.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/SpanValueSourceTest.java
@@ -3,15 +3,18 @@ package org.hypertrace.trace.reader.attributes;
 import static org.hypertrace.trace.reader.attributes.AvroUtil.buildAttributesWithKeyValue;
 import static org.hypertrace.trace.reader.attributes.AvroUtil.buildMetricsWithKeyValue;
 import static org.hypertrace.trace.reader.attributes.AvroUtil.defaultedEventBuilder;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.defaultedStructuredTraceBuilder;
 import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.doubleLiteral;
 import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.longLiteral;
 import static org.hypertrace.trace.reader.attributes.LiteralValueUtil.stringLiteral;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
+import java.util.List;
 import java.util.Optional;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.Resource;
 import org.hypertrace.core.datamodel.StructuredTrace;
 import org.junit.jupiter.api.Test;
 
@@ -78,5 +81,52 @@ class SpanValueSourceTest {
     assertEquals(
         Optional.of(ValueSourceFactory.forTrace(mockTrace)),
         originalSource.sourceForScope("TRACE"));
+  }
+
+  @Test
+  void returnsEmptyOptionalIfNoResource() {
+    Event span = defaultedEventBuilder().build();
+    assertEquals(
+        Optional.empty(),
+        new SpanValueSource(mock(StructuredTrace.class), span)
+            .getAttribute("resourceKey", AttributeKind.TYPE_STRING));
+  }
+
+  @Test
+  void returnsEmptyOptionalIfNoMatchingKeyInResource() {
+    StructuredTrace trace =
+        defaultedStructuredTraceBuilder()
+            .setResourceList(
+                List.of(
+                    Resource.newBuilder()
+                        .setAttributes(buildAttributesWithKeyValue("otherResourceKey", "value"))
+                        .build()))
+            .build();
+
+    Event span = defaultedEventBuilder().setResourceIndex(0).build();
+
+    assertEquals(
+        Optional.empty(),
+        new SpanValueSource(mock(StructuredTrace.class), span)
+            .getAttribute("resourceKey", AttributeKind.TYPE_STRING));
+  }
+
+  @Test
+  void returnsValueIfMatchingKeyInResource() {
+    StructuredTrace trace =
+        defaultedStructuredTraceBuilder()
+            .setResourceList(
+                List.of(
+                    mock(Resource.class), // idx 0 won't be used in this test
+                    Resource.newBuilder()
+                        .setAttributes(buildAttributesWithKeyValue("resourceKey", "value"))
+                        .build()))
+            .build();
+
+    Event span = defaultedEventBuilder().setResourceIndex(1).build();
+
+    assertEquals(
+        Optional.of(stringLiteral("value")),
+        new SpanValueSource(trace, span).getAttribute("resourceKey", AttributeKind.TYPE_STRING));
   }
 }


### PR DESCRIPTION
## Description
Added support for reading attributes from a span-associated resource.


### Testing
Added UT

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

