### PR TITLE
feat : add support for handling grpc request url

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,5 +5,5 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: no available replacement
-        expires: 2021-10-31T00:00:00.000Z
+        expires: 2021-12-31T00:00:00.000Z
 patch: {}

--- a/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
+++ b/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
@@ -46,5 +46,5 @@ dependencies {
   // test
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")
-  testImplementation("com.google.code.gson:gson:2.8.7")
+  testImplementation("com.google.code.gson:gson:2.8.9")
 }

--- a/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
+++ b/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-proto:1.6.0-alpha")
 
   // kafka
-  implementation("org.apache.kafka:kafka-clients:2.6.0")
+  implementation("org.apache.kafka:kafka-clients:2.7.2")
 
   // test
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")

--- a/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
+++ b/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-proto:1.6.0-alpha")
 
   constraints {
-    implementation("org.glassfish.jersey.core:jersey-common@2.30") {
+    implementation("org.glassfish.jersey.core:jersey-common@2.34") {
       because("introduced by org.hypertrace.core.kafkastreams.framework:" +
           "kafka-streams-framework@0.1.21 > io.confluent:kafka-streams-avro-serde@6.0.1 > " +
           "io.confluent:kafka-schema-registry-client@6.0.1 > " +

--- a/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
+++ b/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
@@ -36,6 +36,15 @@ dependencies {
   // open telemetry proto
   implementation("io.opentelemetry:opentelemetry-proto:1.6.0-alpha")
 
+  constraints {
+    implementation("org.glassfish.jersey.core:jersey-common@2.30") {
+      because("introduced by org.hypertrace.core.kafkastreams.framework:" +
+          "kafka-streams-framework@0.1.21 > io.confluent:kafka-streams-avro-serde@6.0.1 > " +
+          "io.confluent:kafka-schema-registry-client@6.0.1 > " +
+          "org.glassfish.jersey.core:jersey-common@2.30")
+    }
+  }
+
   // test
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")

--- a/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
+++ b/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-proto:1.6.0-alpha")
 
   constraints {
-    implementation("org.glassfish.jersey.core:jersey-common@2.34") {
+    implementation("org.glassfish.jersey.core:jersey-common:2.34") {
       because("introduced by org.hypertrace.core.kafkastreams.framework:" +
           "kafka-streams-framework@0.1.21 > io.confluent:kafka-streams-avro-serde@6.0.1 > " +
           "io.confluent:kafka-schema-registry-client@6.0.1 > " +

--- a/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
+++ b/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
@@ -21,7 +21,7 @@ protobuf {
   }
   plugins {
     id("grpc_java") {
-      artifact = "io.grpc:protoc-gen-grpc-java:1.41.0"
+      artifact = "io.grpc:protoc-gen-grpc-java:1.42.0"
     }
 
     if (generateLocalGoGrpcFiles) {

--- a/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
+++ b/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
@@ -17,7 +17,7 @@ val generateLocalGoGrpcFiles = false
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.19.1"
+    artifact = "com.google.protobuf:protoc:3.17.3"
   }
   plugins {
     id("grpc_java") {
@@ -63,7 +63,7 @@ sourceSets {
 }
 
 dependencies {
-  api("com.google.protobuf:protobuf-java-util:3.19.1")
+  api("com.google.protobuf:protobuf-java-util:3.17.3")
 
   implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
   implementation(project(":span-normalizer:raw-span-constants"))

--- a/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
+++ b/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
@@ -17,7 +17,7 @@ val generateLocalGoGrpcFiles = false
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.15.7"
+    artifact = "com.google.protobuf:protoc:3.19.1"
   }
   plugins {
     id("grpc_java") {
@@ -63,7 +63,7 @@ sourceSets {
 }
 
 dependencies {
-  api("com.google.protobuf:protobuf-java-util:3.15.7")
+  api("com.google.protobuf:protobuf-java-util:3.19.1")
 
   implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
   implementation(project(":span-normalizer:raw-span-constants"))

--- a/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/EnrichedSpanConstants.java
+++ b/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/EnrichedSpanConstants.java
@@ -15,9 +15,8 @@ public class EnrichedSpanConstants {
   public static final String HEAD_EVENT_ID = "head.event.id";
   public static final String API_EXIT_CALLS_COUNT = "api.exit.calls.count";
   public static final String UNIQUE_API_NODES_COUNT = "unique.apis.count";
-  public static final String GRPC_REQUEST_URL_FORMAT_DOTTED = "grpc.request.url.format.dotted";
-  public static final String GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED =
-      "grpc.request.endpoint.format.dotted";
+  public static final String GRPC_REQUEST_URL = "grpc.request.url";
+  public static final String GRPC_REQUEST_ENDPOINT = "grpc.request.endpoint";
 
   /**
    * Returns the constant value for the given Enum.

--- a/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/EnrichedSpanConstants.java
+++ b/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/EnrichedSpanConstants.java
@@ -15,6 +15,10 @@ public class EnrichedSpanConstants {
   public static final String HEAD_EVENT_ID = "head.event.id";
   public static final String API_EXIT_CALLS_COUNT = "api.exit.calls.count";
   public static final String UNIQUE_API_NODES_COUNT = "unique.apis.count";
+  public static final String GRPC_REQUEST_URL_FORMAT_DOTTED = "grpc.request.url.format.dotted";
+  public static final String GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED =
+      "grpc.request.endpoint.format.dotted";
+
   /**
    * Returns the constant value for the given Enum.
    *

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
@@ -19,9 +19,9 @@ dependencies {
   implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
   implementation("org.hypertrace.entity.service:entity-service-client:0.8.5")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.28")
-  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.1")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.2")
   implementation("org.hypertrace.config.service:spaces-config-service-api:0.1.0")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.1")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.2")
 
   implementation("com.typesafe:config:1.4.1")
   implementation("org.apache.httpcomponents:httpclient:4.5.13")
@@ -33,5 +33,5 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")
-  testImplementation("io.grpc:grpc-core:1.41.0")
+  testImplementation("io.grpc:grpc-core:1.42.0")
 }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/GrpcAttributeEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/GrpcAttributeEnricher.java
@@ -1,7 +1,7 @@
 package org.hypertrace.traceenricher.enrichment.enrichers;
 
-import static org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED;
-import static org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants.GRPC_REQUEST_URL_FORMAT_DOTTED;
+import static org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT;
+import static org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants.GRPC_REQUEST_URL;
 
 import java.util.Optional;
 import org.hypertrace.core.datamodel.Event;
@@ -26,14 +26,12 @@ public class GrpcAttributeEnricher extends AbstractTraceEnricher {
           RpcSemanticConventionUtils.getGrpcRequestEndpoint(event);
       if (grpcRequestEndpoint.isPresent()) {
         addEnrichedAttribute(
-            event,
-            GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED,
-            AttributeValueCreator.create(grpcRequestEndpoint.get()));
+            event, GRPC_REQUEST_ENDPOINT, AttributeValueCreator.create(grpcRequestEndpoint.get()));
 
         String prefix = getPrefix(event);
         addEnrichedAttribute(
             event,
-            GRPC_REQUEST_URL_FORMAT_DOTTED,
+            GRPC_REQUEST_URL,
             AttributeValueCreator.create(prefix.concat(grpcRequestEndpoint.get())));
       }
     }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/GrpcAttributeEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/GrpcAttributeEnricher.java
@@ -1,0 +1,50 @@
+package org.hypertrace.traceenricher.enrichment.enrichers;
+
+import static org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED;
+import static org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants.GRPC_REQUEST_URL_FORMAT_DOTTED;
+
+import java.util.Optional;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;
+import org.hypertrace.semantic.convention.utils.rpc.RpcSemanticConventionUtils;
+import org.hypertrace.traceenricher.enrichedspan.constants.utils.EnrichedSpanUtils;
+import org.hypertrace.traceenricher.enrichedspan.constants.v1.Protocol;
+import org.hypertrace.traceenricher.enrichment.AbstractTraceEnricher;
+
+public class GrpcAttributeEnricher extends AbstractTraceEnricher {
+
+  private static final String GRPC_RECV_DOT = "Recv.";
+  private static final String GRPC_SENT_DOT = "Sent.";
+
+  @Override
+  public void enrichEvent(StructuredTrace trace, Event event) {
+    // if protocol is Grpc update attribute
+    Protocol protocol = EnrichedSpanUtils.getProtocol(event);
+    if (Protocol.PROTOCOL_GRPC == protocol) {
+      Optional<String> grpcRequestEndpoint =
+          RpcSemanticConventionUtils.getGrpcRequestEndpoint(event);
+      if (grpcRequestEndpoint.isPresent()) {
+        addEnrichedAttribute(
+            event,
+            GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED,
+            AttributeValueCreator.create(grpcRequestEndpoint.get()));
+
+        String prefix = getPrefix(event);
+        addEnrichedAttribute(
+            event,
+            GRPC_REQUEST_URL_FORMAT_DOTTED,
+            AttributeValueCreator.create(prefix.concat(grpcRequestEndpoint.get())));
+      }
+    }
+  }
+
+  private String getPrefix(Event event) {
+    if (EnrichedSpanUtils.isEntrySpan(event)) {
+      return GRPC_RECV_DOT;
+    } else if (EnrichedSpanUtils.isExitSpan(event)) {
+      return GRPC_SENT_DOT;
+    }
+    return "";
+  }
+}

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/GrpcAttributeEnricherTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/GrpcAttributeEnricherTest.java
@@ -36,13 +36,11 @@ public class GrpcAttributeEnricherTest extends AbstractAttributeEnricherTest {
     enricher.enrichEvent(mockTrace, e);
 
     String grpcRequestUrl =
-        SpanAttributeUtils.getStringAttribute(
-            e, EnrichedSpanConstants.GRPC_REQUEST_URL_FORMAT_DOTTED);
+        SpanAttributeUtils.getStringAttribute(e, EnrichedSpanConstants.GRPC_REQUEST_URL);
     assertEquals("Recv.TestService.GetEventEchos", grpcRequestUrl);
 
     String grpcRequestEndPoint =
-        SpanAttributeUtils.getStringAttribute(
-            e, EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED);
+        SpanAttributeUtils.getStringAttribute(e, EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT);
     assertEquals("TestService.GetEventEchos", grpcRequestEndPoint);
 
     // case 2: using grpc.path
@@ -57,13 +55,11 @@ public class GrpcAttributeEnricherTest extends AbstractAttributeEnricherTest {
     enricher.enrichEvent(mockTrace, e);
 
     grpcRequestUrl =
-        SpanAttributeUtils.getStringAttribute(
-            e, EnrichedSpanConstants.GRPC_REQUEST_URL_FORMAT_DOTTED);
+        SpanAttributeUtils.getStringAttribute(e, EnrichedSpanConstants.GRPC_REQUEST_URL);
     assertEquals("Recv.TestGrpcService.GetGrpcPathEchos", grpcRequestUrl);
 
     grpcRequestEndPoint =
-        SpanAttributeUtils.getStringAttribute(
-            e, EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED);
+        SpanAttributeUtils.getStringAttribute(e, EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT);
     assertEquals("TestGrpcService.GetGrpcPathEchos", grpcRequestEndPoint);
 
     // case 3: no grpc protocol
@@ -76,13 +72,11 @@ public class GrpcAttributeEnricherTest extends AbstractAttributeEnricherTest {
     enricher.enrichEvent(mockTrace, e);
 
     grpcRequestUrl =
-        SpanAttributeUtils.getStringAttribute(
-            e, EnrichedSpanConstants.GRPC_REQUEST_URL_FORMAT_DOTTED);
+        SpanAttributeUtils.getStringAttribute(e, EnrichedSpanConstants.GRPC_REQUEST_URL);
     assertNull(grpcRequestUrl);
 
     grpcRequestEndPoint =
-        SpanAttributeUtils.getStringAttribute(
-            e, EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED);
+        SpanAttributeUtils.getStringAttribute(e, EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT);
     assertNull(grpcRequestEndPoint);
 
     // case 4: client call - EXIT
@@ -97,13 +91,11 @@ public class GrpcAttributeEnricherTest extends AbstractAttributeEnricherTest {
     enricher.enrichEvent(mockTrace, e);
 
     grpcRequestUrl =
-        SpanAttributeUtils.getStringAttribute(
-            e, EnrichedSpanConstants.GRPC_REQUEST_URL_FORMAT_DOTTED);
+        SpanAttributeUtils.getStringAttribute(e, EnrichedSpanConstants.GRPC_REQUEST_URL);
     assertEquals("Sent.TestGrpcService.GetGrpcPathEchos", grpcRequestUrl);
 
     grpcRequestEndPoint =
-        SpanAttributeUtils.getStringAttribute(
-            e, EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED);
+        SpanAttributeUtils.getStringAttribute(e, EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT);
     assertEquals("TestGrpcService.GetGrpcPathEchos", grpcRequestEndPoint);
 
     // case 5: no entry or exsit span (internal span) - not prefix sent / recv
@@ -116,13 +108,11 @@ public class GrpcAttributeEnricherTest extends AbstractAttributeEnricherTest {
     enricher.enrichEvent(mockTrace, e);
 
     grpcRequestUrl =
-        SpanAttributeUtils.getStringAttribute(
-            e, EnrichedSpanConstants.GRPC_REQUEST_URL_FORMAT_DOTTED);
+        SpanAttributeUtils.getStringAttribute(e, EnrichedSpanConstants.GRPC_REQUEST_URL);
     assertEquals("TestGrpcService.GetGrpcPathEchos", grpcRequestUrl);
 
     grpcRequestEndPoint =
-        SpanAttributeUtils.getStringAttribute(
-            e, EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED);
+        SpanAttributeUtils.getStringAttribute(e, EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT);
     assertEquals("TestGrpcService.GetGrpcPathEchos", grpcRequestEndPoint);
   }
 

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/GrpcAttributeEnricherTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/GrpcAttributeEnricherTest.java
@@ -1,0 +1,135 @@
+package org.hypertrace.traceenricher.enrichment.enrichers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+import org.hypertrace.core.datamodel.AttributeValue;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.core.datamodel.shared.SpanAttributeUtils;
+import org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants;
+import org.hypertrace.traceenricher.enrichedspan.constants.v1.CommonAttribute;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class GrpcAttributeEnricherTest extends AbstractAttributeEnricherTest {
+
+  @Mock private StructuredTrace mockTrace;
+
+  private final GrpcAttributeEnricher enricher = new GrpcAttributeEnricher();
+
+  /*
+   * Covers cases of GrpcAttributeEnricher, the details cases of getGrpcRequestEndpoint
+   * are covered at RpcSemanticConventionUtilsTest
+   * */
+  @Test
+  public void test_withAValidUrl_shouldEnrichHttpPathAndParams() {
+    // case 1: using event name prefixed with Recv
+    Event e = createMockEvent();
+    when(e.getEventName()).thenReturn("Recv.TestService.GetEventEchos");
+    addAttribute(
+        e, EnrichedSpanConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_PROTOCOL), "GRPC");
+    addAttribute(
+        e, EnrichedSpanConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_SPAN_TYPE), "ENTRY");
+
+    enricher.enrichEvent(mockTrace, e);
+
+    String grpcRequestUrl =
+        SpanAttributeUtils.getStringAttribute(
+            e, EnrichedSpanConstants.GRPC_REQUEST_URL_FORMAT_DOTTED);
+    assertEquals("Recv.TestService.GetEventEchos", grpcRequestUrl);
+
+    String grpcRequestEndPoint =
+        SpanAttributeUtils.getStringAttribute(
+            e, EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED);
+    assertEquals("TestService.GetEventEchos", grpcRequestEndPoint);
+
+    // case 2: using grpc.path
+    e = createMockEvent();
+    when(e.getEventName()).thenReturn("TestService.GetEventEchos");
+    addAttribute(
+        e, EnrichedSpanConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_PROTOCOL), "GRPC");
+    addAttribute(
+        e, EnrichedSpanConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_SPAN_TYPE), "ENTRY");
+    addAttribute(e, "grpc.path", "/TestGrpcService/GetGrpcPathEchos");
+
+    enricher.enrichEvent(mockTrace, e);
+
+    grpcRequestUrl =
+        SpanAttributeUtils.getStringAttribute(
+            e, EnrichedSpanConstants.GRPC_REQUEST_URL_FORMAT_DOTTED);
+    assertEquals("Recv.TestGrpcService.GetGrpcPathEchos", grpcRequestUrl);
+
+    grpcRequestEndPoint =
+        SpanAttributeUtils.getStringAttribute(
+            e, EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED);
+    assertEquals("TestGrpcService.GetGrpcPathEchos", grpcRequestEndPoint);
+
+    // case 3: no grpc protocol
+    e = createMockEvent();
+    when(e.getEventName()).thenReturn("TestService.GetEventEchos");
+    addAttribute(
+        e, EnrichedSpanConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_SPAN_TYPE), "ENTRY");
+    addAttribute(e, "grpc.path", "/TestGrpcService/GetGrpcPathEchos");
+
+    enricher.enrichEvent(mockTrace, e);
+
+    grpcRequestUrl =
+        SpanAttributeUtils.getStringAttribute(
+            e, EnrichedSpanConstants.GRPC_REQUEST_URL_FORMAT_DOTTED);
+    assertNull(grpcRequestUrl);
+
+    grpcRequestEndPoint =
+        SpanAttributeUtils.getStringAttribute(
+            e, EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED);
+    assertNull(grpcRequestEndPoint);
+
+    // case 4: client call - EXIT
+    e = createMockEvent();
+    when(e.getEventName()).thenReturn("TestService.GetEventEchos");
+    addAttribute(
+        e, EnrichedSpanConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_PROTOCOL), "GRPC");
+    addAttribute(
+        e, EnrichedSpanConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_SPAN_TYPE), "EXIT");
+    addAttribute(e, "grpc.path", "/TestGrpcService/GetGrpcPathEchos");
+
+    enricher.enrichEvent(mockTrace, e);
+
+    grpcRequestUrl =
+        SpanAttributeUtils.getStringAttribute(
+            e, EnrichedSpanConstants.GRPC_REQUEST_URL_FORMAT_DOTTED);
+    assertEquals("Sent.TestGrpcService.GetGrpcPathEchos", grpcRequestUrl);
+
+    grpcRequestEndPoint =
+        SpanAttributeUtils.getStringAttribute(
+            e, EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED);
+    assertEquals("TestGrpcService.GetGrpcPathEchos", grpcRequestEndPoint);
+
+    // case 5: no entry or exsit span (internal span) - not prefix sent / recv
+    e = createMockEvent();
+    when(e.getEventName()).thenReturn("TestService.GetEventEchos");
+    addAttribute(
+        e, EnrichedSpanConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_PROTOCOL), "GRPC");
+    addAttribute(e, "grpc.path", "/TestGrpcService/GetGrpcPathEchos");
+
+    enricher.enrichEvent(mockTrace, e);
+
+    grpcRequestUrl =
+        SpanAttributeUtils.getStringAttribute(
+            e, EnrichedSpanConstants.GRPC_REQUEST_URL_FORMAT_DOTTED);
+    assertEquals("TestGrpcService.GetGrpcPathEchos", grpcRequestUrl);
+
+    grpcRequestEndPoint =
+        SpanAttributeUtils.getStringAttribute(
+            e, EnrichedSpanConstants.GRPC_REQUEST_ENDPOINT_FORMAT_DOTTED);
+    assertEquals("TestGrpcService.GetGrpcPathEchos", grpcRequestEndPoint);
+  }
+
+  private void addAttribute(Event event, String key, String val) {
+    event
+        .getAttributes()
+        .getAttributeMap()
+        .put(key, AttributeValue.newBuilder().setValue(val).build());
+  }
+}

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/resources/enricher.conf
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/resources/enricher.conf
@@ -56,4 +56,9 @@ enricher {
       port = 50061
     }
   }
+
+  GrpcAttributeEnricher {
+    class = "org.hypertrace.traceenricher.enrichment.enrichers.GrpcAttributeEnricher"
+    dependencies = ["SpanTypeAttributeEnricher", "ApiBoundaryTypeAttributeEnricher"]
+  }
 }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
   }
 
   // Required for the GRPC clients.
-  runtimeOnly("io.grpc:grpc-netty:1.41.0")
+  runtimeOnly("io.grpc:grpc-netty:1.42.0")
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/src/main/resources/configs/common/application.conf
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/src/main/resources/configs/common/application.conf
@@ -24,7 +24,7 @@ kafka.streams.config = {
 }
 
 enricher {
-  names = ["SpanTypeAttributeEnricher", "ApiStatusEnricher", "EndpointEnricher", "TransactionNameEnricher", "ApiBoundaryTypeAttributeEnricher", "ErrorsAndExceptionsEnricher", "BackendEntityEnricher", "HttpAttributeEnricher", "DefaultServiceEntityEnricher", "UserAgentSpanEnricher", "SpaceEnricher", "EntitySpanEnricher", "ExitCallsEnricher", "TraceStatsEnricher"]
+  names = ["SpanTypeAttributeEnricher", "ApiStatusEnricher", "EndpointEnricher", "TransactionNameEnricher", "ApiBoundaryTypeAttributeEnricher", "ErrorsAndExceptionsEnricher", "BackendEntityEnricher", "HttpAttributeEnricher", "DefaultServiceEntityEnricher", "UserAgentSpanEnricher", "SpaceEnricher", "EntitySpanEnricher", "ExitCallsEnricher", "TraceStatsEnricher", "GrpcAttributeEnricher"]
 
   clients = {
       entity.service.config = {
@@ -109,6 +109,11 @@ enricher {
   TraceStatsEnricher {
     class = "org.hypertrace.traceenricher.enrichment.enrichers.TraceStatsEnrichere"
     dependencies = ["EndpointEnricher"]
+  }
+
+  GrpcAttributeEnricher {
+    class = "org.hypertrace.traceenricher.enrichment.enrichers.GrpcAttributeEnricher"
+    dependencies = ["SpanTypeAttributeEnricher", "ApiBoundaryTypeAttributeEnricher"]
   }
 }
 

--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -12,8 +12,8 @@ dependencies {
   api("org.hypertrace.entity.service:entity-data-service-rx-client:0.8.5")
   api("org.hypertrace.core.datamodel:data-model:0.1.20")
   implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.12.3")
-  implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.6.1")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.1")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.6.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.2")
   implementation("io.reactivex.rxjava3:rxjava:3.0.11")
 
   annotationProcessor("org.projectlombok:lombok:1.18.20")

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -44,5 +44,5 @@ dependencies {
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")
-  testImplementation("com.google.code.gson:gson:2.8.7")
+  testImplementation("com.google.code.gson:gson:2.8.9")
 }

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
@@ -15,6 +15,7 @@ import org.hypertrace.core.datamodel.MetricValue;
 import org.hypertrace.core.datamodel.StructuredTrace;
 import org.hypertrace.core.datamodel.shared.SpanAttributeUtils;
 import org.hypertrace.semantic.convention.utils.http.HttpSemanticConventionUtils;
+import org.hypertrace.semantic.convention.utils.rpc.RpcSemanticConventionUtils;
 import org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants;
 import org.hypertrace.traceenricher.enrichedspan.constants.utils.EnrichedSpanUtils;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.Api;
@@ -315,7 +316,15 @@ public class SpanEventViewGenerator extends BaseViewGenerator<SpanEventView> {
             .orElse(HttpSemanticConventionUtils.getHttpPath(event).orElse(null));
 
       case PROTOCOL_GRPC:
-        return event.getEventName();
+        /**
+         * For RPC methods, we show URL/URI as a combination of rpc.service and rpc.method. The same
+         * information is also available as Span Name -
+         * https://github.com/open-telemetry/opentelemetry-specification/blob/3e380e249f60c3a5f68746f5e84d10195ba41a79/specification/trace/semantic_conventions/rpc.md#span-name
+         * So, as part of this method, we will form Url using rpc.service and rpc.method, and
+         * fallback to spanName. While setting GRPC protocol from rpc attributes, it already checks
+         * for rpc.system.
+         */
+        return RpcSemanticConventionUtils.getRpcPath(event).orElse(event.getEventName());
     }
     return null;
   }

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
@@ -318,7 +318,7 @@ public class SpanEventViewGenerator extends BaseViewGenerator<SpanEventView> {
       case PROTOCOL_GRPC:
         return Optional.ofNullable(
                 SpanAttributeUtils.getStringAttribute(
-                    event, EnrichedSpanConstants.GRPC_REQUEST_URL_FORMAT_DOTTED))
+                    event, EnrichedSpanConstants.GRPC_REQUEST_URL))
             .orElse(event.getEventName());
     }
     return null;

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/SpanEventViewGeneratorTest.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/SpanEventViewGeneratorTest.java
@@ -80,6 +80,57 @@ public class SpanEventViewGeneratorTest {
   }
 
   @Test
+  public void test_getRequestUrl_grpcProctol_shouldReturnRpcServiceAndMethod() {
+    Event event = mock(Event.class);
+    when(event.getAttributes())
+        .thenReturn(
+            Attributes.newBuilder()
+                .setAttributeMap(
+                    Map.of(
+                        "rpc.service",
+                        AttributeValue.newBuilder().setValue("hipstershop.AdService").build(),
+                        "rpc.method",
+                        AttributeValue.newBuilder().setValue("GetEcho").build()))
+                .build());
+    when(event.getEventName()).thenReturn("Sent.hipstershop.AdService.GetAds");
+    assertEquals(
+        "hipstershop.AdService.GetEcho",
+        spanEventViewGenerator.getRequestUrl(event, Protocol.PROTOCOL_GRPC));
+  }
+
+  @Test
+  public void test_getRequestUrl_grpcProctol_shouldReturnEventNameIfOnlyRpcService() {
+    Event event = mock(Event.class);
+    when(event.getAttributes())
+        .thenReturn(
+            Attributes.newBuilder()
+                .setAttributeMap(
+                    Map.of(
+                        "rpc.service",
+                        AttributeValue.newBuilder().setValue("hipstershop.AdService").build()))
+                .build());
+    when(event.getEventName()).thenReturn("Sent.hipstershop.AdService.GetAds");
+    assertEquals(
+        "Sent.hipstershop.AdService.GetAds",
+        spanEventViewGenerator.getRequestUrl(event, Protocol.PROTOCOL_GRPC));
+  }
+
+  @Test
+  public void test_getRequestUrl_grpcProctol_shouldReturnEventNameIfOnlyRpcMethod() {
+    Event event = mock(Event.class);
+    when(event.getAttributes())
+        .thenReturn(
+            Attributes.newBuilder()
+                .setAttributeMap(
+                    Map.of("rpc.method", AttributeValue.newBuilder().setValue("GetEcho").build()))
+                .build());
+    when(event.getEventName()).thenReturn("Sent.hipstershop.AdService.GetAds");
+    assertEquals(
+        "Sent.hipstershop.AdService.GetAds",
+        spanEventViewGenerator.getRequestUrl(event, Protocol.PROTOCOL_GRPC));
+  }
+
+  @Test
   public void testGetRequestUrl_fullUrlIsAbsent() {
     Event event =
         createMockEventWithAttribute(

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/SpanEventViewGeneratorTest.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/SpanEventViewGeneratorTest.java
@@ -80,53 +80,19 @@ public class SpanEventViewGeneratorTest {
   }
 
   @Test
-  public void test_getRequestUrl_grpcProctol_shouldReturnRpcServiceAndMethod() {
+  public void test_getRequestUrl_grpcProctol_shouldReturnEnrichedAttribute() {
     Event event = mock(Event.class);
     when(event.getAttributes())
         .thenReturn(
             Attributes.newBuilder()
                 .setAttributeMap(
                     Map.of(
-                        "rpc.service",
-                        AttributeValue.newBuilder().setValue("hipstershop.AdService").build(),
-                        "rpc.method",
-                        AttributeValue.newBuilder().setValue("GetEcho").build()))
+                        "grpc.request.url.format.dotted",
+                        AttributeValue.newBuilder().setValue("Recv.hipstershop.AdService").build()))
                 .build());
     when(event.getEventName()).thenReturn("Sent.hipstershop.AdService.GetAds");
     assertEquals(
-        "hipstershop.AdService.GetEcho",
-        spanEventViewGenerator.getRequestUrl(event, Protocol.PROTOCOL_GRPC));
-  }
-
-  @Test
-  public void test_getRequestUrl_grpcProctol_shouldReturnEventNameIfOnlyRpcService() {
-    Event event = mock(Event.class);
-    when(event.getAttributes())
-        .thenReturn(
-            Attributes.newBuilder()
-                .setAttributeMap(
-                    Map.of(
-                        "rpc.service",
-                        AttributeValue.newBuilder().setValue("hipstershop.AdService").build()))
-                .build());
-    when(event.getEventName()).thenReturn("Sent.hipstershop.AdService.GetAds");
-    assertEquals(
-        "Sent.hipstershop.AdService.GetAds",
-        spanEventViewGenerator.getRequestUrl(event, Protocol.PROTOCOL_GRPC));
-  }
-
-  @Test
-  public void test_getRequestUrl_grpcProctol_shouldReturnEventNameIfOnlyRpcMethod() {
-    Event event = mock(Event.class);
-    when(event.getAttributes())
-        .thenReturn(
-            Attributes.newBuilder()
-                .setAttributeMap(
-                    Map.of("rpc.method", AttributeValue.newBuilder().setValue("GetEcho").build()))
-                .build());
-    when(event.getEventName()).thenReturn("Sent.hipstershop.AdService.GetAds");
-    assertEquals(
-        "Sent.hipstershop.AdService.GetAds",
+        "Recv.hipstershop.AdService",
         spanEventViewGenerator.getRequestUrl(event, Protocol.PROTOCOL_GRPC));
   }
 

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/SpanEventViewGeneratorTest.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/SpanEventViewGeneratorTest.java
@@ -87,7 +87,7 @@ public class SpanEventViewGeneratorTest {
             Attributes.newBuilder()
                 .setAttributeMap(
                     Map.of(
-                        "grpc.request.url.format.dotted",
+                        "grpc.request.url",
                         AttributeValue.newBuilder().setValue("Recv.hipstershop.AdService").build()))
                 .build());
     when(event.getEventName()).thenReturn("Sent.hipstershop.AdService.GetAds");

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -184,8 +184,10 @@ public class HttpSemanticConventionUtils {
    */
   public static Optional<String> getHttpUrlForOTelFormat(
       Map<String, AttributeValue> attributeValueMap) {
-    if (attributeValueMap.containsKey(HTTP_URL.getValue())) {
-      return Optional.of(attributeValueMap.get(HTTP_URL.getValue()).getValue());
+    Optional<String> httpUrlForOTelFormat = Optional.empty();
+    if (attributeValueMap.containsKey(HTTP_URL.getValue())
+        && isAbsoluteUrl(attributeValueMap.get(HTTP_URL.getValue()).getValue())) {
+      httpUrlForOTelFormat = Optional.of(attributeValueMap.get(HTTP_URL.getValue()).getValue());
     } else if (attributeValueMap.containsKey(HTTP_SCHEME.getValue())
         && attributeValueMap.containsKey(HTTP_HOST.getValue())
         && attributeValueMap.containsKey(HTTP_TARGET.getValue())) {
@@ -195,15 +197,19 @@ public class HttpSemanticConventionUtils {
               attributeValueMap.get(HTTP_SCHEME.getValue()).getValue(),
               attributeValueMap.get(HTTP_HOST.getValue()).getValue(),
               attributeValueMap.get(HTTP_TARGET.getValue()).getValue());
-      return Optional.of(url);
+      httpUrlForOTelFormat = Optional.of(url);
     } else if (SpanSemanticConventionUtils.isClientSpanForOtelFormat(attributeValueMap)
         || SpanSemanticConventionUtils.isClientSpanForOCFormat(attributeValueMap)) {
-      return getHttpUrlForOtelFormatClientSpan(attributeValueMap);
+      httpUrlForOTelFormat = getHttpUrlForOtelFormatClientSpan(attributeValueMap);
     } else if (SpanSemanticConventionUtils.isServerSpanForOtelFormat(attributeValueMap)
         || SpanSemanticConventionUtils.isServerSpanForOCFormat(attributeValueMap)) {
-      return getHttpUrlForOtelFormatServerSpan(attributeValueMap);
+      httpUrlForOTelFormat = getHttpUrlForOtelFormatServerSpan(attributeValueMap);
     }
-    return Optional.empty();
+
+    if (httpUrlForOTelFormat.isEmpty() && attributeValueMap.containsKey(HTTP_URL.getValue())) {
+      return Optional.of(attributeValueMap.get(HTTP_URL.getValue()).getValue());
+    }
+    return httpUrlForOTelFormat;
   }
 
   private static Optional<String> getHttpUrlForOtelFormatClientSpan(

--- a/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/rpc/RpcSemanticConventionUtilsTest.java
+++ b/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/rpc/RpcSemanticConventionUtilsTest.java
@@ -911,34 +911,28 @@ class RpcSemanticConventionUtilsTest {
   }
 
   @Test
-  public void testGetGrpcRequestUrl() {
+  public void testGetGrpcRequestEndpoint() {
     Event e = mock(Event.class);
 
     // case 1: event name starts with Sent. prefix
     Attributes attributes =
         buildAttributes(
-            Map.of(
-                "rpc.system", "grpc",
-                "rpc.request.metadata.:path", "/TestGrpcService/getRpcMetadataPathEcho"));
+            Map.of("rpc.request.metadata.:path", "/TestGrpcService/getRpcMetadataPathEcho"));
     when(e.getAttributes()).thenReturn(attributes);
     when(e.getEventName()).thenReturn("Sent.TestService.getEventEchos");
 
     assertEquals(
-        "Sent.TestService.getEventEchos",
-        RpcSemanticConventionUtils.getGrpcRequestUrl(e).get());
+        "TestService.getEventEchos", RpcSemanticConventionUtils.getGrpcRequestEndpoint(e).get());
 
     // case 2: event name starts with Sent. prefix
     attributes =
         buildAttributes(
-            Map.of(
-                "rpc.system", "grpc",
-                "rpc.request.metadata.:path", "/TestGrpcService/getRpcMetadataPathEcho"));
+            Map.of("rpc.request.metadata.:path", "/TestGrpcService/getRpcMetadataPathEcho"));
     when(e.getAttributes()).thenReturn(attributes);
     when(e.getEventName()).thenReturn("Recv.TestService.getEventEchos");
 
     assertEquals(
-        "Recv.TestService.getEventEchos",
-        RpcSemanticConventionUtils.getGrpcRequestUrl(e).get());
+        "TestService.getEventEchos", RpcSemanticConventionUtils.getGrpcRequestEndpoint(e).get());
 
     // case 3: attributes map is empty, fallback to event name
     attributes = buildAttributes(Map.of());
@@ -946,15 +940,13 @@ class RpcSemanticConventionUtilsTest {
     when(e.getEventName()).thenReturn("TestService.getEventEchos");
 
     assertEquals(
-        "TestService.getEventEchos",
-        RpcSemanticConventionUtils.getGrpcRequestUrl(e).get());
+        "TestService.getEventEchos", RpcSemanticConventionUtils.getGrpcRequestEndpoint(e).get());
 
     // case 4: event name doesn't start with req prefix, and rpc.system = grpc,
     // uses rpc.request.metadata.:path
     attributes =
         buildAttributes(
             Map.of(
-                "rpc.system", "grpc",
                 "rpc.request.metadata.:path", "/TestGrpcService/getRpcRequestMetadataPathEcho",
                 "rpc.service", "TestRpcService",
                 "rpc.method", "getRpcMethodEcho",
@@ -965,14 +957,13 @@ class RpcSemanticConventionUtilsTest {
 
     assertEquals(
         "TestGrpcService.getRpcRequestMetadataPathEcho",
-        RpcSemanticConventionUtils.getGrpcRequestUrl(e).get());
+        RpcSemanticConventionUtils.getGrpcRequestEndpoint(e).get());
 
     // case 5: event name doesn't start with req prefix, and rpc.system = grpc,
     // uses rpc.service and rpc.method
     attributes =
         buildAttributes(
             Map.of(
-                "rpc.system", "grpc",
                 "rpc.service", "TestRpcService",
                 "rpc.method", "getRpcMethodEcho",
                 "http.request.header.:path", "/TestHttpGrpcService/getHttpRequestHeaderPathEcho",
@@ -982,14 +973,13 @@ class RpcSemanticConventionUtilsTest {
 
     assertEquals(
         "TestRpcService.getRpcMethodEcho",
-        RpcSemanticConventionUtils.getGrpcRequestUrl(e).get());
+        RpcSemanticConventionUtils.getGrpcRequestEndpoint(e).get());
 
     // case 6: event name doesn't start with req prefix, and rpc.system = grpc,
     // uses http.request.header.:path
     attributes =
         buildAttributes(
             Map.of(
-                "rpc.system", "grpc",
                 "http.request.header.:path", "/TestHttpGrpcService/getHttpRequestHeaderPathEcho",
                 "grpc.path", "/TestGrpcService/getGrpcPathEcho"));
     when(e.getAttributes()).thenReturn(attributes);
@@ -997,35 +987,26 @@ class RpcSemanticConventionUtilsTest {
 
     assertEquals(
         "TestHttpGrpcService.getHttpRequestHeaderPathEcho",
-        RpcSemanticConventionUtils.getGrpcRequestUrl(e).get());
+        RpcSemanticConventionUtils.getGrpcRequestEndpoint(e).get());
 
     // case 7: event name doesn't start with req prefix, and rpc.system = grpc,
     // uses grpc.path
-    attributes =
-        buildAttributes(
-            Map.of(
-                "rpc.system", "grpc",
-                "grpc.path", "/TestGrpcService/getGrpcPathEcho"));
+    attributes = buildAttributes(Map.of("grpc.path", "/TestGrpcService/getGrpcPathEcho"));
     when(e.getAttributes()).thenReturn(attributes);
     when(e.getEventName()).thenReturn("TestService.getEventEchos");
 
     assertEquals(
         "TestGrpcService.getGrpcPathEcho",
-        RpcSemanticConventionUtils.getGrpcRequestUrl(e).get());
+        RpcSemanticConventionUtils.getGrpcRequestEndpoint(e).get());
 
     // case 7: event name doesn't start with req prefix, and rpc.system = grpc,
     // but all fallback attributes are missing, uses eventName
-    attributes =
-        buildAttributes(
-            Map.of(
-                "rpc.system", "grpc"));
+    attributes = buildAttributes(Map.of());
     when(e.getAttributes()).thenReturn(attributes);
     when(e.getEventName()).thenReturn("TestService.getEventEchos");
 
     assertEquals(
-        "TestService.getEventEchos",
-        RpcSemanticConventionUtils.getGrpcRequestUrl(e).get());
-
+        "TestService.getEventEchos", RpcSemanticConventionUtils.getGrpcRequestEndpoint(e).get());
   }
 
   private static Attributes buildAttributes(Map<String, String> attributes) {

--- a/span-normalizer/raw-span-constants/build.gradle.kts
+++ b/span-normalizer/raw-span-constants/build.gradle.kts
@@ -59,4 +59,9 @@ sourceSets {
 dependencies {
   api("com.google.protobuf:protobuf-java-util:3.17.3")
   implementation("org.slf4j:slf4j-api:1.7.30")
+  constraints {
+    implementation("com.google.code.gson:gson:2.8.9") {
+      because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327")
+    }
+  }
 }

--- a/span-normalizer/raw-span-constants/build.gradle.kts
+++ b/span-normalizer/raw-span-constants/build.gradle.kts
@@ -15,7 +15,7 @@ val generateLocalGoGrpcFiles = false
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.15.7"
+    artifact = "com.google.protobuf:protoc:3.19.1"
   }
   plugins {
     id("grpc_java") {
@@ -57,6 +57,6 @@ sourceSets {
 }
 
 dependencies {
-  api("com.google.protobuf:protobuf-java-util:3.15.7")
+  api("com.google.protobuf:protobuf-java-util:3.19.1")
   implementation("org.slf4j:slf4j-api:1.7.30")
 }

--- a/span-normalizer/raw-span-constants/build.gradle.kts
+++ b/span-normalizer/raw-span-constants/build.gradle.kts
@@ -19,7 +19,7 @@ protobuf {
   }
   plugins {
     id("grpc_java") {
-      artifact = "io.grpc:protoc-gen-grpc-java:1.41.0"
+      artifact = "io.grpc:protoc-gen-grpc-java:1.42.0"
     }
 
     if (generateLocalGoGrpcFiles) {

--- a/span-normalizer/raw-span-constants/build.gradle.kts
+++ b/span-normalizer/raw-span-constants/build.gradle.kts
@@ -15,7 +15,7 @@ val generateLocalGoGrpcFiles = false
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.19.1"
+    artifact = "com.google.protobuf:protoc:3.17.3"
   }
   plugins {
     id("grpc_java") {
@@ -57,6 +57,6 @@ sourceSets {
 }
 
 dependencies {
-  api("com.google.protobuf:protobuf-java-util:3.19.1")
+  api("com.google.protobuf:protobuf-java-util:3.17.3")
   implementation("org.slf4j:slf4j-api:1.7.30")
 }

--- a/span-normalizer/raw-span-constants/src/main/proto/org/hypertrace/core/span/constants/v1/span_attribute.proto
+++ b/span-normalizer/raw-span-constants/src/main/proto/org/hypertrace/core/span/constants/v1/span_attribute.proto
@@ -96,6 +96,7 @@ enum Grpc {
     GRPC_METHOD = 10 [(string_value) = "grpc.method"];
     GRPC_REQUEST_BODY_TRUNCATED = 11 [(string_value) = "grpc.request.body.truncated"];
     GRPC_RESPONSE_BODY_TRUNCATED = 12 [(string_value) = "grpc.response.body.truncated"];
+    GRPC_PATH = 13 [(string_value) = "grpc.path"];
 }
 
 // Error related attributes

--- a/span-normalizer/span-normalizer-api/build.gradle.kts
+++ b/span-normalizer/span-normalizer-api/build.gradle.kts
@@ -16,7 +16,7 @@ val generateLocalGoGrpcFiles = false
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.15.7"
+    artifact = "com.google.protobuf:protoc:3.19.1"
   }
   plugins {
     id("grpc_java") {

--- a/span-normalizer/span-normalizer-api/build.gradle.kts
+++ b/span-normalizer/span-normalizer-api/build.gradle.kts
@@ -20,7 +20,7 @@ protobuf {
   }
   plugins {
     id("grpc_java") {
-      artifact = "io.grpc:protoc-gen-grpc-java:1.41.0"
+      artifact = "io.grpc:protoc-gen-grpc-java:1.42.0"
     }
 
     if (generateLocalGoGrpcFiles) {

--- a/span-normalizer/span-normalizer-api/build.gradle.kts
+++ b/span-normalizer/span-normalizer-api/build.gradle.kts
@@ -16,7 +16,7 @@ val generateLocalGoGrpcFiles = false
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.19.1"
+    artifact = "com.google.protobuf:protoc:3.17.3"
   }
   plugins {
     id("grpc_java") {

--- a/span-normalizer/span-normalizer/build.gradle.kts
+++ b/span-normalizer/span-normalizer/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
   implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.21")
 
   // Required for the GRPC clients.
-  runtimeOnly("io.grpc:grpc-netty:1.41.0")
+  runtimeOnly("io.grpc:grpc-netty:1.42.0")
   constraints {
     runtimeOnly("io.netty:netty-codec-http2:4.1.68.Final") {
       because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")


### PR DESCRIPTION
 For RPC span, the span name is equivalent to Endpoint (URL) - https://github.com/open-telemetry/opentelemetry-specification/blob/3e380e249f60c3a5f68746f5e84d10195ba41a79/specification/trace/semantic_conventions/rpc.md#span-name

In cases if the convention is not followed, we would like to extend the platform to handle calc grpc request URL (& Endpoint) using a few other fallback attributes.

Secondly, we also want to enrich the URL based on client  (Sent) or server (Recv) calls.
 
So, This PR,
- add utility method for calc grpc request URL from spanName + fallback attributes
- add GrpcAttribute enricher which adds two new attributes 1) URL 2) Endpoint
- update spanEventView generator to use an enriched attribute for populating grpc request url