### PR TITLE
refactor: moving out avro checks as a separate job

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     branches:
       - main
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request_target:
-    branches: 
+    branches:
       - main
 
 jobs:
@@ -90,8 +90,19 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
 
-      - name: validate avros
-          uses: hypertrace/github-actions/gradle@main
-          with:
-            args: avroCompatibilityCheck
+      - name: create checksum file
+        uses: hypertrace/github-actions/checksum@main
 
+      - name: Cache packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle
+          key: gradle-packages-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/checksum.txt') }}
+          restore-keys: |
+            gradle-packages-${{ runner.os }}-${{ github.job }}
+            gradle-packages-${{ runner.os }}
+
+      - name: validate avros
+        uses: hypertrace/github-actions/gradle@main
+        with:
+          args: avroCompatibilityCheck

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -3,8 +3,8 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
-    branches: 
+  pull_request:
+    branches:
       - main
 
 jobs:
@@ -40,7 +40,7 @@ jobs:
       - name: Build with Gradle
         uses: hypertrace/github-actions/gradle@main
         with: 
-          args: build dockerBuildImages
+          args: build -x avroCompatibilityCheck dockerBuildImages
 
   validate-helm-charts:
     runs-on: ubuntu-20.04
@@ -78,3 +78,20 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           GRADLE_OPTS: -Dorg.gradle.workers.max=1
+
+  validate-avros:
+    runs-on: ubuntu-20.04
+    steps:
+      # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
+      - name: Check out code
+        uses: actions/checkout@v2.3.4
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 0
+
+      - name: validate avros
+          uses: hypertrace/github-actions/gradle@main
+          with:
+            args: avroCompatibilityCheck
+

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request_target:
-    branches:
+    branches: 
       - main
 
 jobs:


### PR DESCRIPTION
This PR, separate out `avroCompatibilityCheck` compatibility check into a different job.
This helps in certain scenarios where we first time adds avro file, and want to skip checks