### PR TITLE
fix: provides a fix for handling external HTTP backends

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/BackendEntityEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/BackendEntityEnricher.java
@@ -101,10 +101,8 @@ public class BackendEntityEnricher extends AbstractTraceEnricher {
       return false;
     }
 
-    // if there's no child, but, it is a partial trace, then check if the destination API
-    // And, as destination API can be associated either with service identified by backend resolver
-    // or either with attributes related to peers. As we are using service name as fqn,
-    // we will check using peer.service attribute.
+    // checks the existence of peer service in case if it is a partial trace, and we are missing
+    // its immediate child span.
     String peerServiceName = SpanSemanticConventionUtils.getPeerServiceName(backendSpan);
     if (peerServiceName != null
         && checkIfServiceEntityExists(

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/BackendEntityEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/BackendEntityEnricher.java
@@ -12,12 +12,12 @@ import org.hypertrace.core.datamodel.StructuredTrace;
 import org.hypertrace.core.datamodel.shared.SpanAttributeUtils;
 import org.hypertrace.core.datamodel.shared.StructuredTraceGraph;
 import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;
-import org.hypertrace.entity.constants.v1.ApiAttribute;
 import org.hypertrace.entity.constants.v1.BackendAttribute;
 import org.hypertrace.entity.data.service.client.EdsClient;
 import org.hypertrace.entity.data.service.v1.AttributeValue;
 import org.hypertrace.entity.data.service.v1.Entity;
 import org.hypertrace.entity.service.constants.EntityConstants;
+import org.hypertrace.semantic.convention.utils.span.SpanSemanticConventionUtils;
 import org.hypertrace.traceenricher.enrichedspan.constants.utils.EnrichedSpanUtils;
 import org.hypertrace.traceenricher.enrichment.AbstractTraceEnricher;
 import org.hypertrace.traceenricher.enrichment.clients.ClientRegistry;
@@ -96,29 +96,23 @@ public class BackendEntityEnricher extends AbstractTraceEnricher {
             .get(BACKEND_HOST_ATTR_NAME)
             .getValue()
             .getString();
-    try {
-      boolean serviceExists =
-          entityCache
-              .getFqnToServiceEntityCache()
-              .get(Pair.of(backendSpan.getCustomerId(), fqn))
-              .isPresent();
-      if (serviceExists) {
-        LOGGER.debug(
-            "BackendEntity {} is actually an Existing service entity.", candidateInfo.getEntity());
-        return false;
-      }
-    } catch (ExecutionException ex) {
-      LOGGER.error(
-          "Error getting service entity using FQN:{} from cache for customerId:{}",
-          fqn,
-          backendSpan.getCustomerId());
+
+    if (checkIfServiceEntityExists(backendSpan.getCustomerId(), fqn, candidateInfo.getEntity())) {
+      return false;
     }
 
     // if there's no child, but, it is a partial trace, then check if the destination API
-    // is internal to the application
-    return !SpanAttributeUtils.containsAttributeKey(
-        backendSpan, EntityConstants.getValue(ApiAttribute.API_ATTRIBUTE_ID));
-    // if it couldn't find a child that's not a service
+    // And, as destination API can be associated either with service identified by backend resolver
+    // or either with attributes related to peers. As we are using service name as fqn,
+    // we will check using peer.service attribute.
+    String peerServiceName = SpanSemanticConventionUtils.getPeerServiceName(backendSpan);
+    if (peerServiceName != null
+        && checkIfServiceEntityExists(
+            backendSpan.getCustomerId(), peerServiceName, candidateInfo.getEntity())) {
+      return false;
+    }
+
+    return true;
   }
 
   private void decorateWithBackendEntity(
@@ -142,6 +136,25 @@ public class BackendEntityEnricher extends AbstractTraceEnricher {
     addEntity(trace, event, avroEntity);
     addEnrichedAttributes(event, getAttributesToEnrich(backend));
     addEnrichedAttributes(event, backendInfo.getAttributes());
+  }
+
+  private boolean checkIfServiceEntityExists(
+      String tenantId, String serviceFqn, Entity candidateBackendEntity) {
+    try {
+      boolean serviceExists =
+          entityCache.getFqnToServiceEntityCache().get(Pair.of(tenantId, serviceFqn)).isPresent();
+      if (serviceExists) {
+        LOGGER.debug(
+            "BackendEntity {} is actually an Existing service entity.", candidateBackendEntity);
+      }
+      return serviceExists;
+    } catch (ExecutionException ex) {
+      LOGGER.error(
+          "Error getting service entity using FQN:{} from cache for customerId:{}",
+          serviceFqn,
+          tenantId);
+      return false;
+    }
   }
 
   private Map<String, org.hypertrace.core.datamodel.AttributeValue> getAttributesToEnrich(


### PR DESCRIPTION
## Description
Addresses the issue - https://github.com/hypertrace/hypertrace/issues/235
This was happening after a fix of service call related - https://github.com/hypertrace/hypertrace-ingester/pull/159

Reason:
The endpoint enricher enriches all the events with API_ATTRIBUTE_ID associated with the given ApiNode. However, BackendEntityEnricher was using existence check for the same attribute to handle partial trace scenario for HTTP/GRPC backend. However, this condition is not handling the proper scenario.

Solution:
As destination API called by the client service will be associated with a service. In the case of a broken (or partial trace) scenario, we are missing links, so we are missing the entry span of the called service. And that service could be,
- identified by either HTTP BackendResolver or GRPC backend resolver 
- or span's attributes related to peer service

We are using the above information to fix this.

### Testing
locally using docker-compose setup

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
