### PR TITLE
Mark span as APIBoundary if service name differs from parent service …

### DIFF
--- a/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/utils/EnrichedSpanUtils.java
+++ b/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/utils/EnrichedSpanUtils.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.avro.reflect.Nullable;
+import org.apache.commons.codec.binary.StringUtils;
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.shared.SpanAttributeUtils;
@@ -367,5 +368,13 @@ public class EnrichedSpanUtils {
             SpanAttributeUtils.getAttributeValue(event, EnrichedSpanConstants.SPACE_IDS_ATTRIBUTE))
         .map(AttributeValue::getValueList)
         .orElseGet(Collections::emptyList);
+  }
+
+  /** Check whether these spans belongs to different services. */
+  public static boolean areBothSpansFromDifferentService(Event event, Event parentEvent) {
+    if (event.getServiceName() == null || parentEvent.getServiceName() == null) {
+      return false;
+    }
+    return !StringUtils.equals(event.getServiceName(), parentEvent.getServiceName());
   }
 }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraph.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraph.java
@@ -340,7 +340,7 @@ public class ApiTraceGraph {
             // if the child of an entry boundary event is an entry api boundary type,
             // which can happen if exit span missing and both belongs to different services.
             if (EnrichedSpanUtils.isEntryApiBoundary(child)
-                && GraphBuilderUtil.areBothSpansFromDifferentService(
+                && EnrichedSpanUtils.areBothSpansFromDifferentService(
                     child, entryBoundaryEvent.get())) {
               ApiNode<Event> destinationApiNode = entryApiBoundaryEventIdToApiNode.get(child);
               if (LOGGER.isDebugEnabled()) {

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraph.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/ApiTraceGraph.java
@@ -343,13 +343,15 @@ public class ApiTraceGraph {
                 && GraphBuilderUtil.areBothSpansFromDifferentService(
                     child, entryBoundaryEvent.get())) {
               ApiNode<Event> destinationApiNode = entryApiBoundaryEventIdToApiNode.get(child);
-              LOGGER.debug(
-                  "Edge between entry boundaries servicename: {} span: {}  to servicename: {} span: {} of trace {}",
-                  entryBoundaryEvent.get().getServiceName(),
-                  HexUtils.getHex(entryBoundaryEvent.get().getEventId()),
-                  child.getServiceName(),
-                  HexUtils.getHex(child.getEventId()),
-                  HexUtils.getHex(trace.getTraceId()));
+              if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
+                    "Edge between entry boundaries servicename: {} span: {}  to servicename: {} span: {} of trace {}",
+                    entryBoundaryEvent.get().getServiceName(),
+                    HexUtils.getHex(entryBoundaryEvent.get().getEventId()),
+                    child.getServiceName(),
+                    HexUtils.getHex(child.getEventId()),
+                    HexUtils.getHex(trace.getTraceId()));
+              }
               Optional<ApiNodeEventEdge> edgeBetweenApiNodes =
                   createEdgeBetweenApiNodes(
                       apiNode, destinationApiNode, entryBoundaryEvent.get(), child);

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/GraphBuilderUtil.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/GraphBuilderUtil.java
@@ -1,7 +1,5 @@
 package org.hypertrace.traceenricher.trace.util;
 
-import org.apache.commons.lang3.StringUtils;
-import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.StructuredTrace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,13 +55,5 @@ public class GraphBuilderUtil {
       return true;
     }
     return false;
-  }
-
-  /** Check whether these spans belongs to different services. */
-  public static boolean areBothSpansFromDifferentService(Event event, Event parentEvent) {
-    if (event.getServiceName() == null || parentEvent.getServiceName() == null) {
-      return false;
-    }
-    return !StringUtils.equals(event.getServiceName(), parentEvent.getServiceName());
   }
 }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/GraphBuilderUtil.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/src/main/java/org/hypertrace/traceenricher/trace/util/GraphBuilderUtil.java
@@ -1,5 +1,7 @@
 package org.hypertrace.traceenricher.trace.util;
 
+import org.apache.commons.lang3.StringUtils;
+import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.StructuredTrace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,5 +57,13 @@ public class GraphBuilderUtil {
       return true;
     }
     return false;
+  }
+
+  /** Check whether these spans belongs to different services. */
+  public static boolean areBothSpansFromDifferentService(Event event, Event parentEvent) {
+    if (event.getServiceName() == null || parentEvent.getServiceName() == null) {
+      return false;
+    }
+    return !StringUtils.equals(event.getServiceName(), parentEvent.getServiceName());
   }
 }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
