### PR TITLE
feat: add support for resolving first available attribute

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/src/main/resources/configs/common/application.conf
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/src/main/resources/configs/common/application.conf
@@ -24,7 +24,7 @@ kafka.streams.config = {
 }
 
 enricher {
-  names = ["SpanTypeAttributeEnricher", "ApiStatusEnricher", "EndpointEnricher", "TransactionNameEnricher", "ApiBoundaryTypeAttributeEnricher", "ErrorsAndExceptionsEnricher", "BackendEntityEnricher", "HttpAttributeEnricher", "DefaultServiceEntityEnricher", "UserAgentSpanEnricher", "SpaceEnricher", "ExitCallsEnricher"]
+  names = ["SpanTypeAttributeEnricher", "ApiStatusEnricher", "EndpointEnricher", "TransactionNameEnricher", "ApiBoundaryTypeAttributeEnricher", "ErrorsAndExceptionsEnricher", "BackendEntityEnricher", "HttpAttributeEnricher", "DefaultServiceEntityEnricher", "UserAgentSpanEnricher", "SpaceEnricher", "EntitySpanEnricher", "ExitCallsEnricher"]
 
   clients = {
       entity.service.config = {

--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 }
 
 dependencies {
-  api("org.hypertrace.core.attribute.service:attribute-service-api:0.10.5")
-  api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.10.5")
+  api("org.hypertrace.core.attribute.service:attribute-service-api:0.11.0")
+  api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.11.0")
   api("org.hypertrace.entity.service:entity-type-service-rx-client:0.6.0")
   api("org.hypertrace.entity.service:entity-data-service-rx-client:0.6.0")
   api("org.hypertrace.core.datamodel:data-model:0.1.14")
-  implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.10.5")
+  implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.11.0")
   implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.4.0")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.4.0")
   implementation("io.reactivex.rxjava3:rxjava:3.0.11")

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/DefaultValueResolver.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/DefaultValueResolver.java
@@ -10,11 +10,14 @@ import java.util.stream.Collectors;
 import org.hypertrace.core.attribute.service.cachingclient.CachingAttributeClient;
 import org.hypertrace.core.attribute.service.projection.AttributeProjection;
 import org.hypertrace.core.attribute.service.projection.AttributeProjectionRegistry;
+import org.hypertrace.core.attribute.service.v1.AttributeDefinition;
+import org.hypertrace.core.attribute.service.v1.AttributeDefinition.AttributeDefinitions;
 import org.hypertrace.core.attribute.service.v1.AttributeDefinition.SourceField;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
 import org.hypertrace.core.attribute.service.v1.AttributeType;
 import org.hypertrace.core.attribute.service.v1.LiteralValue;
+import org.hypertrace.core.attribute.service.v1.LiteralValue.ValueCase;
 import org.hypertrace.core.attribute.service.v1.Projection;
 import org.hypertrace.core.attribute.service.v1.ProjectionExpression;
 
@@ -36,26 +39,47 @@ class DefaultValueResolver implements ValueResolver {
       return this.buildError("Attribute definition not set");
     }
 
-    switch (attributeMetadata.getDefinition().getValueCase()) {
+    return this.resolveDefinition(
+        valueSource, attributeMetadata, attributeMetadata.getDefinition());
+  }
+
+  private Single<LiteralValue> resolveDefinition(
+      ValueSource valueSource,
+      AttributeMetadata attributeMetadata,
+      AttributeDefinition definition) {
+
+    switch (definition.getValueCase()) {
       case SOURCE_PATH:
         return this.resolveValue(
             valueSource,
             attributeMetadata.getScopeString(),
             attributeMetadata.getType(),
             attributeMetadata.getValueKind(),
-            attributeMetadata.getDefinition().getSourcePath());
+            definition.getSourcePath());
       case PROJECTION:
         return this.resolveProjection(
             valueSource, attributeMetadata.getDefinition().getProjection());
       case SOURCE_FIELD:
         return this.resolveField(
+            valueSource, definition.getSourceField(), attributeMetadata.getValueKind());
+      case FIRST_VALUE_PRESENT:
+        return this.resolveFirstValuePresent(
             valueSource,
-            attributeMetadata.getDefinition().getSourceField(),
-            attributeMetadata.getValueKind());
+            attributeMetadata,
+            attributeMetadata.getDefinition().getFirstValuePresent());
       case VALUE_NOT_SET:
       default:
         return this.buildError("Unrecognized attribute definition");
     }
+  }
+
+  private Maybe<LiteralValue> maybeResolveDefinition(
+      ValueSource valueSource,
+      AttributeMetadata attributeMetadata,
+      AttributeDefinition definition) {
+    return this.resolveDefinition(valueSource, attributeMetadata, definition)
+        .filter(literalValue -> !literalValue.getValueCase().equals(ValueCase.VALUE_NOT_SET))
+        .onErrorComplete();
   }
 
   private Single<LiteralValue> resolveValue(
@@ -105,6 +129,17 @@ class DefaultValueResolver implements ValueResolver {
       ValueSource valueSource, SourceField sourceField, AttributeKind attributeKind) {
     return Maybe.fromOptional(valueSource.getSourceField(sourceField, attributeKind))
         .defaultIfEmpty(LiteralValue.getDefaultInstance());
+  }
+
+  private Single<LiteralValue> resolveFirstValuePresent(
+      ValueSource valueSource,
+      AttributeMetadata attributeMetadata,
+      AttributeDefinitions definitions) {
+
+    return Observable.fromIterable(definitions.getDefinitionsList())
+        .concatMapMaybe(
+            definition -> this.maybeResolveDefinition(valueSource, attributeMetadata, definition))
+        .first(LiteralValue.getDefaultInstance());
   }
 
   private Single<LiteralValue> resolveExpression(

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/DefaultValueResolverTest.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/attributes/DefaultValueResolverTest.java
@@ -1,6 +1,7 @@
 package org.hypertrace.trace.reader.attributes;
 
 import static org.hypertrace.trace.reader.attributes.AvroUtil.buildAttributesWithKeyValue;
+import static org.hypertrace.trace.reader.attributes.AvroUtil.buildAttributesWithKeyValues;
 import static org.hypertrace.trace.reader.attributes.AvroUtil.buildMetricsWithKeyValue;
 import static org.hypertrace.trace.reader.attributes.AvroUtil.defaultedEventBuilder;
 import static org.hypertrace.trace.reader.attributes.AvroUtil.defaultedStructuredTraceBuilder;
@@ -11,13 +12,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.reactivex.rxjava3.core.Single;
+import java.util.Map;
 import org.hypertrace.core.attribute.service.cachingclient.CachingAttributeClient;
 import org.hypertrace.core.attribute.service.projection.AttributeProjectionRegistry;
 import org.hypertrace.core.attribute.service.v1.AttributeDefinition;
+import org.hypertrace.core.attribute.service.v1.AttributeDefinition.AttributeDefinitions;
 import org.hypertrace.core.attribute.service.v1.AttributeDefinition.SourceField;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
 import org.hypertrace.core.attribute.service.v1.AttributeType;
+import org.hypertrace.core.attribute.service.v1.LiteralValue;
 import org.hypertrace.core.attribute.service.v1.Projection;
 import org.hypertrace.core.attribute.service.v1.ProjectionExpression;
 import org.hypertrace.core.attribute.service.v1.ProjectionOperator;
@@ -240,6 +244,71 @@ class DefaultValueResolverTest {
         longLiteral(234),
         this.resolver
             .resolve(ValueSourceFactory.forSpan(this.mockStructuredTrace, span), metadataEndTime)
+            .blockingGet());
+  }
+
+  @Test
+  void resolvesFirstAvailableDefinition() {
+    AttributeMetadata metadata =
+        AttributeMetadata.newBuilder()
+            .setScopeString("TEST_SCOPE")
+            .setType(AttributeType.ATTRIBUTE)
+            .setValueKind(AttributeKind.TYPE_INT64)
+            .setDefinition(
+                AttributeDefinition.newBuilder()
+                    .setFirstValuePresent(
+                        AttributeDefinitions.newBuilder()
+                            .addDefinitions( // Should error due to data type
+                                AttributeDefinition.newBuilder().setSourcePath("path.to.string"))
+                            .addDefinitions( // Should be empty and skipped
+                                AttributeDefinition.newBuilder().setSourcePath("non.existent"))
+                            .addDefinitions(
+                                AttributeDefinition.newBuilder().setSourcePath("path.to.int"))
+                            .addDefinitions( // Shouldn't be reached
+                                AttributeDefinition.newBuilder()
+                                    .setSourceField(SourceField.SOURCE_FIELD_START_TIME))))
+            .build();
+
+    Event span =
+        defaultedEventBuilder()
+            .setAttributes(
+                buildAttributesWithKeyValues(Map.of("path.to.string", "foo", "path.to.int", "14")))
+            .build();
+
+    assertEquals(
+        longLiteral(14),
+        this.resolver
+            .resolve(ValueSourceFactory.forSpan(this.mockStructuredTrace, span), metadata)
+            .blockingGet());
+  }
+
+  @Test
+  void resolvesEmptyIfNoDefinitionAvailable() {
+    AttributeMetadata metadata =
+        AttributeMetadata.newBuilder()
+            .setScopeString("TEST_SCOPE")
+            .setType(AttributeType.ATTRIBUTE)
+            .setValueKind(AttributeKind.TYPE_INT64)
+            .setDefinition(
+                AttributeDefinition.newBuilder()
+                    .setFirstValuePresent(
+                        AttributeDefinitions.newBuilder()
+                            .addDefinitions( // Should error due to data type
+                                AttributeDefinition.newBuilder().setSourcePath("path.to.string"))
+                            .addDefinitions( // Should be empty and skipped
+                                AttributeDefinition.newBuilder().setSourcePath("non.existent"))))
+            .build();
+
+    Event span =
+        defaultedEventBuilder()
+            .setAttributes(
+                buildAttributesWithKeyValues(Map.of("path.to.string", "foo", "path.to.int", "14")))
+            .build();
+
+    assertEquals(
+        LiteralValue.getDefaultInstance(),
+        this.resolver
+            .resolve(ValueSourceFactory.forSpan(this.mockStructuredTrace, span), metadata)
             .blockingGet());
   }
 }


### PR DESCRIPTION
## Description
This is the implementation side that allows resolution of a fallback attribute definition added and described in https://github.com/hypertrace/attribute-service/pull/84

### Testing
Added UT and verified functionality E2E

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
