### PR TITLE
chore: read tenant id from process tags

### DIFF
--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerResourceNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerResourceNormalizer.java
@@ -1,6 +1,5 @@
 package org.hypertrace.core.spannormalizer.jaeger;
 
-import static java.util.function.Predicate.not;
 import static org.hypertrace.core.spannormalizer.util.JaegerHTTagsConverter.createFromJaegerKeyValue;
 
 import io.jaegertracing.api_v2.JaegerSpanInternalModel.KeyValue;
@@ -22,23 +21,28 @@ class JaegerResourceNormalizer {
       MAP_COLLECTOR =
           Collectors.toUnmodifiableMap(Entry::getKey, Entry::getValue, (first, second) -> first);
 
-  Optional<Resource> normalize(Span span) {
+  Optional<Resource> normalize(Span span, Optional<String> tenantIdKey) {
     return Optional.of(span.getProcess())
         .map(Process::getTagsList)
-        .filter(not(List::isEmpty))
-        .map(this::buildResource);
+        .flatMap(keyValueList -> buildResource(keyValueList, tenantIdKey));
   }
 
-  private Resource buildResource(List<KeyValue> keyValueList) {
+  private Optional<Resource> buildResource(
+      List<KeyValue> keyValueList, Optional<String> tenantIdKey) {
     return keyValueList.stream()
+        .filter(kv -> tenantIdKey.isEmpty() || !tenantIdKey.get().equalsIgnoreCase(kv.getKey()))
         .map(this::buildResourceValue)
         .collect(Collectors.collectingAndThen(MAP_COLLECTOR, this::buildResource));
   }
 
-  private Resource buildResource(Map<String, AttributeValue> resourceValueMap) {
-    return Resource.newBuilder()
-        .setAttributesBuilder(Attributes.newBuilder().setAttributeMap(resourceValueMap))
-        .build();
+  private Optional<Resource> buildResource(Map<String, AttributeValue> resourceValueMap) {
+    if (resourceValueMap.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        Resource.newBuilder()
+            .setAttributesBuilder(Attributes.newBuilder().setAttributeMap(resourceValueMap))
+            .build());
   }
 
   private Entry<String, AttributeValue> buildResourceValue(KeyValue keyValue) {

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -112,7 +112,9 @@ public class JaegerSpanNormalizer {
               tenantIdHandler.getTenantIdProvider().getTenantIdTagKey());
       rawSpanBuilder.setEvent(event);
       rawSpanBuilder.setReceivedTimeMillis(System.currentTimeMillis());
-      resourceNormalizer.normalize(jaegerSpan).ifPresent(rawSpanBuilder::setResource);
+      resourceNormalizer
+          .normalize(jaegerSpan, tenantIdHandler.getTenantIdProvider().getTenantIdTagKey())
+          .ifPresent(rawSpanBuilder::setResource);
 
       // build raw span
       RawSpan rawSpan = rawSpanBuilder.build();

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/TenantIdHandler.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/TenantIdHandler.java
@@ -84,8 +84,9 @@ public class TenantIdHandler {
     }
   }
 
-  Optional<String> getAllowedTenantId(Span jaegerSpan, Map<String, KeyValue> tags) {
-    Optional<String> maybeTenantId = this.tenantIdProvider.getTenantId(jaegerSpan, tags);
+  Optional<String> getAllowedTenantId(
+      Span jaegerSpan, Map<String, KeyValue> spanTags, Map<String, KeyValue> processTags) {
+    Optional<String> maybeTenantId = this.tenantIdProvider.getTenantId(spanTags, processTags);
 
     if (maybeTenantId.isEmpty()) {
       tenantIdProvider.logWarning(LOG, jaegerSpan);

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/TenantIdHandler.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/TenantIdHandler.java
@@ -85,7 +85,7 @@ public class TenantIdHandler {
   }
 
   Optional<String> getAllowedTenantId(Span jaegerSpan, Map<String, KeyValue> tags) {
-    Optional<String> maybeTenantId = this.tenantIdProvider.getTenantId(tags);
+    Optional<String> maybeTenantId = this.tenantIdProvider.getTenantId(jaegerSpan, tags);
 
     if (maybeTenantId.isEmpty()) {
       tenantIdProvider.logWarning(LOG, jaegerSpan);

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/tenant/DefaultTenantIdProvider.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/tenant/DefaultTenantIdProvider.java
@@ -24,7 +24,7 @@ public class DefaultTenantIdProvider implements TenantIdProvider {
 
   @Override
   public Optional<String> getTenantId(
-      JaegerSpanInternalModel.Span span, Map<String, KeyValue> tags) {
+      Map<String, KeyValue> spanTags, Map<String, KeyValue> processTags) {
     return defaultTenantId;
   }
 

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/tenant/DefaultTenantIdProvider.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/tenant/DefaultTenantIdProvider.java
@@ -23,7 +23,8 @@ public class DefaultTenantIdProvider implements TenantIdProvider {
   }
 
   @Override
-  public Optional<String> getTenantId(Map<String, KeyValue> tags) {
+  public Optional<String> getTenantId(
+      JaegerSpanInternalModel.Span span, Map<String, KeyValue> tags) {
     return defaultTenantId;
   }
 

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/tenant/JaegerKeyBasedTenantIdProvider.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/tenant/JaegerKeyBasedTenantIdProvider.java
@@ -29,17 +29,16 @@ public class JaegerKeyBasedTenantIdProvider implements TenantIdProvider {
   /**
    * gets the tenant id from process tags, with a fallback to getting it from the span tags.
    *
-   * @param span
-   * @param tags
+   * @param spanTags
+   * @param processTags
    * @return the tenant id if it is present in the process tags or span tags; otherwise, returns an
    *     empty optional.
    */
   @Override
-  public Optional<String> getTenantId(Span span, Map<String, KeyValue> tags) {
-    return span.getProcess().getTagsList().stream()
-        .filter(t -> t.getKey().equals(tenantIdKey))
-        .findFirst()
-        .or(() -> Optional.ofNullable(tags.get(tenantIdKey)))
+  public Optional<String> getTenantId(
+      Map<String, KeyValue> spanTags, Map<String, KeyValue> processTags) {
+    return Optional.ofNullable(processTags.get(tenantIdKey))
+        .or(() -> Optional.ofNullable(spanTags.get(tenantIdKey)))
         .map(KeyValue::getVStr);
   }
 

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/tenant/TenantIdProvider.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/tenant/TenantIdProvider.java
@@ -6,9 +6,11 @@ import java.util.Optional;
 import org.slf4j.Logger;
 
 public interface TenantIdProvider {
+
   Optional<String> getTenantIdTagKey();
 
-  Optional<String> getTenantId(Map<String, JaegerSpanInternalModel.KeyValue> tags);
+  Optional<String> getTenantId(
+      JaegerSpanInternalModel.Span span, Map<String, JaegerSpanInternalModel.KeyValue> tags);
 
   void logWarning(Logger logger, JaegerSpanInternalModel.Span span);
 }

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/tenant/TenantIdProvider.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/tenant/TenantIdProvider.java
@@ -1,6 +1,7 @@
 package org.hypertrace.core.spannormalizer.jaeger.tenant;
 
-import io.jaegertracing.api_v2.JaegerSpanInternalModel;
+import io.jaegertracing.api_v2.JaegerSpanInternalModel.KeyValue;
+import io.jaegertracing.api_v2.JaegerSpanInternalModel.Span;
 import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -9,8 +10,7 @@ public interface TenantIdProvider {
 
   Optional<String> getTenantIdTagKey();
 
-  Optional<String> getTenantId(
-      JaegerSpanInternalModel.Span span, Map<String, JaegerSpanInternalModel.KeyValue> tags);
+  Optional<String> getTenantId(Map<String, KeyValue> spanTags, Map<String, KeyValue> processTags);
 
-  void logWarning(Logger logger, JaegerSpanInternalModel.Span span);
+  void logWarning(Logger logger, Span span);
 }

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessorTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessorTest.java
@@ -13,7 +13,7 @@ import org.hypertrace.core.span.constants.v1.SpanAttribute;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class JaegerSpanPreProcessorTest {
+class JaegerSpanPreProcessorTest {
 
   private final Random random = new Random();
 
@@ -57,7 +57,7 @@ public class JaegerSpanPreProcessorTest {
     PreProcessedSpan preProcessedSpan = jaegerSpanPreProcessor.preProcessSpan(span1);
     Assertions.assertEquals("default-tenant", preProcessedSpan.getTenantId());
 
-    // provided tenant id
+    // provided tenant id in span tags
     configs = new HashMap<>(getCommonConfig());
     configs.putAll(Map.of("processor", Map.of("tenantIdTagKey", "tenant-key")));
     jaegerSpanPreProcessor = new JaegerSpanPreProcessor(ConfigFactory.parseMap(configs));
@@ -68,6 +68,16 @@ public class JaegerSpanPreProcessorTest {
             .addTags(KeyValue.newBuilder().setKey("tenant-key").setVStr(tenantId).build())
             .build();
     preProcessedSpan = jaegerSpanPreProcessor.preProcessSpan(span2);
+    Assertions.assertEquals(tenantId, preProcessedSpan.getTenantId());
+
+    // provided tenant id in process tags
+    process =
+        Process.newBuilder()
+            .addTags(KeyValue.newBuilder().setKey("tenant-key").setVStr(tenantId).build())
+            .build();
+
+    Span span3 = Span.newBuilder().setProcess(process).build();
+    preProcessedSpan = jaegerSpanPreProcessor.preProcessSpan(span3);
     Assertions.assertEquals(tenantId, preProcessedSpan.getTenantId());
   }
 


### PR DESCRIPTION
## Description
In hypertrace collector, we're going to remove tenantId from tags in span. Instead, tenantId will only be present in resource spans (refer [this PR](https://github.com/hypertrace/hypertrace-collector/pull/58)). So, we should be getting tenantId from `Process` in resource spans instead of getting from `Tags` in span. We're also keeping a fallback option for getting the tenantId from tags in span.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Updated unit test.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
