### PR TITLE
reduce excessive logging in case of dropped spans

### DIFF
--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
@@ -3,7 +3,6 @@ package org.hypertrace.core.spannormalizer.jaeger;
 import static org.hypertrace.core.spannormalizer.constants.SpanNormalizerConstants.SPAN_NORMALIZER_JOB_CONFIG;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.RateLimiter;
 import com.typesafe.config.Config;
 import io.jaegertracing.api_v2.JaegerSpanInternalModel;
 import io.jaegertracing.api_v2.JaegerSpanInternalModel.Span;
@@ -20,13 +19,11 @@ import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings("UnstableApiUsage")
 public class JaegerSpanPreProcessor
     implements Transformer<byte[], Span, KeyValue<byte[], PreProcessedSpan>> {
 
   static final String SPANS_COUNTER = "hypertrace.reported.spans";
   private static final Logger LOG = LoggerFactory.getLogger(JaegerSpanPreProcessor.class);
-  private static final RateLimiter DROPPED_SPANS_RATE_LIMITER = RateLimiter.create(1.0);
   private static final ConcurrentMap<String, Counter> statusToSpansCounter =
       new ConcurrentHashMap<>();
   private TenantIdHandler tenantIdHandler;
@@ -97,9 +94,6 @@ public class JaegerSpanPreProcessor
     String tenantId = maybeTenantId.get();
 
     if (spanFilter.shouldDropSpan(span, tags)) {
-      if (DROPPED_SPANS_RATE_LIMITER.tryAcquire()) {
-        LOG.info("Dropped span: {}", span);
-      }
       return null;
     }
 

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
@@ -3,6 +3,7 @@ package org.hypertrace.core.spannormalizer.jaeger;
 import static org.hypertrace.core.spannormalizer.constants.SpanNormalizerConstants.SPAN_NORMALIZER_JOB_CONFIG;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.RateLimiter;
 import com.typesafe.config.Config;
 import io.jaegertracing.api_v2.JaegerSpanInternalModel;
 import io.jaegertracing.api_v2.JaegerSpanInternalModel.Span;
@@ -19,11 +20,13 @@ import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("UnstableApiUsage")
 public class JaegerSpanPreProcessor
     implements Transformer<byte[], Span, KeyValue<byte[], PreProcessedSpan>> {
 
   static final String SPANS_COUNTER = "hypertrace.reported.spans";
   private static final Logger LOG = LoggerFactory.getLogger(JaegerSpanPreProcessor.class);
+  private static final RateLimiter DROPPED_SPANS_RATE_LIMITER = RateLimiter.create(1.0);
   private static final ConcurrentMap<String, Counter> statusToSpansCounter =
       new ConcurrentHashMap<>();
   private TenantIdHandler tenantIdHandler;
@@ -94,6 +97,9 @@ public class JaegerSpanPreProcessor
     String tenantId = maybeTenantId.get();
 
     if (spanFilter.shouldDropSpan(span, tags)) {
+      if (DROPPED_SPANS_RATE_LIMITER.tryAcquire()) {
+        LOG.info("Dropped span: {}", span);
+      }
       return null;
     }
 

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanFilter.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanFilter.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("UnstableApiUsage")
 public class SpanFilter {
   private static final Logger LOG = LoggerFactory.getLogger(SpanFilter.class);
-  private static final RateLimiter DROPPED_SPANS_RATE_LIMITER = RateLimiter.create(1.0);
+  private static final RateLimiter DROPPED_SPANS_RATE_LIMITER = RateLimiter.create(0.01);
   private static final String SPAN_KIND_TAG =
       RawSpanConstants.getValue(SpanAttribute.SPAN_ATTRIBUTE_SPAN_KIND);
   private static final String SPAN_KIND_CLIENT = "client";


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
