### PR TITLE
Fix URI path in EnrichedSpanUtils

### DIFF
--- a/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
+++ b/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
   implementation("org.hypertrace.core.datamodel:data-model:0.1.15")
   implementation(project(":span-normalizer:raw-span-constants"))
   implementation(project(":span-normalizer:span-normalizer-constants"))
+  implementation(project(":semantic-convention-utils"))
   implementation("org.hypertrace.entity.service:entity-service-api:0.6.4")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")

--- a/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/utils/EnrichedSpanUtils.java
+++ b/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/utils/EnrichedSpanUtils.java
@@ -19,6 +19,7 @@ import org.hypertrace.entity.constants.v1.BackendAttribute;
 import org.hypertrace.entity.constants.v1.K8sEntityAttribute;
 import org.hypertrace.entity.constants.v1.ServiceAttribute;
 import org.hypertrace.entity.service.constants.EntityConstants;
+import org.hypertrace.semantic.convention.utils.http.HttpSemanticConventionUtils;
 import org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.Api;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.Backend;
@@ -319,8 +320,8 @@ public class EnrichedSpanUtils {
     if (event.getHttp() != null && event.getHttp().getRequest() != null) {
       return Optional.ofNullable(event.getHttp().getRequest().getUrl());
     }
-    String httpUrl = getStringAttribute(event, EnrichedSpanConstants.getValue(Http.HTTP_URL));
-    return Optional.ofNullable(httpUrl);
+    Optional<AttributeValue> httpUrl = HttpSemanticConventionUtils.getValidHttpUrl(event);
+    return httpUrl.map(AttributeValue::getValue);
   }
 
   public static Optional<String> getPath(Event event) {

--- a/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/utils/EnrichedSpanUtils.java
+++ b/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/utils/EnrichedSpanUtils.java
@@ -319,8 +319,8 @@ public class EnrichedSpanUtils {
     if (event.getHttp() != null && event.getHttp().getRequest() != null) {
       return Optional.ofNullable(event.getHttp().getRequest().getUrl());
     }
-
-    return Optional.empty();
+    String httpUrl = getStringAttribute(event, EnrichedSpanConstants.getValue(Http.HTTP_URL));
+    return Optional.ofNullable(httpUrl);
   }
 
   public static Optional<String> getPath(Event event) {

--- a/hypertrace-trace-enricher/enriched-span-constants/src/main/proto/org/hypertrace/traceenricher/enrichedspan/constants/v1/enriched_span_attribute.proto
+++ b/hypertrace-trace-enricher/enriched-span-constants/src/main/proto/org/hypertrace/traceenricher/enrichedspan/constants/v1/enriched_span_attribute.proto
@@ -19,7 +19,6 @@ enum Http {
     HTTP_REQUEST_QUERY_PARAM = 2 [(string_value) = "http.request.query.param"];
     HTTP_HOST = 3 [(string_value) = "HTTP_HOST"]; // We should probably stick to a standard of keeping all enriched attributes in capital letters.
     HTTP_REQUEST_PATH_PARAM = 4 [(string_value) = "http.request.path.param"];
-    HTTP_URL = 5 [(string_value) = "http.url"];
 }
 
 enum Api {

--- a/hypertrace-trace-enricher/enriched-span-constants/src/main/proto/org/hypertrace/traceenricher/enrichedspan/constants/v1/enriched_span_attribute.proto
+++ b/hypertrace-trace-enricher/enriched-span-constants/src/main/proto/org/hypertrace/traceenricher/enrichedspan/constants/v1/enriched_span_attribute.proto
@@ -19,6 +19,7 @@ enum Http {
     HTTP_REQUEST_QUERY_PARAM = 2 [(string_value) = "http.request.query.param"];
     HTTP_HOST = 3 [(string_value) = "HTTP_HOST"]; // We should probably stick to a standard of keeping all enriched attributes in capital letters.
     HTTP_REQUEST_PATH_PARAM = 4 [(string_value) = "http.request.path.param"];
+    HTTP_URL = 5 [(string_value) = "http.url"];
 }
 
 enum Api {

--- a/hypertrace-trace-enricher/enriched-span-constants/src/test/java/org/hypertrace/traceenricher/enrichedspan/constants/utils/EnrichedSpanUtilsTest.java
+++ b/hypertrace-trace-enricher/enriched-span-constants/src/test/java/org/hypertrace/traceenricher/enrichedspan/constants/utils/EnrichedSpanUtilsTest.java
@@ -239,6 +239,24 @@ public class EnrichedSpanUtilsTest {
     Optional<String> url = EnrichedSpanUtils.getFullHttpUrl(e);
     assertFalse(url.isEmpty());
     assertEquals("http://hipstershop.com?order=1", url.get());
+
+    // When it is present in attributemap
+    e = mock(Event.class);
+    when(e.getEnrichedAttributes())
+        .thenReturn(
+            Attributes.newBuilder()
+                .setAttributeMap(
+                    Map.of(
+                        "http.url", AttributeValueCreator.create("http://hypertrace.com?order=2")))
+                .build());
+    url = EnrichedSpanUtils.getFullHttpUrl(e);
+    assertFalse(url.isEmpty());
+    assertEquals("http://hypertrace.com?order=2", url.get());
+
+    // Check when url is not present
+    e = mock(Event.class);
+    url = EnrichedSpanUtils.getFullHttpUrl(e);
+    assertTrue(url.isEmpty());
   }
 
   @Test

--- a/semantic-convention-utils/build.gradle.kts
+++ b/semantic-convention-utils/build.gradle.kts
@@ -7,7 +7,6 @@ tasks.test {
 }
 
 dependencies {
-    implementation(project(":hypertrace-trace-enricher:enriched-span-constants"))
     implementation(project(":span-normalizer:raw-span-constants"))
     implementation(project(":span-normalizer:span-normalizer-constants"))
 

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/error/ErrorSemanticConventionUtils.java
@@ -7,7 +7,6 @@ import org.hypertrace.core.semantic.convention.constants.error.OTelErrorSemantic
 import org.hypertrace.core.span.constants.RawSpanConstants;
 import org.hypertrace.core.span.constants.v1.Error;
 import org.hypertrace.core.span.constants.v1.OTSpanTag;
-import org.hypertrace.traceenricher.enrichedspan.constants.v1.ErrorMetrics;
 
 /** Utility class for fetching error related attributes */
 public class ErrorSemanticConventionUtils {


### PR DESCRIPTION
## Description
While retrieving http url it should also check attribute map apart from first class fields

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
