### PR TITLE
feat: enforce entity formation conditions

### DIFF
--- a/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
+++ b/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
   implementation("org.hypertrace.core.datamodel:data-model:0.1.14")
   implementation(project(":span-normalizer:raw-span-constants"))
   implementation(project(":span-normalizer:span-normalizer-constants"))
-  implementation("org.hypertrace.entity.service:entity-service-api:0.6.0")
+  implementation("org.hypertrace.entity.service:entity-service-api:0.6.4")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   implementation(project(":hypertrace-trace-enricher:trace-reader"))
 
   implementation("org.hypertrace.core.datamodel:data-model:0.1.14")
-  implementation("org.hypertrace.entity.service:entity-service-client:0.6.0")
+  implementation("org.hypertrace.entity.service:entity-service-client:0.6.4")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.23")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.4.0")
   implementation("org.hypertrace.config.service:spaces-config-service-api:0.1.0")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
   implementation("org.hypertrace.core.datamodel:data-model:0.1.14")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.23")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.23")
-  implementation("org.hypertrace.entity.service:entity-service-client:0.6.0")
+  implementation("org.hypertrace.entity.service:entity-service-client:0.6.4")
 
   implementation("com.typesafe:config:1.4.1")
   implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.20")

--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -16,6 +16,9 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.4.0")
   implementation("io.reactivex.rxjava3:rxjava:3.0.11")
 
+  annotationProcessor("org.projectlombok:lombok:1.18.20")
+  compileOnly("org.projectlombok:lombok:1.18.20")
+
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")

--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -8,8 +8,8 @@ plugins {
 dependencies {
   api("org.hypertrace.core.attribute.service:attribute-service-api:0.11.0")
   api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.11.0")
-  api("org.hypertrace.entity.service:entity-type-service-rx-client:0.6.0")
-  api("org.hypertrace.entity.service:entity-data-service-rx-client:0.6.0")
+  api("org.hypertrace.entity.service:entity-type-service-rx-client:0.6.4")
+  api("org.hypertrace.entity.service:entity-data-service-rx-client:0.6.4")
   api("org.hypertrace.core.datamodel:data-model:0.1.14")
   implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.11.0")
   implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.4.0")

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReader.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReader.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericRecord;
 import org.hypertrace.core.attribute.service.cachingclient.CachingAttributeClient;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
@@ -29,6 +30,7 @@ import org.hypertrace.entity.type.service.v2.EntityType;
 import org.hypertrace.entity.type.service.v2.EntityType.EntityFormationCondition;
 import org.hypertrace.trace.reader.attributes.TraceAttributeReader;
 
+@Slf4j
 class DefaultTraceEntityReader<T extends GenericRecord, S extends GenericRecord>
     implements TraceEntityReader<T, S> {
   private final EntityTypeClient entityTypeClient;
@@ -155,9 +157,11 @@ class DefaultTraceEntityReader<T extends GenericRecord, S extends GenericRecord>
     switch (condition.getConditionCase()) {
       case REQUIRED_KEY:
         return entity.getAttributesMap().containsKey(condition.getRequiredKey());
-      case CONDITION_NOT_SET:
-      default:
+      case CONDITION_NOT_SET: // No condition should not filter formation
         return true;
+      default: // Unrecognized condition
+        log.error("Unrecognized formation condition: {}", condition);
+        return false;
     }
   }
 

--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReaderTest.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReaderTest.java
@@ -243,6 +243,26 @@ class DefaultTraceEntityReaderTest {
     verify(mockDataClient, times(1)).createOrUpdateEntityEventually(any(), any(), any());
   }
 
+  @Test
+  void skipsUnsetFormationConditions() {
+    mockSingleEntityType(
+        TEST_ENTITY_TYPE.toBuilder()
+            .addRequiredConditions(EntityFormationCondition.newBuilder())
+            .build());
+    mockGetAllAttributes(TEST_ENTITY_ID_ATTRIBUTE, TEST_ENTITY_NAME_ATTRIBUTE);
+    mockTenantId();
+    mockEntityUpsert();
+
+    mockAttributeRead(TEST_ENTITY_ID_ATTRIBUTE, stringLiteral(TEST_ENTITY_ID_ATTRIBUTE_VALUE));
+    mockAttributeRead(TEST_ENTITY_NAME_ATTRIBUTE, stringLiteral(TEST_ENTITY_NAME_ATTRIBUTE_VALUE));
+
+    this.entityReader
+        .getAssociatedEntityForSpan(TEST_ENTITY_TYPE_NAME, TEST_TRACE, TEST_SPAN)
+        .blockingSubscribe();
+
+    verify(mockDataClient, times(1)).createOrUpdateEntityEventually(any(), any(), any());
+  }
+
   private void mockTenantId() {
     when(this.mockAttributeReader.getTenantId(TEST_SPAN)).thenReturn(TENANT_ID);
   }

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
   implementation("org.hypertrace.core.datamodel:data-model:0.1.14")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.23")
 
-  implementation("org.hypertrace.entity.service:entity-service-api:0.6.0")
+  implementation("org.hypertrace.entity.service:entity-service-api:0.6.4")
 
   implementation("org.apache.avro:avro:1.10.2")
   implementation("org.apache.commons:commons-lang3:3.12.0")

--- a/semantic-convention-utils/build.gradle.kts
+++ b/semantic-convention-utils/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     implementation(project(":span-normalizer:span-normalizer-constants"))
 
     implementation("org.hypertrace.core.datamodel:data-model:0.1.14")
-    implementation("org.hypertrace.entity.service:entity-service-client:0.6.0")
+    implementation("org.hypertrace.entity.service:entity-service-client:0.6.4")
 
     implementation("org.apache.commons:commons-lang3:3.12.0")
 


### PR DESCRIPTION
## Description
Entity formation previously was predicated on generating a non-null ID, but in https://github.com/hypertrace/entity-service/pull/105 support was added for defining further conditions. Here, we use that metadata to actually enforce those new conditions.

### Testing
Added UTs, also verified E2E

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

