### PR TITLE
bug: handle the logging of malformed URL exception

### DIFF
--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -321,7 +321,8 @@ public class HttpSemanticConventionUtils {
       try {
         return Optional.of(getNormalizedUrl(url.get()).getAuthority());
       } catch (MalformedURLException e) {
-        LOGGER.warn("Received invalid URL host : {}", e.getMessage());
+        LOGGER.warn(
+            "On extracting httpHost, received an invalid URL: {}, {}", url.get(), e.getMessage());
       }
     }
     return Optional.ofNullable(
@@ -339,7 +340,8 @@ public class HttpSemanticConventionUtils {
         }
         return Optional.of(removeTrailingSlash(pathval));
       } catch (MalformedURLException e) {
-        LOGGER.warn("Received invalid URL path : {}", e.getMessage());
+        LOGGER.warn(
+            "On extracting httpPath, received an invalid URL: {}, {}", url.get(), e.getMessage());
       }
     }
     return path;
@@ -386,7 +388,8 @@ public class HttpSemanticConventionUtils {
       try {
         return Optional.of(getNormalizedUrl(url.get()).getProtocol());
       } catch (MalformedURLException e) {
-        LOGGER.warn("Received invalid URL scheme : {}", e.getMessage());
+        LOGGER.warn(
+            "On extracting httpScheme, received an invalid URL: {}, {}", url.get(), e.getMessage());
       }
     }
     return getHttpSchemeFromRawAttributes(event);
@@ -459,7 +462,10 @@ public class HttpSemanticConventionUtils {
       try {
         return Optional.ofNullable(getNormalizedUrl(url.get()).getQuery());
       } catch (MalformedURLException e) {
-        LOGGER.warn("Received invalid URL querystring : {}", e.getMessage());
+        LOGGER.warn(
+            "On extracting httpQueryString, received an invalid URL: {}, {}",
+            url.get(),
+            e.getMessage());
       }
     }
     return queryString;
@@ -525,7 +531,10 @@ public class HttpSemanticConventionUtils {
       URL url = getNormalizedUrl(urlPath);
       return Optional.of(url.getPath());
     } catch (MalformedURLException e) {
-      LOGGER.warn("Received invalid URL path : {}, {}", urlPath, e.getMessage());
+      LOGGER.warn(
+          "On extracting httpResponseStatusCode, received invalid URL path : {}, {}",
+          urlPath,
+          e.getMessage());
     }
     return Optional.empty();
   }

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -46,9 +46,13 @@ import org.hypertrace.core.span.constants.RawSpanConstants;
 import org.hypertrace.core.span.constants.v1.Http;
 import org.hypertrace.core.span.constants.v1.OTSpanTag;
 import org.hypertrace.semantic.convention.utils.span.SpanSemanticConventionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Utility class to fetch http span attributes */
 public class HttpSemanticConventionUtils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HttpSemanticConventionUtils.class);
 
   // otel specific attributes
   private static final String OTEL_HTTP_METHOD = OTelHttpSemanticConventions.HTTP_METHOD.getValue();
@@ -317,7 +321,7 @@ public class HttpSemanticConventionUtils {
       try {
         return Optional.of(getNormalizedUrl(url.get()).getAuthority());
       } catch (MalformedURLException e) {
-        e.printStackTrace();
+        LOGGER.warn("Received invalid URL host : {}", e.getMessage());
       }
     }
     return Optional.ofNullable(
@@ -335,7 +339,7 @@ public class HttpSemanticConventionUtils {
         }
         return Optional.of(removeTrailingSlash(pathval));
       } catch (MalformedURLException e) {
-        e.printStackTrace();
+        LOGGER.warn("Received invalid URL path : {}", e.getMessage());
       }
     }
     return path;
@@ -382,7 +386,7 @@ public class HttpSemanticConventionUtils {
       try {
         return Optional.of(getNormalizedUrl(url.get()).getProtocol());
       } catch (MalformedURLException e) {
-        e.printStackTrace();
+        LOGGER.warn("Received invalid URL scheme : {}", e.getMessage());
       }
     }
     return getHttpSchemeFromRawAttributes(event);
@@ -455,7 +459,7 @@ public class HttpSemanticConventionUtils {
       try {
         return Optional.ofNullable(getNormalizedUrl(url.get()).getQuery());
       } catch (MalformedURLException e) {
-        e.printStackTrace();
+        LOGGER.warn("Received invalid URL querystring : {}", e.getMessage());
       }
     }
     return queryString;
@@ -521,7 +525,7 @@ public class HttpSemanticConventionUtils {
       URL url = getNormalizedUrl(urlPath);
       return Optional.of(url.getPath());
     } catch (MalformedURLException e) {
-      e.printStackTrace();
+      LOGGER.warn("Received invalid URL path : {}, {}", urlPath, e.getMessage());
     }
     return Optional.empty();
   }

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -431,13 +431,17 @@ public class HttpSemanticConventionUtils {
       }
     }
 
-    // check for OTel format
-    Optional<String> httpUrlForOTelFormat = getHttpUrlForOTelFormat(attributeValueMap);
-    if (httpUrlFromRawAttributes != null
-        && (isAbsoluteUrl(httpUrlFromRawAttributes) || httpUrlForOTelFormat.isEmpty())) {
+    if (httpUrlFromRawAttributes != null && isAbsoluteUrl(httpUrlFromRawAttributes)) {
       return Optional.of(httpUrlFromRawAttributes);
     }
-    return httpUrlForOTelFormat;
+
+    // check for OTel format
+    Optional<String> httpUrlForOTelFormat = getHttpUrlForOTelFormat(attributeValueMap);
+    if (httpUrlForOTelFormat.isPresent()) {
+      return httpUrlForOTelFormat;
+    }
+
+    return Optional.ofNullable(httpUrlFromRawAttributes);
   }
 
   public static Optional<String> getHttpQueryString(Event event) {


### PR DESCRIPTION
As part of this PR,
- wrapped the malformed URL exception as a warning message
- refactored getHttpUrlFromRawAttributes for ease of readability