### PR TITLE
feat: add forming grpc reqeuest url if rpc attributes are present

### DIFF
--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
@@ -15,6 +15,7 @@ import org.hypertrace.core.datamodel.MetricValue;
 import org.hypertrace.core.datamodel.StructuredTrace;
 import org.hypertrace.core.datamodel.shared.SpanAttributeUtils;
 import org.hypertrace.semantic.convention.utils.http.HttpSemanticConventionUtils;
+import org.hypertrace.semantic.convention.utils.rpc.RpcSemanticConventionUtils;
 import org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants;
 import org.hypertrace.traceenricher.enrichedspan.constants.utils.EnrichedSpanUtils;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.Api;
@@ -315,7 +316,15 @@ public class SpanEventViewGenerator extends BaseViewGenerator<SpanEventView> {
             .orElse(HttpSemanticConventionUtils.getHttpPath(event).orElse(null));
 
       case PROTOCOL_GRPC:
-        return event.getEventName();
+        /**
+         * For RPC methods, we shows URL/URI as combination of rpc.service and rpc.method. The same
+         * information is also available as Span Name -
+         * https://github.com/open-telemetry/opentelemetry-specification/blob/3e380e249f60c3a5f68746f5e84d10195ba41a79/specification/trace/semantic_conventions/rpc.md#span-name
+         * So, as part of this method, we will form Url using rpc.service and rpc.method, and
+         * fallback to spanName. While setting GRPC protocol from rpc attributes, it already checks
+         * for rpc.system.
+         */
+        return RpcSemanticConventionUtils.getRpcPath(event).orElse(event.getEventName());
     }
     return null;
   }

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
@@ -317,7 +317,7 @@ public class SpanEventViewGenerator extends BaseViewGenerator<SpanEventView> {
 
       case PROTOCOL_GRPC:
         /**
-         * For RPC methods, we shows URL/URI as combination of rpc.service and rpc.method. The same
+         * For RPC methods, we show URL/URI as a combination of rpc.service and rpc.method. The same
          * information is also available as Span Name -
          * https://github.com/open-telemetry/opentelemetry-specification/blob/3e380e249f60c3a5f68746f5e84d10195ba41a79/specification/trace/semantic_conventions/rpc.md#span-name
          * So, as part of this method, we will form Url using rpc.service and rpc.method, and

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/SpanEventViewGeneratorTest.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/SpanEventViewGeneratorTest.java
@@ -80,6 +80,57 @@ public class SpanEventViewGeneratorTest {
   }
 
   @Test
+  public void test_getRequestUrl_grpcProctol_shouldReturnRpcServiceAndMethod() {
+    Event event = mock(Event.class);
+    when(event.getAttributes())
+        .thenReturn(
+            Attributes.newBuilder()
+                .setAttributeMap(
+                    Map.of(
+                        "rpc.service",
+                        AttributeValue.newBuilder().setValue("hipstershop.AdService").build(),
+                        "rpc.method",
+                        AttributeValue.newBuilder().setValue("GetEcho").build()))
+                .build());
+    when(event.getEventName()).thenReturn("Sent.hipstershop.AdService.GetAds");
+    assertEquals(
+        "hipstershop.AdService.GetEcho",
+        spanEventViewGenerator.getRequestUrl(event, Protocol.PROTOCOL_GRPC));
+  }
+
+  @Test
+  public void test_getRequestUrl_grpcProctol_shouldReturnEventNameIfOnlyRpcService() {
+    Event event = mock(Event.class);
+    when(event.getAttributes())
+        .thenReturn(
+            Attributes.newBuilder()
+                .setAttributeMap(
+                    Map.of(
+                        "rpc.service",
+                        AttributeValue.newBuilder().setValue("hipstershop.AdService").build()))
+                .build());
+    when(event.getEventName()).thenReturn("Sent.hipstershop.AdService.GetAds");
+    assertEquals(
+        "Sent.hipstershop.AdService.GetAds",
+        spanEventViewGenerator.getRequestUrl(event, Protocol.PROTOCOL_GRPC));
+  }
+
+  @Test
+  public void test_getRequestUrl_grpcProctol_shouldReturnEventNameIfOnlyRpcMethod() {
+    Event event = mock(Event.class);
+    when(event.getAttributes())
+        .thenReturn(
+            Attributes.newBuilder()
+                .setAttributeMap(
+                    Map.of("rpc.method", AttributeValue.newBuilder().setValue("GetEcho").build()))
+                .build());
+    when(event.getEventName()).thenReturn("Sent.hipstershop.AdService.GetAds");
+    assertEquals(
+        "Sent.hipstershop.AdService.GetAds",
+        spanEventViewGenerator.getRequestUrl(event, Protocol.PROTOCOL_GRPC));
+  }
+
+  @Test
   public void testGetRequestUrl_fullUrlIsAbsent() {
     Event event =
         createMockEventWithAttribute(


### PR DESCRIPTION
## Description
 For RPC methods, we show URL/URI as a combination of `rpc.service` and `rpc.method`. The same information is also available as Span Name - https://github.com/open-telemetry/opentelemetry-specification/blob/3e380e249f60c3a5f68746f5e84d10195ba41a79/specification/trace/semantic_conventions/rpc.md#span-name

It has been observed that spanName is not correctly set on certain scenarios. However, the span contains `rpc.service` and `rpc.method` attribute correctly set. So, as part of this PR, we will first look into RPC attributes if a protocol is grpc, and if those are not present, we will fall back to eventName which is nothing but spanName.

### Testing
Added unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
