### PR TITLE
feat: enhance the support for dropping filter

### DIFF
--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
@@ -100,7 +100,7 @@ public class JaegerSpanPreProcessor
 
     String tenantId = maybeTenantId.get();
 
-    if (spanFilter.shouldDropSpan(span, spanTags)) {
+    if (spanFilter.shouldDropSpan(span, spanTags, processTags)) {
       // increment dropped counter at tenant level
       tenantToSpansDroppedCount
           .computeIfAbsent(

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanDropFilter.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanDropFilter.java
@@ -44,4 +44,18 @@ public class SpanDropFilter {
   public String getTagValue() {
     return tagValue;
   }
+
+  @Override
+  public String toString() {
+    return "SpanDropFilter{"
+        + "tagKey='"
+        + tagKey
+        + '\''
+        + ", operator="
+        + operator
+        + ", tagValue='"
+        + tagValue
+        + '\''
+        + '}';
+  }
 }

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanDropFilter.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanDropFilter.java
@@ -1,0 +1,47 @@
+package org.hypertrace.core.spannormalizer.jaeger;
+
+public class SpanDropFilter {
+
+  public static final String TAG_KEY = "tagKey";
+  public static final String OPERATOR = "operator";
+  public static final String TAG_VALUE = "tagValue";
+
+  public enum Operator {
+    EQ("EQ"),
+    NEQ("NEQ"),
+    EXISTS("EXISTS"),
+    CONTAINS("CONTAINS");
+
+    private final String value;
+
+    Operator(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+
+  private String tagKey;
+  private Operator operator;
+  private String tagValue;
+
+  public SpanDropFilter(String tagKey, String operator, String tagValue) {
+    this.tagKey = tagKey;
+    this.operator = Operator.valueOf(operator);
+    this.tagValue = tagValue;
+  }
+
+  public String getTagKey() {
+    return tagKey;
+  }
+
+  public Operator getOperator() {
+    return operator;
+  }
+
+  public String getTagValue() {
+    return tagValue;
+  }
+}

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanFilter.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanFilter.java
@@ -130,7 +130,7 @@ public class SpanFilter {
     }
 
     if (anySpanDropFiltersMatch(spanDropFilters, tags, processTags)) {
-      if (DROPPED_SPANS_RATE_LIMITER.tryAcquire()) {
+      if (LOG.isDebugEnabled() && DROPPED_SPANS_RATE_LIMITER.tryAcquire()) {
         LOG.debug("Dropping span: [{}] with drop filters: [{}]", span, spanDropFilters.toString());
       }
       return true;

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanFilter.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanFilter.java
@@ -1,10 +1,15 @@
 package org.hypertrace.core.spannormalizer.jaeger;
 
+import static org.hypertrace.core.spannormalizer.jaeger.SpanDropFilter.OPERATOR;
+import static org.hypertrace.core.spannormalizer.jaeger.SpanDropFilter.TAG_KEY;
+import static org.hypertrace.core.spannormalizer.jaeger.SpanDropFilter.TAG_VALUE;
+
 import com.google.common.util.concurrent.RateLimiter;
 import com.typesafe.config.Config;
 import io.jaegertracing.api_v2.JaegerSpanInternalModel;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -35,6 +40,8 @@ public class SpanFilter {
    */
   private static final String SPAN_DROP_CRITERION_CONFIG = "processor.spanDropCriterion";
 
+  private static final String SPAN_DROP_FILTERS = "processor.spanDropFilters";
+
   public static final String ROOT_SPAN_DROP_CRITERION_CONFIG =
       "processor.rootExitSpanDropCriterion";
   private static final String ROOT_SPAN_ALWAYS_DROP = "alwaysDrop";
@@ -44,6 +51,8 @@ public class SpanFilter {
   private static final String COLON = ":";
 
   private List<List<Pair<String, String>>> spanDropCriterion = Collections.emptyList();
+  private List<List<SpanDropFilter>> spanDropFilters = Collections.emptyList();
+  ;
   private boolean alwaysDropRootSpan = false;
   private List<List<Pair<String, String>>> rootSpanDropExclusionCriterion = Collections.emptyList();
 
@@ -53,6 +62,26 @@ public class SpanFilter {
       LOG.info("Span drop criterion: {}", criterion);
       // Parse the config to see if there is any criteria to drop spans.
       this.spanDropCriterion = parseStringList(criterion);
+    }
+
+    if (config.hasPath(SPAN_DROP_FILTERS)) {
+      this.spanDropFilters =
+          config.getList(SPAN_DROP_FILTERS).stream()
+              .map(
+                  orFilters -> {
+                    List<HashMap<String, String>> andFilters =
+                        (List<HashMap<String, String>>) orFilters.unwrapped();
+                    return andFilters.stream()
+                        .map(
+                            filter ->
+                                new SpanDropFilter(
+                                    filter.get(TAG_KEY),
+                                    filter.get(OPERATOR),
+                                    filter.get(TAG_VALUE)))
+                        .collect(Collectors.toList());
+                  })
+              .collect(Collectors.toList());
+      LOG.info("Json String for Span drop criterion: {}", this.spanDropFilters);
     }
 
     if (config.hasPath(ROOT_SPAN_DROP_CRITERION_CONFIG)) {
@@ -92,6 +121,13 @@ public class SpanFilter {
     if (anyCriteriaMatch(tags, spanDropCriterion)) {
       if (DROPPED_SPANS_RATE_LIMITER.tryAcquire()) {
         LOG.info("Dropping span: [{}] with drop criterion: [{}]", span, spanDropCriterion);
+      }
+      return true;
+    }
+
+    if (anySpanDropFiltersMatch(spanDropFilters, tags)) {
+      if (DROPPED_SPANS_RATE_LIMITER.tryAcquire()) {
+        LOG.info("Dropping span: [{}] with drop filters: [{}]", span, spanDropFilters);
       }
       return true;
     }
@@ -148,5 +184,33 @@ public class SpanFilter {
     }
 
     return SPAN_KIND_CLIENT.equals(spanKindKeyValue.getVStr());
+  }
+
+  private boolean anySpanDropFiltersMatch(
+      List<List<SpanDropFilter>> spanDropFilters,
+      Map<String, JaegerSpanInternalModel.KeyValue> tags) {
+    return spanDropFilters.stream()
+        .anyMatch(
+            andFilters ->
+                andFilters.stream().allMatch(filter -> matchSpanDropFilter(filter, tags)));
+  }
+
+  private boolean matchSpanDropFilter(
+      SpanDropFilter filter, Map<String, JaegerSpanInternalModel.KeyValue> tags) {
+    switch (filter.getOperator()) {
+      case EQ:
+        return tags.containsKey(filter.getTagKey())
+            && StringUtils.equals(tags.get(filter.getTagKey()).getVStr(), filter.getTagValue());
+      case NEQ:
+        return tags.containsKey(filter.getTagKey())
+            && !StringUtils.equals(tags.get(filter.getTagKey()).getVStr(), filter.getTagValue());
+      case CONTAINS:
+        return tags.containsKey(filter.getTagKey())
+            && StringUtils.contains(tags.get(filter.getTagKey()).getVStr(), filter.getTagValue());
+      case EXISTS:
+        return tags.containsKey(filter.getTagKey());
+      default:
+        return false;
+    }
   }
 }

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanFilter.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanFilter.java
@@ -6,6 +6,7 @@ import static org.hypertrace.core.spannormalizer.jaeger.SpanDropFilter.TAG_VALUE
 
 import com.google.common.util.concurrent.RateLimiter;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigList;
 import io.jaegertracing.api_v2.JaegerSpanInternalModel;
 import java.util.Arrays;
 import java.util.Collections;
@@ -65,8 +66,10 @@ public class SpanFilter {
     }
 
     if (config.hasPath(SPAN_DROP_FILTERS)) {
+      ConfigList spanDropFiltersConfig = config.getList(SPAN_DROP_FILTERS);
+      LOG.info("Span drop filters: {}", spanDropFiltersConfig);
       this.spanDropFilters =
-          config.getList(SPAN_DROP_FILTERS).stream()
+          spanDropFiltersConfig.stream()
               .map(
                   orFilters -> {
                     List<HashMap<String, String>> andFilters =
@@ -81,7 +84,6 @@ public class SpanFilter {
                         .collect(Collectors.toList());
                   })
               .collect(Collectors.toList());
-      LOG.info("Json String for Span drop criterion: {}", this.spanDropFilters);
     }
 
     if (config.hasPath(ROOT_SPAN_DROP_CRITERION_CONFIG)) {
@@ -129,7 +131,7 @@ public class SpanFilter {
 
     if (anySpanDropFiltersMatch(spanDropFilters, tags, processTags)) {
       if (DROPPED_SPANS_RATE_LIMITER.tryAcquire()) {
-        LOG.info("Dropping span: [{}] with drop filters: [{}]", span, spanDropFilters);
+        LOG.debug("Dropping span: [{}] with drop filters: [{}]", span, spanDropFilters);
       }
       return true;
     }

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanFilter.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanFilter.java
@@ -131,7 +131,7 @@ public class SpanFilter {
 
     if (anySpanDropFiltersMatch(spanDropFilters, tags, processTags)) {
       if (DROPPED_SPANS_RATE_LIMITER.tryAcquire()) {
-        LOG.debug("Dropping span: [{}] with drop filters: [{}]", span, spanDropFilters);
+        LOG.debug("Dropping span: [{}] with drop filters: [{}]", span, spanDropFilters.toString());
       }
       return true;
     }

--- a/span-normalizer/span-normalizer/src/test/resources/configs/span-normalizer/application.conf
+++ b/span-normalizer/span-normalizer/src/test/resources/configs/span-normalizer/application.conf
@@ -27,3 +27,27 @@ processor {
   defaultTenantId = "__default"
 }
 
+processor {
+  spanDropFilters = [
+    [
+      {
+        "tagKey": "http.method",
+        "operator": "EQ",
+        "tagValue": "GET"
+      },
+      {
+        "tagKey": "http.url",
+        "operator": "CONTAINS",
+        "tagValue": "health"
+      }
+    ],
+    [
+      {
+        "tagKey": "grpc.url",
+        "operator": "NEQ",
+        "tagValue": "Sent.TestServiceGetEchos"
+      }
+    ]
+  ]
+}
+


### PR DESCRIPTION
## Description
This PR, enhance the support for dropping the span at entry-level. There are certain issues in the existing one.
- It only supports equal operation
- it's not easily readable 
- uses a certain string delimiter making its error-prone

e.g of existing drop filter criteria
`["k1:v1, k2:v2", "k3:v3]`

As we can see, it is supported as an array of strings that are considered as OR expressions. The string supports AND operation via `:`.

New Approach:
- It will be readable JSON structure
- will supports EQ, CONTAINS, EXISTS and NEQ operator

e.g
```
[
	[
		{
			"tagKey": "http.path",
			"operator": "EQ",
			"tagValue": "abcdef"
		},
		{
			"tagKey": "http.url",
			"operator": "CONTAINS",
			"tagValue": "val"
		},
		{
			"tagKey": "grpc.tag",
			"operator": "EXISTS"
		}
	],
	[
		{
		"tagKey": "tenant-id",
		"operator": "EQ",
		"tagValue": "xyz"
		}
	]
]
```

As it can be seen, its array of OR (AND [Filters]) expression.




### Testing
Added unit tests and extended topology test driver test too

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

