### PR TITLE
emit metrics for dropped spans at tenant level

### DIFF
--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
@@ -68,6 +68,7 @@ public class JaegerSpanPreProcessor
                 "dropped",
                 k -> PlatformMetricsRegistry.registerCounter(SPANS_COUNTER, Map.of("result", k)))
             .increment();
+        return null;
       }
 
       return new KeyValue<>(key, preProcessedSpan);

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
@@ -23,8 +23,11 @@ public class JaegerSpanPreProcessor
     implements Transformer<byte[], Span, KeyValue<byte[], PreProcessedSpan>> {
 
   static final String SPANS_COUNTER = "hypertrace.reported.spans";
+  private static final String DROPPED_SPANS_COUNTER = "hypertrace.reported.spans.dropped";
   private static final Logger LOG = LoggerFactory.getLogger(JaegerSpanPreProcessor.class);
   private static final ConcurrentMap<String, Counter> statusToSpansCounter =
+      new ConcurrentHashMap<>();
+  private static final ConcurrentMap<String, Counter> tenantToSpansDroppedCount =
       new ConcurrentHashMap<>();
   private TenantIdHandler tenantIdHandler;
   private SpanFilter spanFilter;
@@ -65,7 +68,6 @@ public class JaegerSpanPreProcessor
                 "dropped",
                 k -> PlatformMetricsRegistry.registerCounter(SPANS_COUNTER, Map.of("result", k)))
             .increment();
-        return null;
       }
 
       return new KeyValue<>(key, preProcessedSpan);
@@ -94,6 +96,14 @@ public class JaegerSpanPreProcessor
     String tenantId = maybeTenantId.get();
 
     if (spanFilter.shouldDropSpan(span, tags)) {
+      // increment dropped counter at tenant level
+      tenantToSpansDroppedCount
+          .computeIfAbsent(
+              tenantId,
+              tenant ->
+                  PlatformMetricsRegistry.registerCounter(
+                      DROPPED_SPANS_COUNTER, Map.of("tenantId", tenantId)))
+          .increment();
       return null;
     }
 


### PR DESCRIPTION
## Description
This PR adds support to emit metrics for dropped spans at tenant level.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
