### PR TITLE
Fixed the span drop criteria parsing logic

### DIFF
--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanFilter.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanFilter.java
@@ -115,10 +115,8 @@ public class SpanFilter {
   @Nullable
   private Pair<String, String> convertToPair(String s) {
     if (s != null && s.contains(COLON)) {
-      String[] parts = s.split(COLON);
-      if (parts.length == 2) {
-        return Pair.of(parts[0], parts[1]);
-      }
+      int colonIndex = s.indexOf(COLON);
+      return Pair.of(s.substring(0, colonIndex), s.substring(colonIndex + 1));
     }
     return null;
   }


### PR DESCRIPTION
## Description
Fixed the span drop criteria parsing logic which fails if the the tag value has the delimeter(`:`)



### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works


<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
