### PR TITLE
Optimization to avoid excessing reflection

### DIFF
--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/util/JaegerHTTagsConverter.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/util/JaegerHTTagsConverter.java
@@ -5,8 +5,15 @@ import io.jaegertracing.api_v2.JaegerSpanInternalModel;
 import org.hypertrace.core.datamodel.AttributeValue;
 
 public class JaegerHTTagsConverter {
+  private static final AttributeValue.Builder ATTRIBUTE_VALUE_BUILDER = AttributeValue.newBuilder();
+
   public static AttributeValue createFromJaegerKeyValue(JaegerSpanInternalModel.KeyValue keyValue) {
-    AttributeValue.Builder valueBuilder = AttributeValue.newBuilder();
+    // newBuilder() in Avro classes uses SpecificData.getForSchema which uses
+    // reflection(Class.forName) for loading the class
+    // This may be too expensive when being done at a large scale(like in the case of
+    // AttributeValue).
+    // By using an existing empty builder to create a new builder we are bypassing the reflection
+    AttributeValue.Builder valueBuilder = AttributeValue.newBuilder(ATTRIBUTE_VALUE_BUILDER);
     switch (keyValue.getVType()) {
       case STRING:
         valueBuilder.setValue(keyValue.getVStr());


### PR DESCRIPTION
## Description
Optimization for bypassing the newBuilder() in Avro classes uses SpecificData.getForSchema which uses  reflection(Class.forName) for loading the class
   