### PR TITLE
chore: update vulnerable deps

### DIFF
--- a/hypertrace-ingester/build.gradle.kts
+++ b/hypertrace-ingester/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
   implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.21")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.26")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.26")
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.16")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.17")
   implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.3.1")
   implementation("com.typesafe:config:1.4.1")
   implementation("org.apache.commons:commons-lang3:3.12.0")

--- a/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
+++ b/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
@@ -65,7 +65,7 @@ sourceSets {
 dependencies {
   api("com.google.protobuf:protobuf-java-util:3.15.7")
 
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.16")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.17")
   implementation(project(":span-normalizer:raw-span-constants"))
   implementation(project(":span-normalizer:span-normalizer-constants"))
   implementation(project(":semantic-convention-utils"))

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/build.gradle.kts
@@ -9,7 +9,7 @@ tasks.test {
 
 dependencies {
   implementation(project(":hypertrace-trace-enricher:enriched-span-constants"))
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.16")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.17")
 
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("org.apache.commons:commons-lang3:3.12.0")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   implementation(project(":semantic-convention-utils"))
   implementation(project(":hypertrace-trace-enricher:trace-reader"))
 
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.16")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.17")
   implementation("org.hypertrace.entity.service:entity-service-client:0.6.8")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.26")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.5.2")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -35,7 +35,7 @@ tasks.test {
 
 dependencies {
   implementation(project(":hypertrace-trace-enricher:hypertrace-trace-enricher-impl"))
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.16")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.17")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.26")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.26")
   implementation("org.hypertrace.entity.service:entity-service-client:0.6.8")

--- a/hypertrace-trace-enricher/hypertrace-trace-visualizer/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-visualizer/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.16")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.17")
 
   implementation("org.json:json:20210307")
   implementation("org.apache.commons:commons-lang3:3.12.0")

--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
   api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.0")
   api("org.hypertrace.entity.service:entity-type-service-rx-client:0.6.4")
   api("org.hypertrace.entity.service:entity-data-service-rx-client:0.6.4")
-  api("org.hypertrace.core.datamodel:data-model:0.1.14")
+  api("org.hypertrace.core.datamodel:data-model:0.1.17")
   implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.12.0")
   implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.5.2")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.5.2")

--- a/hypertrace-view-generator/hypertrace-view-generator-api/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator-api/build.gradle.kts
@@ -13,4 +13,9 @@ sourceSets {
 
 dependencies {
   api("org.apache.avro:avro:1.10.2")
+  constraints {
+    api("org.apache.commons:commons-compress:1.21") {
+      because("Multiple vulnerabilities in avro-declared version")
+    }
+  }
 }

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
 
   // TODO: migrate in core
   implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.3.1")
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.16")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.17")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.26")
 
   implementation("org.hypertrace.entity.service:entity-service-api:0.6.4")

--- a/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
+++ b/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
         because("https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-1255637")
     }
     implementation(project(":span-normalizer:span-normalizer-api"))
-    implementation("org.hypertrace.core.datamodel:data-model:0.1.16")
+    implementation("org.hypertrace.core.datamodel:data-model:0.1.17")
     implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.26")
     implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.26")
 

--- a/semantic-convention-utils/build.gradle.kts
+++ b/semantic-convention-utils/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation(project(":span-normalizer:raw-span-constants"))
     implementation(project(":span-normalizer:span-normalizer-constants"))
 
-    implementation("org.hypertrace.core.datamodel:data-model:0.1.16")
+    implementation("org.hypertrace.core.datamodel:data-model:0.1.17")
     implementation("org.hypertrace.entity.service:entity-service-client:0.6.8")
     implementation("org.apache.commons:commons-lang3:3.12.0")
 

--- a/span-normalizer/span-normalizer-api/build.gradle.kts
+++ b/span-normalizer/span-normalizer-api/build.gradle.kts
@@ -58,4 +58,9 @@ sourceSets {
 dependencies {
   api("com.google.api.grpc:proto-google-common-protos:2.1.0")
   api("org.apache.avro:avro:1.10.2")
+  constraints {
+    api("org.apache.commons:commons-compress:1.21") {
+      because("Multiple vulnerabilities in avro-declared version")
+    }
+  }
 }

--- a/span-normalizer/span-normalizer/build.gradle.kts
+++ b/span-normalizer/span-normalizer/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
   implementation(project(":span-normalizer:span-normalizer-constants"))
   implementation(project(":semantic-convention-utils"))
 
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.16")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.17")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.26")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.26")
   implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.21")


### PR DESCRIPTION
## Description
Minor transitive dependency update to fix a newly published vulnerability in commons-compress. Depends on https://github.com/hypertrace/data-model/pull/27 