### PR TITLE
fix: support projections inside first attr def

### DIFF
--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 }
 
 dependencies {
-  api("org.hypertrace.core.attribute.service:attribute-service-api:0.11.0")
-  api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.11.0")
+  api("org.hypertrace.core.attribute.service:attribute-service-api:0.12.0")
+  api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.0")
   api("org.hypertrace.entity.service:entity-type-service-rx-client:0.6.4")
   api("org.hypertrace.entity.service:entity-data-service-rx-client:0.6.4")
   api("org.hypertrace.core.datamodel:data-model:0.1.14")
-  implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.11.0")
+  implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.12.0")
   implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.4.0")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.4.0")
   implementation("io.reactivex.rxjava3:rxjava:3.0.11")

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/DefaultValueResolver.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/attributes/DefaultValueResolver.java
@@ -57,16 +57,13 @@ class DefaultValueResolver implements ValueResolver {
             attributeMetadata.getValueKind(),
             definition.getSourcePath());
       case PROJECTION:
-        return this.resolveProjection(
-            valueSource, attributeMetadata.getDefinition().getProjection());
+        return this.resolveProjection(valueSource, definition.getProjection());
       case SOURCE_FIELD:
         return this.resolveField(
             valueSource, definition.getSourceField(), attributeMetadata.getValueKind());
       case FIRST_VALUE_PRESENT:
         return this.resolveFirstValuePresent(
-            valueSource,
-            attributeMetadata,
-            attributeMetadata.getDefinition().getFirstValuePresent());
+            valueSource, attributeMetadata, definition.getFirstValuePresent());
       case VALUE_NOT_SET:
       default:
         return this.buildError("Unrecognized attribute definition");


### PR DESCRIPTION
## Description
This PR does two things:
- Fixes resolution of projections and first_value_present type definitions inside a first_value_type present def
- Updates attribute projection to add support for newest operators

### Testing
Added UT, verified E2E

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