@@ -24,7 +24,6 @@ import org.hypertrace.traceenricher.enrichedspan.constants.v1.BoundaryTypeValue;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.Http;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.Protocol;
 import org.hypertrace.traceenricher.enrichment.AbstractTraceEnricher;
-import org.hypertrace.traceenricher.trace.util.GraphBuilderUtil;
 
 /**
  * This is to determine if the span is the entry / exit point for a particular API. We can't use the
@@ -89,7 +88,7 @@ public class ApiBoundaryTypeAttributeEnricher extends AbstractTraceEnricher {
 
       Event parentEvent = graph.getParentEvent(event);
       if (!EnrichedSpanUtils.isEntrySpan(parentEvent)
-          || GraphBuilderUtil.areBothSpansFromDifferentService(event, parentEvent)) {
+          || EnrichedSpanUtils.areBothSpansFromDifferentService(event, parentEvent)) {
         addEnrichedAttribute(
             event, API_BOUNDARY_TYPE_ATTR_NAME, AttributeValueCreator.create(ENTRY_BOUNDARY_TYPE));
 

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
@@ -24,6 +24,7 @@ import org.hypertrace.traceenricher.enrichedspan.constants.v1.BoundaryTypeValue;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.Http;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.Protocol;
 import org.hypertrace.traceenricher.enrichment.AbstractTraceEnricher;
+import org.hypertrace.traceenricher.trace.util.GraphBuilderUtil;
 
 /**
  * This is to determine if the span is the entry / exit point for a particular API. We can't use the
@@ -88,7 +89,7 @@ public class ApiBoundaryTypeAttributeEnricher extends AbstractTraceEnricher {
 
       Event parentEvent = graph.getParentEvent(event);
       if (!EnrichedSpanUtils.isEntrySpan(parentEvent)
-          || areBothSpansFromDifferentService(event, parentEvent)) {
+          || GraphBuilderUtil.areBothSpansFromDifferentService(event, parentEvent)) {
         addEnrichedAttribute(
             event, API_BOUNDARY_TYPE_ATTR_NAME, AttributeValueCreator.create(ENTRY_BOUNDARY_TYPE));
 
@@ -118,13 +119,6 @@ public class ApiBoundaryTypeAttributeEnricher extends AbstractTraceEnricher {
         }
       }
     }
-  }
-
-  private boolean areBothSpansFromDifferentService(Event event, Event parentEvent) {
-    if (event.getServiceName() == null || parentEvent.getServiceName() == null) {
-      return false;
-    }
-    return !StringUtils.equals(event.getServiceName(), parentEvent.getServiceName());
   }
 
   /**

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
@@ -84,10 +84,12 @@ public class ApiBoundaryTypeAttributeEnricher extends AbstractTraceEnricher {
       Determines if this is entry span is an entry to  api
       1. If the event is an ENTRY span, and
       2. If the direct parent span is either an EXIT Span or Null, then this is the entry point.
+      3. If the direct parent span service name different from current span service name.
       */
 
       Event parentEvent = graph.getParentEvent(event);
-      if (!EnrichedSpanUtils.isEntrySpan(parentEvent)) {
+      if (!EnrichedSpanUtils.isEntrySpan(parentEvent)
+          || areBothSpansFromDifferentService(event, parentEvent)) {
         addEnrichedAttribute(
             event, API_BOUNDARY_TYPE_ATTR_NAME, AttributeValueCreator.create(ENTRY_BOUNDARY_TYPE));
 
@@ -117,6 +119,13 @@ public class ApiBoundaryTypeAttributeEnricher extends AbstractTraceEnricher {
         }
       }
     }
