### PR TITLE
chore: reduce logging of error message

### DIFF
--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java
@@ -556,7 +556,7 @@ public class HttpFieldsGenerator extends ProtocolFieldsGenerator<Http.Builder> {
       }
     } catch (MalformedURLException e) {
       // Should not happen Since the url in the request should be valid.
-      LOGGER.error("Error populating url parts", e);
+      LOGGER.warn("Error populating url parts - An invalid URL: {}, {}", urlStr, e.getMessage());
     }
   }
 


### PR DESCRIPTION
- converting log level for malformed URL in a fallback case as warn and avoid printing entire stack trace