### PR TITLE
fix: handle the semantics of error related attributes for considering error span

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ErrorsAndExceptionsEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ErrorsAndExceptionsEnricher.java
@@ -46,7 +46,9 @@ public class ErrorsAndExceptionsEnricher extends AbstractTraceEnricher {
 
   private void enrichExceptionDetails(Event event) {
     // Figure out if event has any exceptions in it.
-    boolean hasException = ErrorSemanticConventionUtils.checkForErrorStackTrace(event);
+    boolean hasException =
+        ErrorSemanticConventionUtils.checkForException(event)
+            || ErrorSemanticConventionUtils.checkForErrorStackTrace(event);
 
     if (hasException) {
       if (event.getMetrics() == null) {
@@ -66,6 +68,7 @@ public class ErrorsAndExceptionsEnricher extends AbstractTraceEnricher {
     // Figure out if there are any errors in the event.
     boolean hasError =
         ErrorSemanticConventionUtils.checkForError(event)
+            || ErrorSemanticConventionUtils.checkForException(event)
             || Constants.getEnrichedSpanConstant(ApiStatus.API_STATUS_FAIL)
                 .equals(EnrichedSpanUtils.getStatus(event));
 

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ErrorsAndExceptionsEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ErrorsAndExceptionsEnricher.java
@@ -46,9 +46,7 @@ public class ErrorsAndExceptionsEnricher extends AbstractTraceEnricher {
 
   private void enrichExceptionDetails(Event event) {
     // Figure out if event has any exceptions in it.
-    boolean hasException =
-        ErrorSemanticConventionUtils.checkForException(event)
-            || ErrorSemanticConventionUtils.checkForErrorStackTrace(event);
+    boolean hasException = ErrorSemanticConventionUtils.checkForException(event);
 
     if (hasException) {
       if (event.getMetrics() == null) {

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ErrorsAndExceptionsEnricherTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ErrorsAndExceptionsEnricherTest.java
@@ -219,7 +219,7 @@ public class ErrorsAndExceptionsEnricherTest extends AbstractAttributeEnricherTe
                     ErrorMetrics.ERROR_METRICS_TOTAL_SPANS_WITH_ERRORS))
             .getValue());
     Assertions.assertEquals(
-        2.0d,
+        3.0d,
         trace
             .getMetrics()
             .getMetricMap()

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ErrorsAndExceptionsEnricherTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ErrorsAndExceptionsEnricherTest.java
@@ -174,7 +174,7 @@ public class ErrorsAndExceptionsEnricherTest extends AbstractAttributeEnricherTe
             .getValue());
     enricher.enrichTrace(trace);
     Assertions.assertEquals(
-        4.0d,
+        6.0d,
         trace
             .getMetrics()
             .getMetricMap()
@@ -210,7 +210,7 @@ public class ErrorsAndExceptionsEnricherTest extends AbstractAttributeEnricherTe
                 Constants.getEnrichedSpanConstant(BoundaryTypeValue.BOUNDARY_TYPE_VALUE_ENTRY)));
     enricher.enrichTrace(trace);
     Assertions.assertEquals(
-        4.0d,
+        6.0d,
         trace
             .getMetrics()
             .getMetricMap()

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ErrorsAndExceptionsEnricherTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ErrorsAndExceptionsEnricherTest.java
@@ -84,8 +84,7 @@ public class ErrorsAndExceptionsEnricherTest extends AbstractAttributeEnricherTe
     Event e1 = createMockEvent();
     Map<String, AttributeValue> attributeValueMap = e1.getAttributes().getAttributeMap();
     attributeValueMap.put(
-        Constants.getRawSpanConstant(Error.ERROR_ERROR),
-        AttributeValueCreator.create("test error"));
+        Constants.getRawSpanConstant(Error.ERROR_ERROR), AttributeValueCreator.create(true));
     enricher.enrichEvent(null, e1);
     Assertions.assertEquals(
         1.0d,
@@ -184,7 +183,7 @@ public class ErrorsAndExceptionsEnricherTest extends AbstractAttributeEnricherTe
                     ErrorMetrics.ERROR_METRICS_TOTAL_SPANS_WITH_ERRORS))
             .getValue());
     Assertions.assertEquals(
-        2.0d,
+        3.0d,
         trace
             .getMetrics()
             .getMetricMap()

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtils.java
@@ -18,11 +18,15 @@ public class ErrorSemanticConventionUtils {
       OTelErrorSemanticConventions.EXCEPTION_MESSAGE.getValue();
   private static final String OTEL_EXCEPTION_STACK_TRACE =
       OTelErrorSemanticConventions.EXCEPTION_STACKTRACE.getValue();
+  private static final String OTEL_STATUS_CODE =
+      OTelErrorSemanticConventions.STATUS_CODE.getValue();
+  private static final String OTEL_STATUS_CODE_ERROR_VALUE =
+      OTelErrorSemanticConventions.STATUS_CODE_ERROR_VALUE.getValue();
+  private static final String OTEL_STATUS_CODE_UNSET_VALUE =
+      OTelErrorSemanticConventions.STATUS_CODE_UNSET_VALUE.getValue();
 
-  private static final List<String> ERROR_ATTRIBUTES =
-      List.of(
-          RawSpanConstants.getValue(Error.ERROR_ERROR),
-          RawSpanConstants.getValue(OTSpanTag.OT_SPAN_TAG_ERROR));
+  private static final String OT_SPAN_TAG_ERROR =
+      RawSpanConstants.getValue(OTSpanTag.OT_SPAN_TAG_ERROR);
 
   private static final List<String> EXCEPTION_ATTRIBUTES =
       List.of(OTEL_EXCEPTION_TYPE, OTEL_EXCEPTION_MESSAGE);
@@ -37,8 +41,10 @@ public class ErrorSemanticConventionUtils {
    * @return check for error in the span event
    */
   public static boolean checkForError(Event event) {
-    return EXCEPTION_ATTRIBUTES.stream()
-        .anyMatch(v -> SpanAttributeUtils.getBooleanAttribute(event, v));
+    return SpanAttributeUtils.getBooleanAttribute(event, OT_SPAN_TAG_ERROR)
+        || OTEL_STATUS_CODE_ERROR_VALUE.equals(
+            SpanAttributeUtils.getStringAttributeWithDefault(
+                event, OTEL_STATUS_CODE, OTEL_STATUS_CODE_UNSET_VALUE));
   }
 
   /**

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtils.java
@@ -19,19 +19,16 @@ public class ErrorSemanticConventionUtils {
   private static final String OTEL_EXCEPTION_STACK_TRACE =
       OTelErrorSemanticConventions.EXCEPTION_STACKTRACE.getValue();
 
-  private static final List<String> EXCEPTION_ATTRIBUTES =
+  private static final List<String> ERROR_ATTRIBUTES =
       List.of(
           RawSpanConstants.getValue(Error.ERROR_ERROR),
-          RawSpanConstants.getValue(OTSpanTag.OT_SPAN_TAG_ERROR),
-          OTEL_EXCEPTION_TYPE,
-          OTEL_EXCEPTION_MESSAGE);
+          RawSpanConstants.getValue(OTSpanTag.OT_SPAN_TAG_ERROR));
+
+  private static final List<String> EXCEPTION_ATTRIBUTES =
+      List.of(OTEL_EXCEPTION_TYPE, OTEL_EXCEPTION_MESSAGE);
 
   private static final List<String> EXCEPTION_STACK_TRACE_ATTRIBUTES =
       List.of(RawSpanConstants.getValue(Error.ERROR_STACK_TRACE), OTEL_EXCEPTION_STACK_TRACE);
-
-  public static List<String> getAttributeKeysForException() {
-    return EXCEPTION_ATTRIBUTES;
-  }
 
   /**
    * This maps to {@link ErrorMetrics#ERROR_METRICS_ERROR_COUNT} enriched constant
@@ -40,6 +37,17 @@ public class ErrorSemanticConventionUtils {
    * @return check for error in the span event
    */
   public static boolean checkForError(Event event) {
+    return EXCEPTION_ATTRIBUTES.stream()
+        .anyMatch(v -> SpanAttributeUtils.getBooleanAttribute(event, v));
+  }
+
+  /**
+   * This maps to {@link ErrorMetrics#ERROR_METRICS_ERROR_COUNT} enriched constant
+   *
+   * @param event object encapsulating span data
+   * @return check for error in the span event
+   */
+  public static boolean checkForException(Event event) {
     return EXCEPTION_ATTRIBUTES.stream()
         .anyMatch(v -> SpanAttributeUtils.containsAttributeKey(event, v));
   }

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtils.java
@@ -55,17 +55,8 @@ public class ErrorSemanticConventionUtils {
    */
   public static boolean checkForException(Event event) {
     return EXCEPTION_ATTRIBUTES.stream()
-        .anyMatch(v -> SpanAttributeUtils.containsAttributeKey(event, v));
-  }
-
-  /**
-   * This maps to {@link ErrorMetrics#ERROR_METRICS_EXCEPTION_COUNT} enriched constant
-   *
-   * @param event object encapsulating span data
-   * @return check for exception in the span event
-   */
-  public static boolean checkForErrorStackTrace(Event event) {
-    return EXCEPTION_STACK_TRACE_ATTRIBUTES.stream()
-        .anyMatch(v -> SpanAttributeUtils.containsAttributeKey(event, v));
+            .anyMatch(v -> SpanAttributeUtils.containsAttributeKey(event, v))
+        || EXCEPTION_STACK_TRACE_ATTRIBUTES.stream()
+            .anyMatch(v -> SpanAttributeUtils.containsAttributeKey(event, v));
   }
 }

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtils.java
@@ -48,10 +48,10 @@ public class ErrorSemanticConventionUtils {
   }
 
   /**
-   * This maps to {@link ErrorMetrics#ERROR_METRICS_ERROR_COUNT} enriched constant
+   * This maps to {@link ErrorMetrics#ERROR_METRICS_EXCEPTION_COUNT} enriched constant
    *
    * @param event object encapsulating span data
-   * @return check for error in the span event
+   * @return check for exception in the span event
    */
   public static boolean checkForException(Event event) {
     return EXCEPTION_ATTRIBUTES.stream()

--- a/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtilsTest.java
+++ b/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtilsTest.java
@@ -25,27 +25,45 @@ public class ErrorSemanticConventionUtilsTest {
         SemanticConventionTestUtil.buildAttributes(
             Map.of(
                 RawSpanConstants.getValue(Error.ERROR_ERROR),
-                SemanticConventionTestUtil.buildAttributeValue("xyzerror")));
+                SemanticConventionTestUtil.buildAttributeValue("false")));
     when(e.getAttributes()).thenReturn(attributes);
     boolean v = ErrorSemanticConventionUtils.checkForError(e);
+    assertFalse(v);
+
+    attributes =
+        SemanticConventionTestUtil.buildAttributes(
+            Map.of(
+                RawSpanConstants.getValue(Error.ERROR_ERROR),
+                SemanticConventionTestUtil.buildAttributeValue("false")));
+    when(e.getAttributes()).thenReturn(attributes);
+    v = ErrorSemanticConventionUtils.checkForError(e);
     assertTrue(v);
+
+    attributes = SemanticConventionTestUtil.buildAttributes(Map.of());
+    when(e.getAttributes()).thenReturn(attributes);
+    v = ErrorSemanticConventionUtils.checkForError(e);
+    assertFalse(v);
 
     attributes =
         SemanticConventionTestUtil.buildAttributes(
             Map.of(
                 RawSpanConstants.getValue(OTSpanTag.OT_SPAN_TAG_ERROR),
-                SemanticConventionTestUtil.buildAttributeValue("xyzerror")));
+                SemanticConventionTestUtil.buildAttributeValue("true")));
     when(e.getAttributes()).thenReturn(attributes);
     v = ErrorSemanticConventionUtils.checkForError(e);
     assertTrue(v);
+  }
 
-    attributes =
+  @Test
+  public void testCheckForException() {
+    Event e = mock(Event.class);
+    Attributes attributes =
         SemanticConventionTestUtil.buildAttributes(
             Map.of(
                 OTelErrorSemanticConventions.EXCEPTION_TYPE.getValue(),
                 SemanticConventionTestUtil.buildAttributeValue("xyzerror")));
     when(e.getAttributes()).thenReturn(attributes);
-    v = ErrorSemanticConventionUtils.checkForError(e);
+    boolean v  = ErrorSemanticConventionUtils.checkForException(e);
     assertTrue(v);
 
     attributes =
@@ -54,14 +72,14 @@ public class ErrorSemanticConventionUtilsTest {
                 OTelErrorSemanticConventions.EXCEPTION_MESSAGE.getValue(),
                 SemanticConventionTestUtil.buildAttributeValue("xyzerror")));
     when(e.getAttributes()).thenReturn(attributes);
-    v = ErrorSemanticConventionUtils.checkForError(e);
+    v = ErrorSemanticConventionUtils.checkForException(e);
     assertTrue(v);
 
     attributes =
         SemanticConventionTestUtil.buildAttributes(
             Map.of("other_error", SemanticConventionTestUtil.buildAttributeValue("xyzerror")));
     when(e.getAttributes()).thenReturn(attributes);
-    v = ErrorSemanticConventionUtils.checkForError(e);
+    v = ErrorSemanticConventionUtils.checkForException(e);
     assertFalse(v);
   }
 

--- a/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtilsTest.java
+++ b/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtilsTest.java
@@ -37,11 +37,6 @@ public class ErrorSemanticConventionUtilsTest {
                 SemanticConventionTestUtil.buildAttributeValue("false")));
     when(e.getAttributes()).thenReturn(attributes);
     v = ErrorSemanticConventionUtils.checkForError(e);
-    assertTrue(v);
-
-    attributes = SemanticConventionTestUtil.buildAttributes(Map.of());
-    when(e.getAttributes()).thenReturn(attributes);
-    v = ErrorSemanticConventionUtils.checkForError(e);
     assertFalse(v);
 
     attributes =
@@ -52,6 +47,44 @@ public class ErrorSemanticConventionUtilsTest {
     when(e.getAttributes()).thenReturn(attributes);
     v = ErrorSemanticConventionUtils.checkForError(e);
     assertTrue(v);
+
+    // check for UNSET, OK
+    attributes =
+        SemanticConventionTestUtil.buildAttributes(
+            Map.of(
+                OTelErrorSemanticConventions.STATUS_CODE.getValue(),
+                SemanticConventionTestUtil.buildAttributeValue(
+                    OTelErrorSemanticConventions.STATUS_CODE_UNSET_VALUE.getValue())));
+    when(e.getAttributes()).thenReturn(attributes);
+    v = ErrorSemanticConventionUtils.checkForError(e);
+    assertFalse(v);
+
+    attributes =
+        SemanticConventionTestUtil.buildAttributes(
+            Map.of(
+                OTelErrorSemanticConventions.STATUS_CODE.getValue(),
+                SemanticConventionTestUtil.buildAttributeValue(
+                    OTelErrorSemanticConventions.STATUS_CODE_OK_VALUE.getValue())));
+    when(e.getAttributes()).thenReturn(attributes);
+    v = ErrorSemanticConventionUtils.checkForError(e);
+    assertFalse(v);
+
+    // check for ERROR
+    attributes =
+        SemanticConventionTestUtil.buildAttributes(
+            Map.of(
+                OTelErrorSemanticConventions.STATUS_CODE.getValue(),
+                SemanticConventionTestUtil.buildAttributeValue(
+                    OTelErrorSemanticConventions.STATUS_CODE_ERROR_VALUE.getValue())));
+    when(e.getAttributes()).thenReturn(attributes);
+    v = ErrorSemanticConventionUtils.checkForError(e);
+    assertTrue(v);
+
+    // check for both the attributes are empty
+    attributes = SemanticConventionTestUtil.buildAttributes(Map.of());
+    when(e.getAttributes()).thenReturn(attributes);
+    v = ErrorSemanticConventionUtils.checkForError(e);
+    assertFalse(v);
   }
 
   @Test
@@ -63,7 +96,7 @@ public class ErrorSemanticConventionUtilsTest {
                 OTelErrorSemanticConventions.EXCEPTION_TYPE.getValue(),
                 SemanticConventionTestUtil.buildAttributeValue("xyzerror")));
     when(e.getAttributes()).thenReturn(attributes);
