### PR TITLE
fix: propagate context for building upsert

### DIFF
--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReader.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReader.java
@@ -92,8 +92,11 @@ class DefaultTraceEntityReader<T extends GenericRecord, S extends GenericRecord>
       return Maybe.empty();
     }
 
-    return this.attributeClient
-        .get(entityType.getAttributeScope(), entityType.getTimestampAttributeKey())
+    return spanTenantContext(span)
+        .wrapSingle(
+            () ->
+                this.attributeClient.get(
+                    entityType.getAttributeScope(), entityType.getTimestampAttributeKey()))
         .filter(this::isEntitySourced)
         .flatMap(
             attribute ->


### PR DESCRIPTION
## Description
This remote call was not propagating context and instead relying on the current thread's context - this makes it explicit.
