### PR TITLE
fix : added fallback support for host headers 

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
@@ -1,7 +1,5 @@
 package org.hypertrace.traceenricher.enrichment.enrichers;
 
-import static org.hypertrace.semantic.convention.utils.rpc.RpcSemanticConventionUtils.getGrpcRequestMetadataHost;
-
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import java.net.URI;
@@ -150,9 +148,15 @@ public class ApiBoundaryTypeAttributeEnricher extends AbstractTraceEnricher {
     Optional<String> grpcAuthority = RpcSemanticConventionUtils.getGrpcAuthority(event);
     if (grpcAuthority.isPresent()) {
       return getSanitizedHostValue(grpcAuthority.get());
-    } else {
-      return getGrpcRequestMetadataHost(event);
     }
+
+    Optional<String> grpcRequestMetadataHost =
+        RpcSemanticConventionUtils.getGrpcRequestMetadataHost(event);
+    if (grpcRequestMetadataHost.isPresent()) {
+      return getSanitizedHostValue(grpcRequestMetadataHost.get());
+    }
+
+    return Optional.empty();
   }
 
   private Optional<String> getSanitizedHostValue(String value) {

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricherTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricherTest.java
@@ -276,6 +276,10 @@ public class ApiBoundaryTypeAttributeEnricherTest extends AbstractAttributeEnric
         AttributeValue.newBuilder().setValue("testHost").build());
     addAttributeToEvent(
         innerEntrySpan,
+        RPC_REQUEST_METADATA_HOST.getValue(),
+        AttributeValue.newBuilder().setValue("testHost2").build());
+    addAttributeToEvent(
+        innerEntrySpan,
         OTEL_SPAN_TAG_RPC_SYSTEM.getValue(),
         AttributeValue.newBuilder().setValue("grpc").build());
     target.enrichEvent(trace, innerEntrySpan);

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricherTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricherTest.java
@@ -304,15 +304,6 @@ public class ApiBoundaryTypeAttributeEnricherTest extends AbstractAttributeEnric
   @Test
   public void testEnrichEventWithGrpcNoAuthorityButRequestMetadataHost() {
     mockProtocol(innerEntrySpan, Protocol.PROTOCOL_GRPC);
-    org.hypertrace.core.datamodel.eventfields.grpc.Grpc grpc =
-        mock(org.hypertrace.core.datamodel.eventfields.grpc.Grpc.class);
-    when(innerEntrySpan.getGrpc()).thenReturn(grpc);
-    Request request = mock(Request.class);
-    when(grpc.getRequest()).thenReturn(request);
-    RequestMetadata metadata = mock(RequestMetadata.class);
-    when(request.getRequestMetadata()).thenReturn(metadata);
-    when(metadata.getAuthority()).thenReturn("localhost:443");
-
     addEnrichedAttributeToEvent(
         innerEntrySpan, X_FORWARDED_HOST_METADATA, AttributeValueCreator.create("testHost"));
 

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/rpc/RpcSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/rpc/RpcSemanticConventionUtils.java
@@ -235,12 +235,6 @@ public class RpcSemanticConventionUtils {
     return grpcStatusMsg == null ? "" : grpcStatusMsg;
   }
 
-  public static Optional<String> getGrpcRequestMetadataHost(Event event) {
-    return Optional.ofNullable(
-        SpanAttributeUtils.getFirstAvailableStringAttribute(
-            event, List.of(RPC_REQUEST_METADATA_HOST.getValue())));
-  }
-
   public static String getGrpcErrorMsg(Event event) {
     if (event.getAttributes() == null || event.getAttributes().getAttributeMap() == null) {
       return "";
@@ -433,6 +427,24 @@ public class RpcSemanticConventionUtils {
     if (attributeValueMap.get(RPC_REQUEST_METADATA_X_FORWARDED_FOR.getValue()) != null) {
       return Optional.ofNullable(
           attributeValueMap.get(RPC_REQUEST_METADATA_X_FORWARDED_FOR.getValue()).getValue());
+    }
+    return Optional.empty();
+  }
+
+  public static Optional<String> getGrpcRequestMetadataHost(Event event) {
+    if (event.getAttributes() == null || event.getAttributes().getAttributeMap() == null) {
+      return Optional.empty();
+    }
+
+    Map<String, AttributeValue> attributeValueMap = event.getAttributes().getAttributeMap();
+
+    if (!isRpcSystemGrpc(attributeValueMap)) {
+      return Optional.empty();
+    }
+
+    if (attributeValueMap.get(RPC_REQUEST_METADATA_HOST.getValue()) != null) {
+      return Optional.ofNullable(
+          attributeValueMap.get(RPC_REQUEST_METADATA_HOST.getValue()).getValue());
     }
     return Optional.empty();
   }

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/rpc/RpcSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/rpc/RpcSemanticConventionUtils.java
@@ -17,6 +17,7 @@ import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUE
 import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_BODY_TRUNCATED;
 import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_METADATA_AUTHORITY;
 import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_METADATA_CONTENT_LENGTH;
+import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_METADATA_HOST;
 import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_METADATA_PATH;
 import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_METADATA_USER_AGENT;
 import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_METADATA_X_FORWARDED_FOR;
@@ -232,6 +233,12 @@ public class RpcSemanticConventionUtils {
     String grpcStatusMsg =
         SpanAttributeUtils.getFirstAvailableStringAttribute(event, STATUS_MSG_ATTRIBUTES);
     return grpcStatusMsg == null ? "" : grpcStatusMsg;
+  }
+
+  public static Optional<String> getGrpcRequestMetadataHost(Event event) {
+    return Optional.ofNullable(
+        SpanAttributeUtils.getFirstAvailableStringAttribute(
+            event, List.of(RPC_REQUEST_METADATA_HOST.getValue())));
   }
 
   public static String getGrpcErrorMsg(Event event) {

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/rpc/RpcSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/rpc/RpcSemanticConventionUtils.java
@@ -69,6 +69,7 @@ public class RpcSemanticConventionUtils {
   private static final String OTEL_RPC_SYSTEM_GRPC =
       OTelRpcSemanticConventions.RPC_SYSTEM_VALUE_GRPC.getValue();
   private static final String OTEL_SPAN_TAG_RPC_SYSTEM_ATTR = OTEL_SPAN_TAG_RPC_SYSTEM.getValue();
+  private static final String RPC_REQUEST_METADATA_HOST_ATTR = RPC_REQUEST_METADATA_HOST.getValue();
 
   private static final String OTHER_GRPC_HOST_PORT = RawSpanConstants.getValue(Grpc.GRPC_HOST_PORT);
   private static final String OTHER_GRPC_METHOD = RawSpanConstants.getValue(Grpc.GRPC_METHOD);
@@ -441,12 +442,8 @@ public class RpcSemanticConventionUtils {
     if (!isRpcSystemGrpc(attributeValueMap)) {
       return Optional.empty();
     }
-
-    if (attributeValueMap.get(RPC_REQUEST_METADATA_HOST.getValue()) != null) {
-      return Optional.ofNullable(
-          attributeValueMap.get(RPC_REQUEST_METADATA_HOST.getValue()).getValue());
-    }
-    return Optional.empty();
+    return Optional.ofNullable(attributeValueMap.get(RPC_REQUEST_METADATA_HOST_ATTR))
+        .map(AttributeValue::getValue);
   }
 
   public static Optional<String> getRpcPath(Event event) {

--- a/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/rpc/RpcSemanticConventionUtilsTest.java
+++ b/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/rpc/RpcSemanticConventionUtilsTest.java
@@ -167,7 +167,7 @@ class RpcSemanticConventionUtilsTest {
   }
 
   @Test
-  public void testGetGrpcRequestMetadataHost() {
+  public void testGetGrpcRequestMetadataHostForGrpcSystem() {
     Event event = mock(Event.class);
     when(event.getAttributes())
         .thenReturn(
@@ -181,6 +181,20 @@ class RpcSemanticConventionUtilsTest {
                 .build());
     assertEquals(
         "webhost:9011", RpcSemanticConventionUtils.getGrpcRequestMetadataHost(event).get());
+  }
+
+  @Test
+  public void testGetGrpcRequestMetadataHostForNotGrpcSystem() {
+    Event event = mock(Event.class);
+    when(event.getAttributes())
+        .thenReturn(
+            Attributes.newBuilder()
+                .setAttributeMap(
+                    Map.of(
+                        RPC_REQUEST_METADATA_HOST.getValue(),
+                        AttributeValue.newBuilder().setValue("webhost:9011").build()))
+                .build());
+    assertEquals(Optional.empty(), RpcSemanticConventionUtils.getGrpcRequestMetadataHost(event));
   }
 
   @Test

--- a/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/rpc/RpcSemanticConventionUtilsTest.java
+++ b/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/rpc/RpcSemanticConventionUtilsTest.java
@@ -17,6 +17,7 @@ import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUE
 import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_BODY_TRUNCATED;
 import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_METADATA_AUTHORITY;
 import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_METADATA_CONTENT_LENGTH;
+import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_METADATA_HOST;
 import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_METADATA_PATH;
 import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_METADATA_USER_AGENT;
 import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_METADATA_X_FORWARDED_FOR;
@@ -163,6 +164,23 @@ class RpcSemanticConventionUtilsTest {
                         AttributeValue.newBuilder().setValue("198.12.34.1").build()))
                 .build());
     assertEquals("198.12.34.1", RpcSemanticConventionUtils.getGrpcXForwardedFor(event).get());
+  }
+
+  @Test
+  public void testGetGrpcRequestMetadataHost() {
+    Event event = mock(Event.class);
+    when(event.getAttributes())
+        .thenReturn(
+            Attributes.newBuilder()
+                .setAttributeMap(
+                    Map.of(
+                        OTEL_SPAN_TAG_RPC_SYSTEM.getValue(),
+                        AttributeValue.newBuilder().setValue("grpc").build(),
+                        RPC_REQUEST_METADATA_HOST.getValue(),
+                        AttributeValue.newBuilder().setValue("webhost:9011").build()))
+                .build());
+    assertEquals(
+        "webhost:9011", RpcSemanticConventionUtils.getGrpcRequestMetadataHost(event).get());
   }
 
   @Test

--- a/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/span/normalizer/constants/RpcSpanTag.java
+++ b/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/span/normalizer/constants/RpcSpanTag.java
@@ -5,6 +5,7 @@ public enum RpcSpanTag {
   RPC_ERROR_NAME("rpc.error_name"),
   RPC_ERROR_MESSAGE("rpc.error_message"),
   RPC_REQUEST_METADATA("rpc.request.metadata"),
+  RPC_REQUEST_METADATA_HOST("rpc.request.metadata.host"),
   RPC_RESPONSE_METADATA("rpc.response.metadata"),
   RPC_REQUEST_BODY("rpc.request.body"),
   RPC_RESPONSE_BODY("rpc.response.body"),


### PR DESCRIPTION
Earlier host header was being checked through grpc authority. So it was suggested to check metadata host if authority was not present as a fallback. Added support for this. 