-    boolean v  = ErrorSemanticConventionUtils.checkForException(e);
+    boolean v = ErrorSemanticConventionUtils.checkForException(e);
     assertTrue(v);
 
     attributes =

--- a/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtilsTest.java
+++ b/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtilsTest.java
@@ -114,18 +114,14 @@ public class ErrorSemanticConventionUtilsTest {
     when(e.getAttributes()).thenReturn(attributes);
     v = ErrorSemanticConventionUtils.checkForException(e);
     assertFalse(v);
-  }
 
-  @Test
-  public void testCheckForErrorStacktrace() {
-    Event e = mock(Event.class);
-    Attributes attributes =
+    attributes =
         SemanticConventionTestUtil.buildAttributes(
             Map.of(
                 RawSpanConstants.getValue(Error.ERROR_STACK_TRACE),
                 SemanticConventionTestUtil.buildAttributeValue("org.abc.etc...")));
     when(e.getAttributes()).thenReturn(attributes);
-    boolean v = ErrorSemanticConventionUtils.checkForErrorStackTrace(e);
+    v = ErrorSemanticConventionUtils.checkForException(e);
     assertTrue(v);
 
     attributes =
@@ -134,7 +130,7 @@ public class ErrorSemanticConventionUtilsTest {
                 OTelErrorSemanticConventions.EXCEPTION_STACKTRACE.getValue(),
                 SemanticConventionTestUtil.buildAttributeValue("org.abc.etc...")));
     when(e.getAttributes()).thenReturn(attributes);
