### PR TITLE
bug: Fix npe in HttpSemanticConventionUtils

### DIFF
--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -521,7 +521,7 @@ public class HttpSemanticConventionUtils {
   }
 
   public static Optional<String> getHttpRequestContentType(Event event) {
-    return Optional.of(
+    return Optional.ofNullable(
         SpanAttributeUtils.getFirstAvailableStringAttribute(
             event, List.of(RawSpanConstants.getValue(HTTP_REQUEST_CONTENT_TYPE))));
   }


### PR DESCRIPTION
Fix for following exception
```
java.lang.NullPointerException: null
	at java.util.Objects.requireNonNull(Unknown Source) ~[?:?]
	at java.util.Optional.<init>(Unknown Source) ~[?:?]
	at java.util.Optional.of(Unknown Source) ~[?:?]
	at org.hypertrace.semantic.convention.utils.http.HttpSemanticConventionUtils.getHttpRequestContentType(HttpSemanticConventionUtils.java:524) ~[semantic-convention-utils.jar:?]
```
