### PR TITLE
Removed unused entity service client dependency

### DIFF
--- a/semantic-convention-utils/build.gradle.kts
+++ b/semantic-convention-utils/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
     implementation(project(":span-normalizer:span-normalizer-constants"))
 
     implementation("org.hypertrace.core.datamodel:data-model:0.1.18")
-    implementation("org.hypertrace.entity.service:entity-service-client:0.8.0")
     implementation("org.apache.commons:commons-lang3:3.12.0")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")


### PR DESCRIPTION
## Description
semantic-convention-utils is a module with utility functions and should have no dependency on any client 

### Checklist:
- [x] My changes generate no new warnings