+  }
+
+  private boolean areBothSpansFromDifferentService(Event event, Event parentEvent) {
+    if (event.getServiceName() == null || parentEvent.getServiceName() == null) {
+      return false;
+    }
+    return !StringUtils.equals(event.getServiceName(), parentEvent.getServiceName());
   }
 
   /**

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
@@ -82,9 +82,9 @@ public class ApiBoundaryTypeAttributeEnricher extends AbstractTraceEnricher {
     if (isEntrySpan) {
       /*
       Determines if this is entry span is an entry to  api
-      1. If the event is an ENTRY span, and
-      2. If the direct parent span is either an EXIT Span or Null, then this is the entry point.
-      3. If the direct parent span service name different from current span service name.
+      1. If the event is an ENTRY span, and if the direct parent span is either an EXIT Span or Null.
+                              OR
+      2. If the event is an ENTRY span, and the direct parent span service name different from current span service name.
       */
 
       Event parentEvent = graph.getParentEvent(event);

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
@@ -82,9 +82,8 @@ public class ApiBoundaryTypeAttributeEnricher extends AbstractTraceEnricher {
     if (isEntrySpan) {
       /*
       Determines if this is entry span is an entry to  api
-      1. If the event is an ENTRY span, and if the direct parent span is either an EXIT Span or Null.
-                              OR
-      2. If the event is an ENTRY span, and the direct parent span service name different from current span service name.
+      1. If the event is an ENTRY span, and
+      2. If the direct parent span is either an EXIT Span or Null, or direct parent span service name differs from current span service name.
       */
 
       Event parentEvent = graph.getParentEvent(event);

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/AbstractAttributeEnricherTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/AbstractAttributeEnricherTest.java
@@ -69,6 +69,7 @@ public class AbstractAttributeEnricherTest {
     lenient()
         .when(e.getMetrics())
         .thenReturn(Metrics.newBuilder().setMetricMap(new HashMap<>()).build());
+    when(e.getServiceName()).thenReturn("service");
     return e;
   }
 

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricherTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricherTest.java
@@ -124,16 +124,16 @@ public class ApiBoundaryTypeAttributeEnricherTest extends AbstractAttributeEnric
     mockDoubleEntryStructuredGraph();
     target.enrichEvent(trace, outerEntrySpan);
     Assertions.assertEquals(
-            EnrichedSpanUtils.getApiBoundaryType(outerEntrySpan),
-            Constants.getEnrichedSpanConstant(ENTRY));
+        EnrichedSpanUtils.getApiBoundaryType(outerEntrySpan),
+        Constants.getEnrichedSpanConstant(ENTRY));
     target.enrichEvent(trace, innerEntrySpan);
     Assertions.assertNull(EnrichedSpanUtils.getApiBoundaryType(innerEntrySpan));
     mockDoubleEntryStructuredGraph();
     when(innerEntrySpan.getServiceName()).thenReturn("service2");
     target.enrichEvent(trace, innerEntrySpan);
     Assertions.assertEquals(
-            EnrichedSpanUtils.getApiBoundaryType(innerEntrySpan),
-            Constants.getEnrichedSpanConstant(ENTRY));
+        EnrichedSpanUtils.getApiBoundaryType(innerEntrySpan),
+        Constants.getEnrichedSpanConstant(ENTRY));
   }
 
   @Test

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricherTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricherTest.java
@@ -119,6 +119,24 @@ public class ApiBoundaryTypeAttributeEnricherTest extends AbstractAttributeEnric
   }
 
   @Test
+  public void test_enrichEvent_doubleEntrySpan_differentServiceName() {
+    // OuterEntry -> inner Entry -> inner Exit -> outer Exit
+    mockDoubleEntryStructuredGraph();
+    target.enrichEvent(trace, outerEntrySpan);
+    Assertions.assertEquals(
+            EnrichedSpanUtils.getApiBoundaryType(outerEntrySpan),
+            Constants.getEnrichedSpanConstant(ENTRY));
+    target.enrichEvent(trace, innerEntrySpan);
+    Assertions.assertNull(EnrichedSpanUtils.getApiBoundaryType(innerEntrySpan));
+    mockDoubleEntryStructuredGraph();
+    when(innerEntrySpan.getServiceName()).thenReturn("service2");
+    target.enrichEvent(trace, innerEntrySpan);
+    Assertions.assertEquals(
+            EnrichedSpanUtils.getApiBoundaryType(innerEntrySpan),
+            Constants.getEnrichedSpanConstant(ENTRY));
+  }
+
+  @Test
   public void test_enrichEvent_loopToItsOwnService_findTwoAPIEntries() {
     // Entry to API 1 -> Exit From API 1 & Re-entry -> Entry to API 1 -> Exit to API 2
     Event firstEntry = createMockEntryEvent();


### PR DESCRIPTION
Mark span as APIBoundary if it is entry span and service name differs from parent span service name. 
## Description
Added one more condition to eligible span as APIBoundary type span if it is entry span and service name differs from Parent span. 
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
