### PR TITLE
fix: optimize the usage of ApiTraceGraph in the ingestion pipeline

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/build.gradle.kts
@@ -14,4 +14,6 @@ dependencies {
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("org.apache.commons:commons-lang3:3.12.0")
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
+  testImplementation("org.mockito:mockito-core:3.9.0")
+  testImplementation("org.mockito:mockito-inline:3.9.0")
 }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraphBuilder.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraphBuilder.java
@@ -4,22 +4,21 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import org.hypertrace.core.datamodel.StructuredTrace;
-import org.hypertrace.core.datamodel.shared.StructuredTraceGraph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class StructuredTraceGraphBuilder {
-  public static final Logger LOG = LoggerFactory.getLogger(StructuredTraceGraphBuilder.class);
+public class ApiTraceGraphBuilder {
+  public static final Logger LOG = LoggerFactory.getLogger(ApiTraceGraphBuilder.class);
 
-  private static ThreadLocal<StructuredTraceGraph> cachedGraph = new ThreadLocal<>();
+  private static ThreadLocal<ApiTraceGraph> cachedGraph = new ThreadLocal<>();
   private static ThreadLocal<StructuredTrace> cachedTrace = new ThreadLocal<>();
 
-  public static StructuredTraceGraph buildGraph(StructuredTrace trace) {
+  public static ApiTraceGraph buildGraph(StructuredTrace trace) {
     if (!GraphBuilderUtil.isSameStructuredTrace(cachedTrace.get(), trace)) {
       Instant start = Instant.now();
-      StructuredTraceGraph graph = StructuredTraceGraph.createGraph(trace);
+      ApiTraceGraph graph = new ApiTraceGraph(trace);
       LOG.debug(
-          "Time taken in building StructuredTraceGraph:{} for tenantId:{}",
+          "Time taken in building ApiTraceGraph:{} for tenantId:{}",
           Duration.between(start, Instant.now()).toMillis(),
           TimeUnit.MILLISECONDS,
           trace.getCustomerId());

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraphBuilder.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraphBuilder.java
@@ -8,7 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ApiTraceGraphBuilder {
-  public static final Logger LOG = LoggerFactory.getLogger(ApiTraceGraphBuilder.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ApiTraceGraphBuilder.class);
 
   private static ThreadLocal<ApiTraceGraph> cachedGraph = new ThreadLocal<>();
   private static ThreadLocal<StructuredTrace> cachedTrace = new ThreadLocal<>();

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/GraphBuilderUtil.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/GraphBuilderUtil.java
@@ -1,0 +1,40 @@
+package org.hypertrace.traceenricher.trace.util;
+
+import org.hypertrace.core.datamodel.StructuredTrace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GraphBuilderUtil {
+  public static final Logger LOG = LoggerFactory.getLogger(GraphBuilderUtil.class);
+
+  /**
+   * optimistic method of comparing two trace for considering rebuilding of entire graph structure.
+   */
+  static boolean isSameStructuredTrace(StructuredTrace cachedTrace, StructuredTrace trace) {
+    if (cachedTrace == null || trace == null) {
+      LOG.debug("Cached and Input trace are not same. Reason: one of the input is null");
+      return false;
+    }
+    // is processed and cached are same trace?
+    if (!cachedTrace.getCustomerId().equals(trace.getCustomerId())
+        || !cachedTrace.getTraceId().equals(trace.getTraceId())) {
+      LOG.debug(
+          "Cached and Input trace are not same. Reason: doesn't not match either traceId or tenantId");
+      return false;
+    }
+
+    // trace internally changed (full trace comparision is costly, so we are doing only with
+    // required fields)
+    if (cachedTrace.getEntityList().size() != trace.getEntityList().size()
+        || cachedTrace.getEventList().size() != trace.getEventList().size()
+        || cachedTrace.getEntityEdgeList().size() != trace.getEntityEdgeList().size()
+        || cachedTrace.getEntityEventEdgeList().size() != trace.getEntityEventEdgeList().size()
+        || cachedTrace.getEventEdgeList().size() != trace.getEventEdgeList().size()) {
+      LOG.debug(
+          "Cached and Input trace are not same. Reason: they are having different size either for event or entities");
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/GraphBuilderUtil.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/GraphBuilderUtil.java
@@ -5,7 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class GraphBuilderUtil {
-  public static final Logger LOG = LoggerFactory.getLogger(GraphBuilderUtil.class);
+  private static final Logger LOG = LoggerFactory.getLogger(GraphBuilderUtil.class);
 
   /**
    * optimistic method of comparing two trace for considering rebuilding of entire graph structure.

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/StructuredTraceGraphBuilder.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/StructuredTraceGraphBuilder.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class StructuredTraceGraphBuilder {
-  public static final Logger LOG = LoggerFactory.getLogger(StructuredTraceGraphBuilder.class);
+  private static final Logger LOG = LoggerFactory.getLogger(StructuredTraceGraphBuilder.class);
 
   private static ThreadLocal<StructuredTraceGraph> cachedGraph = new ThreadLocal<>();
   private static ThreadLocal<StructuredTrace> cachedTrace = new ThreadLocal<>();

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/test/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraphBuilderTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/test/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraphBuilderTest.java
@@ -1,0 +1,62 @@
+package org.hypertrace.traceenricher.trace.util;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.hypertrace.core.datamodel.Edge;
+import org.hypertrace.core.datamodel.Entity;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.StructuredTrace;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+public class ApiTraceGraphBuilderTest {
+
+  @Test
+  void testBuildGraph() {
+
+    Entity entity = mock(Entity.class);
+    Event parent = mock(Event.class);
+    Event child = mock(Event.class);
+    Edge eventEdge = mock(Edge.class);
+
+    StructuredTrace underTestTrace = mock(StructuredTrace.class);
+    when(underTestTrace.getCustomerId()).thenReturn("__defaultTenant");
+    when(underTestTrace.getTraceId()).thenReturn(ByteBuffer.wrap("2ebbc19b6428510f".getBytes()));
+    when(underTestTrace.getEntityList()).thenReturn(List.of(entity));
+    when(underTestTrace.getEventList()).thenReturn(List.of(parent, child));
+    when(underTestTrace.getEntityEdgeList()).thenReturn(List.of());
+    when(underTestTrace.getEntityEventEdgeList()).thenReturn(List.of());
+    when(underTestTrace.getEventEdgeList()).thenReturn(List.of(eventEdge));
+
+    // structure trace builder
+    try (MockedStatic<StructuredTrace> builderMockedStatic = mockStatic(StructuredTrace.class)) {
+      StructuredTrace.Builder builder = mock(StructuredTrace.Builder.class);
+      when(builder.build()).thenReturn(underTestTrace);
+
+      builderMockedStatic
+          .when(() -> StructuredTrace.newBuilder(underTestTrace))
+          .thenReturn(builder);
+
+      // check if we get a new
+      try (MockedConstruction<ApiTraceGraph> mockedConstruction =
+          mockConstruction(ApiTraceGraph.class)) {
+        // first call
+        ApiTraceGraph actual = ApiTraceGraphBuilder.buildGraph(underTestTrace);
+        Assertions.assertNotNull(actual);
+        Assertions.assertEquals(1, mockedConstruction.constructed().size());
+
+        // second call
+        ApiTraceGraph second = ApiTraceGraphBuilder.buildGraph(underTestTrace);
+        Assertions.assertEquals(actual, second);
+        Assertions.assertEquals(1, mockedConstruction.constructed().size());
+      }
+    }
+  }
+}

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/test/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraphBuilderTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/test/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraphBuilderTest.java
@@ -44,7 +44,7 @@ public class ApiTraceGraphBuilderTest {
           .when(() -> StructuredTrace.newBuilder(underTestTrace))
           .thenReturn(builder);
 
-      // check if we get a new
+      // make two calls, and check that first call create cache entries, and second call uses same
       try (MockedConstruction<ApiTraceGraph> mockedConstruction =
           mockConstruction(ApiTraceGraph.class)) {
         // first call

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/test/java/org/hypertrace/traceenricher/trace/util/GraphBuilderUtilTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/test/java/org/hypertrace/traceenricher/trace/util/GraphBuilderUtilTest.java
@@ -1,0 +1,88 @@
+package org.hypertrace.traceenricher.trace.util;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.hypertrace.core.datamodel.Edge;
+import org.hypertrace.core.datamodel.Entity;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.StructuredTrace;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class GraphBuilderUtilTest {
+
+  @Test
+  public void testSameTraceForNullInputs() {
+    StructuredTrace cachedTrace = mock(StructuredTrace.class);
+    StructuredTrace underTestTrace = mock(StructuredTrace.class);
+
+    boolean result = GraphBuilderUtil.isSameStructuredTrace(null, null);
+    Assertions.assertFalse(result);
+
+    result = GraphBuilderUtil.isSameStructuredTrace(null, underTestTrace);
+    Assertions.assertFalse(result);
+
+    result = GraphBuilderUtil.isSameStructuredTrace(cachedTrace, null);
+    Assertions.assertFalse(result);
+  }
+
+  @Test
+  public void testSameTraceForTenantAndTraceCondition() {
+    // different tenant id
+    StructuredTrace cachedTrace = mock(StructuredTrace.class);
+    when(cachedTrace.getCustomerId()).thenReturn("__defaultTenant");
+    when(cachedTrace.getTraceId()).thenReturn(ByteBuffer.wrap("2ebbc19b6428510f".getBytes()));
+
+    StructuredTrace underTestTrace = mock(StructuredTrace.class);
+    when(underTestTrace.getCustomerId()).thenReturn("__defaultTenantUnderTest");
+    when(underTestTrace.getTraceId()).thenReturn(ByteBuffer.wrap("2ebbc19b6428510f".getBytes()));
+
+    boolean result = GraphBuilderUtil.isSameStructuredTrace(cachedTrace, underTestTrace);
+    Assertions.assertFalse(result);
+
+    // different trace ids
+    cachedTrace = mock(StructuredTrace.class);
+    when(cachedTrace.getCustomerId()).thenReturn("__defaultTenant");
+    when(cachedTrace.getTraceId()).thenReturn(ByteBuffer.wrap("2ebbc19b6428510f".getBytes()));
+
+    underTestTrace = mock(StructuredTrace.class);
+    when(underTestTrace.getCustomerId()).thenReturn("__defaultTenantUnder");
+    when(underTestTrace.getTraceId()).thenReturn(ByteBuffer.wrap("2ebbc19b6428511f".getBytes()));
+
+    result = GraphBuilderUtil.isSameStructuredTrace(cachedTrace, underTestTrace);
+    Assertions.assertFalse(result);
+  }
+
+  @Test
+  public void testSameTraceForSizeCondition() {
+    Entity entity = mock(Entity.class);
+    Event parent = mock(Event.class);
+    Event child = mock(Event.class);
+    Edge eventEdge = mock(Edge.class);
+
+    // same size
+    StructuredTrace cachedTrace = mock(StructuredTrace.class);
+    when(cachedTrace.getCustomerId()).thenReturn("__defaultTenant");
+    when(cachedTrace.getTraceId()).thenReturn(ByteBuffer.wrap("2ebbc19b6428510f".getBytes()));
+    when(cachedTrace.getEntityList()).thenReturn(List.of(entity));
+    when(cachedTrace.getEventList()).thenReturn(List.of(parent, child));
+    when(cachedTrace.getEntityEdgeList()).thenReturn(List.of());
+    when(cachedTrace.getEntityEventEdgeList()).thenReturn(List.of());
+    when(cachedTrace.getEventEdgeList()).thenReturn(List.of(eventEdge));
+
+    StructuredTrace underTestTrace = mock(StructuredTrace.class);
+    when(underTestTrace.getCustomerId()).thenReturn("__defaultTenant");
+    when(underTestTrace.getTraceId()).thenReturn(ByteBuffer.wrap("2ebbc19b6428510f".getBytes()));
+    when(underTestTrace.getEntityList()).thenReturn(List.of(entity));
+    when(underTestTrace.getEventList()).thenReturn(List.of(parent, child));
+    when(underTestTrace.getEntityEdgeList()).thenReturn(List.of());
+    when(underTestTrace.getEntityEventEdgeList()).thenReturn(List.of());
+    when(underTestTrace.getEventEdgeList()).thenReturn(List.of(eventEdge));
+
+    boolean result = GraphBuilderUtil.isSameStructuredTrace(cachedTrace, underTestTrace);
+    Assertions.assertTrue(result);
+  }
+}

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/test/java/org/hypertrace/traceenricher/trace/util/GraphBuilderUtilTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/test/java/org/hypertrace/traceenricher/trace/util/GraphBuilderUtilTest.java
@@ -49,7 +49,7 @@ public class GraphBuilderUtilTest {
     when(cachedTrace.getTraceId()).thenReturn(ByteBuffer.wrap("2ebbc19b6428510f".getBytes()));
 
     underTestTrace = mock(StructuredTrace.class);
-    when(underTestTrace.getCustomerId()).thenReturn("__defaultTenantUnder");
+    when(underTestTrace.getCustomerId()).thenReturn("__defaultTenant");
     when(underTestTrace.getTraceId()).thenReturn(ByteBuffer.wrap("2ebbc19b6428511f".getBytes()));
 
     result = GraphBuilderUtil.isSameStructuredTrace(cachedTrace, underTestTrace);

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/test/java/org/hypertrace/traceenricher/trace/util/StructuredTraceGraphBuilderTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/test/java/org/hypertrace/traceenricher/trace/util/StructuredTraceGraphBuilderTest.java
@@ -1,0 +1,67 @@
+package org.hypertrace.traceenricher.trace.util;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.hypertrace.core.datamodel.Edge;
+import org.hypertrace.core.datamodel.Entity;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.core.datamodel.shared.StructuredTraceGraph;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+public class StructuredTraceGraphBuilderTest {
+
+  @Test
+  void testBuildGraph() {
+
+    Entity entity = mock(Entity.class);
+    Event parent = mock(Event.class);
+    Event child = mock(Event.class);
+    Edge eventEdge = mock(Edge.class);
+
+    StructuredTrace underTestTrace = mock(StructuredTrace.class);
+    when(underTestTrace.getCustomerId()).thenReturn("__defaultTenant");
+    when(underTestTrace.getTraceId()).thenReturn(ByteBuffer.wrap("2ebbc19b6428510f".getBytes()));
+    when(underTestTrace.getEntityList()).thenReturn(List.of(entity));
+    when(underTestTrace.getEventList()).thenReturn(List.of(parent, child));
+    when(underTestTrace.getEntityEdgeList()).thenReturn(List.of());
+    when(underTestTrace.getEntityEventEdgeList()).thenReturn(List.of());
+    when(underTestTrace.getEventEdgeList()).thenReturn(List.of(eventEdge));
+
+    try (MockedStatic<StructuredTrace> builderMockedStatic = mockStatic(StructuredTrace.class)) {
+
+      StructuredTrace.Builder builder = mock(StructuredTrace.Builder.class);
+      when(builder.build()).thenReturn(underTestTrace);
+
+      builderMockedStatic
+          .when(() -> StructuredTrace.newBuilder(underTestTrace))
+          .thenReturn(builder);
+
+      // mock createGraph method of structured trace graph
+      StructuredTraceGraph mockedStructuredTraceGraph = mock(StructuredTraceGraph.class);
+
+      try (MockedStatic<StructuredTraceGraph> structuredTraceGraphMockedStatic =
+          mockStatic(StructuredTraceGraph.class)) {
+        structuredTraceGraphMockedStatic
+            .when(() -> StructuredTraceGraph.createGraph(underTestTrace))
+            .thenReturn(mockedStructuredTraceGraph);
+
+        // calls first time
+        StructuredTraceGraph actual = StructuredTraceGraphBuilder.buildGraph(underTestTrace);
+        Assertions.assertEquals(mockedStructuredTraceGraph, actual);
+
+        // calls second time, this time it returns from cache
+        StructuredTraceGraphBuilder.buildGraph(underTestTrace);
+        structuredTraceGraphMockedStatic.verify(
+            () -> StructuredTraceGraph.createGraph(underTestTrace), times(1));
+      }
+    }
+  }
+}

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/test/java/org/hypertrace/traceenricher/trace/util/StructuredTraceGraphBuilderTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/test/java/org/hypertrace/traceenricher/trace/util/StructuredTraceGraphBuilderTest.java
@@ -55,6 +55,8 @@ public class StructuredTraceGraphBuilderTest {
         // calls first time
         StructuredTraceGraph actual = StructuredTraceGraphBuilder.buildGraph(underTestTrace);
         Assertions.assertEquals(mockedStructuredTraceGraph, actual);
+        structuredTraceGraphMockedStatic.verify(
+            () -> StructuredTraceGraph.createGraph(underTestTrace), times(1));
 
         // calls second time, this time it returns from cache
         StructuredTraceGraphBuilder.buildGraph(underTestTrace);

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/test/java/org/hypertrace/traceenricher/trace/util/StructuredTraceGraphBuilderTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/test/java/org/hypertrace/traceenricher/trace/util/StructuredTraceGraphBuilderTest.java
@@ -44,9 +44,8 @@ public class StructuredTraceGraphBuilderTest {
           .when(() -> StructuredTrace.newBuilder(underTestTrace))
           .thenReturn(builder);
 
-      // mock createGraph method of structured trace graph
+      // make two calls, and check that first call create cache entries, and second call uses same
       StructuredTraceGraph mockedStructuredTraceGraph = mock(StructuredTraceGraph.class);
-
       try (MockedStatic<StructuredTraceGraph> structuredTraceGraphMockedStatic =
           mockStatic(StructuredTraceGraph.class)) {
         structuredTraceGraphMockedStatic

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ErrorsAndExceptionsEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ErrorsAndExceptionsEnricher.java
@@ -18,6 +18,7 @@ import org.hypertrace.traceenricher.enrichedspan.constants.v1.CommonAttribute;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.ErrorMetrics;
 import org.hypertrace.traceenricher.enrichment.AbstractTraceEnricher;
 import org.hypertrace.traceenricher.trace.util.ApiTraceGraph;
+import org.hypertrace.traceenricher.trace.util.ApiTraceGraphBuilder;
 import org.hypertrace.traceenricher.util.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,7 +99,7 @@ public class ErrorsAndExceptionsEnricher extends AbstractTraceEnricher {
     //  has errored out but the entry span in transaction might be fine (server responded but
     //  client couldn't process it). Those cases should be handled in future.
 
-    ApiTraceGraph apiTraceGraph = new ApiTraceGraph(trace);
+    ApiTraceGraph apiTraceGraph = ApiTraceGraphBuilder.buildGraph(trace);
     for (ApiNode<Event> apiNode : apiTraceGraph.getApiNodeList()) {
       Optional<Event> entryEvent = apiNode.getEntryApiBoundaryEvent();
       int apiTraceErrorCount =

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ExitCallsEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ExitCallsEnricher.java
@@ -18,6 +18,7 @@ import org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants
 import org.hypertrace.traceenricher.enrichedspan.constants.utils.EnrichedSpanUtils;
 import org.hypertrace.traceenricher.enrichment.AbstractTraceEnricher;
 import org.hypertrace.traceenricher.trace.util.ApiTraceGraph;
+import org.hypertrace.traceenricher.trace.util.ApiTraceGraphBuilder;
 
 public class ExitCallsEnricher extends AbstractTraceEnricher {
 
@@ -56,7 +57,7 @@ public class ExitCallsEnricher extends AbstractTraceEnricher {
    * </ul>
    */
   Map<ByteBuffer, ApiExitCallInfo> computeApiExitCallCount(StructuredTrace trace) {
-    ApiTraceGraph apiTraceGraph = new ApiTraceGraph(trace);
+    ApiTraceGraph apiTraceGraph = ApiTraceGraphBuilder.buildGraph(trace);
     // event -> api exit call count for the corresponding api_node
     Map<ByteBuffer, ApiExitCallInfo> eventToExitInfo = Maps.newHashMap();
 

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/endpoint/EndpointEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/endpoint/EndpointEnricher.java
@@ -19,7 +19,7 @@ import org.hypertrace.entity.service.constants.EntityConstants;
 import org.hypertrace.traceenricher.enrichedspan.constants.utils.EnrichedSpanUtils;
 import org.hypertrace.traceenricher.enrichment.AbstractTraceEnricher;
 import org.hypertrace.traceenricher.enrichment.clients.ClientRegistry;
-import org.hypertrace.traceenricher.trace.util.ApiTraceGraph;
+import org.hypertrace.traceenricher.trace.util.ApiTraceGraphBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -155,7 +155,7 @@ public class EndpointEnricher extends AbstractTraceEnricher {
    */
   @Override
   public void enrichTrace(StructuredTrace trace) {
-    List<ApiNode<Event>> apiNodes = new ApiTraceGraph(trace).getApiNodeList();
+    List<ApiNode<Event>> apiNodes = ApiTraceGraphBuilder.buildGraph(trace).getApiNodeList();
     for (ApiNode<Event> apiNode : apiNodes) {
       Optional<Event> optionalEvent = apiNode.getEntryApiBoundaryEvent();
       if (optionalEvent.isEmpty()) {

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ExitCallsEnricherTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ExitCallsEnricherTest.java
@@ -20,7 +20,6 @@ import org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants
 import org.hypertrace.traceenricher.enrichedspan.constants.utils.EnrichedSpanUtils;
 import org.hypertrace.traceenricher.enrichment.enrichers.ExitCallsEnricher.ApiExitCallInfo;
 import org.hypertrace.traceenricher.trace.util.ApiTraceGraph;
-import org.hypertrace.traceenricher.trace.util.ApiTraceGraphBuilder;
 import org.junit.jupiter.api.Test;
 
 public class ExitCallsEnricherTest {
@@ -43,7 +42,7 @@ public class ExitCallsEnricherTest {
 
   private void verifyComputeApiExitInfo_HotrodTrace(
       StructuredTrace trace, ExitCallsEnricher exitCallsEnricher) {
-    ApiTraceGraph apiTraceGraph = ApiTraceGraphBuilder.buildGraph(trace);
+    ApiTraceGraph apiTraceGraph = new ApiTraceGraph(trace);
     // this trace has 12 api nodes
     // api edges
     // 0 -> [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ExitCallsEnricherTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ExitCallsEnricherTest.java
@@ -20,6 +20,7 @@ import org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants
 import org.hypertrace.traceenricher.enrichedspan.constants.utils.EnrichedSpanUtils;
 import org.hypertrace.traceenricher.enrichment.enrichers.ExitCallsEnricher.ApiExitCallInfo;
 import org.hypertrace.traceenricher.trace.util.ApiTraceGraph;
+import org.hypertrace.traceenricher.trace.util.ApiTraceGraphBuilder;
 import org.junit.jupiter.api.Test;
 
 public class ExitCallsEnricherTest {
@@ -42,7 +43,7 @@ public class ExitCallsEnricherTest {
 
   private void verifyComputeApiExitInfo_HotrodTrace(
       StructuredTrace trace, ExitCallsEnricher exitCallsEnricher) {
-    ApiTraceGraph apiTraceGraph = new ApiTraceGraph(trace);
+    ApiTraceGraph apiTraceGraph = ApiTraceGraphBuilder.buildGraph(trace);
     // this trace has 12 api nodes
     // api edges
     // 0 -> [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]


### PR DESCRIPTION
## Description
As part of looking into handling large traces, we have observed a couple of optimization in our ingestion pipeline as described here - https://github.com/hypertrace/hypertrace/issues/244

This PR addresses
- addresses the issue of building ApiTraceGraph across enricher for once if the trace has not modified. (Case 2 of the above ticket)
- it also modifies ApiTraceGraph internal Map data structure to use Id based index instead of using the entire object

### Testing
- local testing by ingesting traces to docker-compose setup