-    v = ErrorSemanticConventionUtils.checkForErrorStackTrace(e);
+    v = ErrorSemanticConventionUtils.checkForException(e);
     assertTrue(v);
   }
 }

--- a/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/error/OTelErrorSemanticConventions.java
+++ b/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/error/OTelErrorSemanticConventions.java
@@ -4,7 +4,11 @@ package org.hypertrace.core.semantic.convention.constants.error;
 public enum OTelErrorSemanticConventions {
   EXCEPTION_TYPE("exception.type"),
   EXCEPTION_MESSAGE("exception.message"),
-  EXCEPTION_STACKTRACE("exception.stacktrace");
+  EXCEPTION_STACKTRACE("exception.stacktrace"),
+  STATUS_CODE("status.code"),
+  STATUS_CODE_UNSET_VALUE("0"),
+  STATUS_CODE_OK_VALUE("1"),
+  STATUS_CODE_ERROR_VALUE("2");
 
   private final String value;
 


### PR DESCRIPTION
## Description
Fixes the issue described here - https://github.com/hypertrace/hypertrace/issues/232

This is happening as we are only checking the existence of error attributes. However, as per [open tracing semantics](https://github.com/opentracing/specification/blob/master/semantic_conventions.md), span error is represented as boolean.

The PR also handles otel semantics for indicating error span using stat using status.code as `unset`, `ok`, and `error` - https://github.com/open-telemetry/opentelemetry-specification/blob/ae31114e2d441f1ecd249ce11bb924a6ac54b5d6/specification/trace/api.md#set-status

References of otel proto and collector exporter:
- https://github.com/open-telemetry/opentelemetry-proto/blob/abbf7b7b49a5342d0d6c0e86e91d713bbedb6580/opentelemetry/proto/trace/v1/trace.proto#L304
- https://github.com/open-telemetry/opentelemetry-collector/blob/main/translator/trace/jaeger/traces_to_jaegerproto.go#L380

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
- added unit tests
- tested using docker-compose by creating test images

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
No impact
