### PR TITLE
chore: update kstream framework version to 0.1.21

### DIFF
--- a/hypertrace-ingester/build.gradle.kts
+++ b/hypertrace-ingester/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.23")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.23")
   implementation("org.hypertrace.core.datamodel:data-model:0.1.15")
-  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.1.25")
+  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.1.26")
   implementation("com.typesafe:config:1.4.1")
   implementation("org.apache.commons:commons-lang3:3.12.0")
 
@@ -41,7 +41,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("org.junit-pioneer:junit-pioneer:1.3.8")
-  testImplementation("org.apache.kafka:kafka-streams-test-utils:6.1.0-ccs")
+  testImplementation("org.apache.kafka:kafka-streams-test-utils:6.0.1-ccs")
   testImplementation(project(":hypertrace-view-generator:hypertrace-view-generator-api"))
   testImplementation(project(":span-normalizer:span-normalizer-api"))
 }

--- a/hypertrace-ingester/build.gradle.kts
+++ b/hypertrace-ingester/build.gradle.kts
@@ -25,7 +25,7 @@ hypertraceDocker {
 }
 
 dependencies {
-  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.20")
+  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.21")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.23")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.23")
   implementation("org.hypertrace.core.datamodel:data-model:0.1.15")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
   implementation("org.hypertrace.entity.service:entity-service-client:0.6.4")
 
   implementation("com.typesafe:config:1.4.1")
-  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.20")
+  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.21")
   constraints {
     runtimeOnly("io.netty:netty-codec-http2:4.1.63.Final") {
       because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -62,5 +62,5 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("org.junit-pioneer:junit-pioneer:1.3.8")
-  testImplementation("org.apache.kafka:kafka-streams-test-utils:6.1.0-ccs")
+  testImplementation("org.apache.kafka:kafka-streams-test-utils:6.0.1-ccs")
 }

--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReader.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReader.java
@@ -92,8 +92,11 @@ class DefaultTraceEntityReader<T extends GenericRecord, S extends GenericRecord>
       return Maybe.empty();
     }
 
-    return this.attributeClient
-        .get(entityType.getAttributeScope(), entityType.getTimestampAttributeKey())
+    return spanTenantContext(span)
+        .wrapSingle(
+            () ->
+                this.attributeClient.get(
+                    entityType.getAttributeScope(), entityType.getTimestampAttributeKey()))
         .filter(this::isEntitySourced)
         .flatMap(
             attribute ->

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   implementation(project(":hypertrace-view-generator:hypertrace-view-generator-api"))
 
   // TODO: migrate in core
-  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.1.25")
+  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.1.26")
   implementation("org.hypertrace.core.datamodel:data-model:0.1.15")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.23")
 

--- a/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
+++ b/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
@@ -51,5 +51,5 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
     testImplementation("org.mockito:mockito-core:3.8.0")
     testImplementation("org.junit-pioneer:junit-pioneer:1.3.8")
-    testImplementation("org.apache.kafka:kafka-streams-test-utils:6.1.0-ccs")
+    testImplementation("org.apache.kafka:kafka-streams-test-utils:6.0.1-ccs")
 }

--- a/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
+++ b/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.23")
     implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.23")
 
-    implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.20")
+    implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.21")
     implementation("com.typesafe:config:1.4.1")
     implementation("de.javakaffee:kryo-serializers:0.45")
     implementation("io.confluent:kafka-avro-serializer:5.5.0")

--- a/span-normalizer/span-normalizer/build.gradle.kts
+++ b/span-normalizer/span-normalizer/build.gradle.kts
@@ -63,5 +63,5 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.23")
   testImplementation("org.junit-pioneer:junit-pioneer:1.3.8")
-  testImplementation("org.apache.kafka:kafka-streams-test-utils:6.1.0-ccs")
+  testImplementation("org.apache.kafka:kafka-streams-test-utils:6.0.1-ccs")
 }

--- a/span-normalizer/span-normalizer/build.gradle.kts
+++ b/span-normalizer/span-normalizer/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
   implementation("org.hypertrace.core.datamodel:data-model:0.1.15")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.23")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.23")
-  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.20")
+  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.21")
 
   // Required for the GRPC clients.
   runtimeOnly("io.grpc:grpc-netty:1.36.1")


### PR DESCRIPTION
Upgrading to kstream framework version to 0.1.21 to go back to kstream-6.0.1