### PR TITLE
chore: use newer attribute client with lazy errors

### DIFF
--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 }
 
 dependencies {
-  api("org.hypertrace.core.attribute.service:attribute-service-api:0.12.0")
-  api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.0")
+  api("org.hypertrace.core.attribute.service:attribute-service-api:0.12.3")
+  api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.3")
   api("org.hypertrace.entity.service:entity-type-service-rx-client:0.6.10")
   api("org.hypertrace.entity.service:entity-data-service-rx-client:0.6.10")
   api("org.hypertrace.core.datamodel:data-model:0.1.17")
-  implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.12.0")
+  implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.12.3")
   implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.5.2")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.5.2")
   implementation("io.reactivex.rxjava3:rxjava:3.0.11")


### PR DESCRIPTION
## Description
Use newer attribute client with better performing client (builds errors lazily, less exception filling)