### PR TITLE
Fix lag metric for grouper

### DIFF
--- a/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/TraceEmitPunctuator.java
+++ b/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/TraceEmitPunctuator.java
@@ -48,7 +48,7 @@ class TraceEmitPunctuator implements Punctuator {
 
   private static final Logger logger = LoggerFactory.getLogger(TraceEmitPunctuator.class);
   private static final Object mutex = new Object();
-
+]
   private static final Timer spansGrouperArrivalLagTimer =
       PlatformMetricsRegistry.registerTimer(DataflowMetricUtils.ARRIVAL_LAG, new HashMap<>());
   private static final String TRACES_EMITTER_COUNTER = "hypertrace.emitted.traces";
@@ -164,12 +164,14 @@ class TraceEmitPunctuator implements Punctuator {
       }
 
       recordSpansPerTrace(rawSpanList.size(), List.of(Tag.of("tenant_id", tenantId)));
-      Timestamps timestamps =
-          trackEndToEndLatencyTimestamps(timestamp, traceState.getTraceStartTimestamp());
+      Timestamps timestamps = null;
+      if (rawSpanList.size() > 0) {
+        timestamps =
+            trackEndToEndLatencyTimestamps(timestamp, rawSpanList.get(0).getReceivedTimeMillis());
+      }
       StructuredTrace trace =
           StructuredTraceBuilder.buildStructuredTraceFromRawSpans(
               rawSpanList, traceId, tenantId, timestamps);
-
       if (logger.isDebugEnabled()) {
         logger.debug(
             "Emit tenant_id=[{}], trace_id=[{}], spans_count=[{}]",

--- a/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/TraceEmitPunctuator.java
+++ b/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/TraceEmitPunctuator.java
@@ -48,7 +48,7 @@ class TraceEmitPunctuator implements Punctuator {
 
   private static final Logger logger = LoggerFactory.getLogger(TraceEmitPunctuator.class);
   private static final Object mutex = new Object();
-]
+
   private static final Timer spansGrouperArrivalLagTimer =
       PlatformMetricsRegistry.registerTimer(DataflowMetricUtils.ARRIVAL_LAG, new HashMap<>());
   private static final String TRACES_EMITTER_COUNTER = "hypertrace.emitted.traces";


### PR DESCRIPTION
## Description
I see 2 potential  issues with current arrival lag reporting: 

1. original objective on 'arrival.lag'  was to report lag at start of job.  overtime this has been changed it seems, and currently it reports lag when trace is about to be emitted. 
hence we are currently reporting `lag` including the time span spent in rawspangrouper. 

2. another issue is that, we are determining the lag based on `trace start time`  which is set of grouper as currenttime. which does not give the correct value of lag.  as lag represents how much delay as span has faced till now in the data pipeline. 

this PR it trying to address only the 2nd point. as of now. 
