### PR TITLE
fix: filter out entities with empty ids

### DIFF
--- a/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReaderTest.java
+++ b/hypertrace-trace-enricher/trace-reader/src/test/java/org/hypertrace/trace/reader/entities/DefaultTraceEntityReaderTest.java
@@ -156,6 +156,23 @@ class DefaultTraceEntityReaderTest {
             .getAssociatedEntityForSpan(TEST_ENTITY_TYPE_NAME, TEST_TRACE, TEST_SPAN)
             .isEmpty()
             .blockingGet());
+    verifyNoInteractions(mockDataClient);
+  }
+
+  @Test
+  void omitsEntityBasedOnEmptyId() {
+    mockSingleEntityType();
+    mockGetAllAttributes(TEST_ENTITY_ID_ATTRIBUTE, TEST_ENTITY_NAME_ATTRIBUTE);
+    mockTenantId();
+    mockAttributeRead(TEST_ENTITY_ID_ATTRIBUTE, stringLiteral(""));
+    mockAttributeRead(TEST_ENTITY_NAME_ATTRIBUTE, stringLiteral(TEST_ENTITY_NAME_ATTRIBUTE_VALUE));
+
+    assertTrue(
+        this.entityReader
+            .getAssociatedEntityForSpan(TEST_ENTITY_TYPE_NAME, TEST_TRACE, TEST_SPAN)
+            .isEmpty()
+            .blockingGet());
+    verifyNoInteractions(mockDataClient);
   }
 
   @Test


### PR DESCRIPTION
## Description
Entity IDs that are present but empty strings attempt to create an invalid entity. This change filters out invalid values.

### Testing
Added UTs

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
