### PR TITLE
fix: handle the cases of resolving destination for http backend

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/HttpBackendResolver.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/HttpBackendResolver.java
@@ -66,11 +66,11 @@ public class HttpBackendResolver extends AbstractBackendResolver {
       if (httpOperation != null) {
         enrichedAttributes.put(BACKEND_OPERATION_ATTR, AttributeValueCreator.create(httpOperation));
       }
-      Optional<String> httpDestination = HttpSemanticConventionUtils.getHttpTarget(event);
-      httpDestination.ifPresent(
-          destination ->
-              enrichedAttributes.put(
-                  BACKEND_DESTINATION_ATTR, AttributeValueCreator.create(destination)));
+
+      if (StringUtils.isNotEmpty(path)) {
+        enrichedAttributes.put(
+            BACKEND_DESTINATION_ATTR, AttributeValueCreator.create(path));
+      }
       return Optional.of(new BackendInfo(entityBuilder.build(), enrichedAttributes));
     }
     return Optional.empty();

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/HttpBackendResolver.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/HttpBackendResolver.java
@@ -68,8 +68,7 @@ public class HttpBackendResolver extends AbstractBackendResolver {
       }
 
       if (StringUtils.isNotEmpty(path)) {
-        enrichedAttributes.put(
-            BACKEND_DESTINATION_ATTR, AttributeValueCreator.create(path));
+        enrichedAttributes.put(BACKEND_DESTINATION_ATTR, AttributeValueCreator.create(path));
       }
       return Optional.of(new BackendInfo(entityBuilder.build(), enrichedAttributes));
     }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendResolverTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendResolverTest.java
@@ -166,7 +166,9 @@ public class BackendResolverTest extends AbstractAttributeEnricherTest {
 
     Map<String, AttributeValue> attributes = backendInfo.getAttributes();
     assertEquals(
-        Map.of("BACKEND_DESTINATION", AttributeValueCreator.create("/product/5d644175551847d7408760b1")),
+        Map.of(
+            "BACKEND_DESTINATION",
+            AttributeValueCreator.create("/product/5d644175551847d7408760b1")),
         attributes);
   }
 

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendResolverTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendResolverTest.java
@@ -166,7 +166,7 @@ public class BackendResolverTest extends AbstractAttributeEnricherTest {
 
     Map<String, AttributeValue> attributes = backendInfo.getAttributes();
     assertEquals(
-        Map.of("BACKEND_DESTINATION", AttributeValueCreator.create("/path/12314/?q=ddds#123")),
+        Map.of("BACKEND_DESTINATION", AttributeValueCreator.create("/product/5d644175551847d7408760b1")),
         attributes);
   }
 

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -14,8 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.hypertrace.core.datamodel.AttributeValue;
-import org.hypertrace.core.datamodel.Event;
-import org.hypertrace.core.datamodel.shared.SpanAttributeUtils;
 import org.hypertrace.core.semantic.convention.constants.http.OTelHttpSemanticConventions;
 import org.hypertrace.core.semantic.convention.constants.span.OTelSpanSemanticConventions;
 import org.hypertrace.core.span.constants.RawSpanConstants;

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -56,12 +56,6 @@ public class HttpSemanticConventionUtils {
     return Lists.newArrayList(Sets.newHashSet(OTEL_HTTP_TARGET));
   }
 
-  public static Optional<String> getHttpTarget(Event event) {
-    return Optional.ofNullable(
-        SpanAttributeUtils.getFirstAvailableStringAttribute(
-            event, getAttributeKeysForHttpTarget()));
-  }
-
   /**
    * OTel mandates one of the following set to be present for http server span - http.scheme,
    * http.host, http.target - http.scheme, http.server_name, net.host.port, http.target -


### PR DESCRIPTION
## Description
Addresses the issue - https://github.com/hypertrace/hypertrace/issues/238

The changes use `path` as a destination from `org.hypertrace.core.datamodel.eventfields.http` instead of using only.
The `path` of `org.hypertrace.core.datamodel.eventfields.http` includes
- `http.request.path`
- `http.path`
- `http.target`
- `http.url`

References for above attributes  :  
- https://github.com/hypertrace/hypertrace-ingester/blob/main/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java#L94
- https://github.com/hypertrace/hypertrace-ingester/blob/main/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java#L275
- https://github.com/hypertrace/hypertrace-ingester/blob/cd7885fcf0356866d59144f672456d47429fafba/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java#L568


### Testing
- exiting unit tests cover the scenario - https://github.com/hypertrace/hypertrace-ingester/blob/8072b1c9acb3802e6adabe36f625c08ca0a8f3fd/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGeneratorTest.java#L734

- verified locally with a shared trace

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
None