### PR TITLE
feat: enhance the capping of max spans per trace at global level

### DIFF
--- a/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpanGrouperConstants.java
+++ b/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpanGrouperConstants.java
@@ -14,7 +14,7 @@ public class RawSpanGrouperConstants {
   public static final String DATAFLOW_SAMPLING_PERCENT_CONFIG_KEY =
       "dataflow.metriccollection.sampling.percent";
   public static final String INFLIGHT_TRACE_MAX_SPAN_COUNT = "max.span.count";
-  public static final String UPPER_INFLIGHT_TRACE_MAX_SPAN_COUNT = "upper.max.span.count";
+  public static final String DEFAULT_INFLIGHT_TRACE_MAX_SPAN_COUNT = "default.max.span.count";
   public static final String DROPPED_SPANS_COUNTER = "hypertrace.dropped.spans";
   public static final String TRUNCATED_TRACES_COUNTER = "hypertrace.truncated.traces";
 }

--- a/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpanGrouperConstants.java
+++ b/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpanGrouperConstants.java
@@ -14,6 +14,7 @@ public class RawSpanGrouperConstants {
   public static final String DATAFLOW_SAMPLING_PERCENT_CONFIG_KEY =
       "dataflow.metriccollection.sampling.percent";
   public static final String INFLIGHT_TRACE_MAX_SPAN_COUNT = "max.span.count";
+  public static final String UPPER_INFLIGHT_TRACE_MAX_SPAN_COUNT = "upper.max.span.count";
   public static final String DROPPED_SPANS_COUNTER = "hypertrace.dropped.spans";
   public static final String TRUNCATED_TRACES_COUNTER = "hypertrace.truncated.traces";
 }

--- a/raw-spans-grouper/raw-spans-grouper/src/test/java/org/hypertrace/core/rawspansgrouper/RawSpansGrouperTest.java
+++ b/raw-spans-grouper/raw-spans-grouper/src/test/java/org/hypertrace/core/rawspansgrouper/RawSpansGrouperTest.java
@@ -10,7 +10,6 @@ import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -257,7 +256,8 @@ public class RawSpansGrouperTest {
     trace = (StructuredTrace) outputTopic.readValue();
     assertEquals(5, trace.getEventList().size());
 
-    // input 8 spans of trace-4 for tenant2, as there is global upper limit apply, it will emit only 6
+    // input 8 spans of trace-4 for tenant2, as there is global upper limit apply, it will emit only
+    // 6
     inputTopic.pipeInput(createTraceIdentity(tenant2, "trace-4"), span12);
     inputTopic.pipeInput(createTraceIdentity(tenant2, "trace-4"), span13);
     inputTopic.pipeInput(createTraceIdentity(tenant2, "trace-4"), span14);

--- a/raw-spans-grouper/raw-spans-grouper/src/test/java/org/hypertrace/core/rawspansgrouper/RawSpansGrouperTest.java
+++ b/raw-spans-grouper/raw-spans-grouper/src/test/java/org/hypertrace/core/rawspansgrouper/RawSpansGrouperTest.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -77,6 +78,7 @@ public class RawSpansGrouperTest {
 
     String tenantId = "tenant1";
 
+    // create spans for trace-1 of tenant1
     RawSpan span1 =
         RawSpan.newBuilder()
             .setTraceId(ByteBuffer.wrap("trace-1".getBytes()))
@@ -95,6 +97,8 @@ public class RawSpansGrouperTest {
             .setCustomerId("tenant1")
             .setEvent(createEvent("event-3", "tenant1"))
             .build();
+
+    // create spans for trace-2 of tenant1
     RawSpan span4 =
         RawSpan.newBuilder()
             .setTraceId(ByteBuffer.wrap("trace-2".getBytes()))
@@ -107,6 +111,8 @@ public class RawSpansGrouperTest {
             .setCustomerId("tenant1")
             .setEvent(createEvent("event-5", "tenant1"))
             .build();
+
+    // create spans for trace-3 of tenant1
     RawSpan span6 =
         RawSpan.newBuilder()
             .setTraceId(ByteBuffer.wrap("trace-3".getBytes()))
@@ -142,6 +148,57 @@ public class RawSpansGrouperTest {
             .setTraceId(ByteBuffer.wrap("trace-3".getBytes()))
             .setCustomerId("tenant1")
             .setEvent(createEvent("event-11", "tenant1"))
+            .build();
+
+    // create 8 spans for tenant-2 for trace-4
+    String tenant2 = "tenant2";
+    RawSpan span12 =
+        RawSpan.newBuilder()
+            .setTraceId(ByteBuffer.wrap("trace-4".getBytes()))
+            .setCustomerId(tenant2)
+            .setEvent(createEvent("event-12", tenant2))
+            .build();
+    RawSpan span13 =
+        RawSpan.newBuilder()
+            .setTraceId(ByteBuffer.wrap("trace-4".getBytes()))
+            .setCustomerId(tenant2)
+            .setEvent(createEvent("event-13", tenant2))
+            .build();
+    RawSpan span14 =
+        RawSpan.newBuilder()
+            .setTraceId(ByteBuffer.wrap("trace-4".getBytes()))
+            .setCustomerId(tenant2)
+            .setEvent(createEvent("event-14", tenant2))
+            .build();
+    RawSpan span15 =
+        RawSpan.newBuilder()
+            .setTraceId(ByteBuffer.wrap("trace-4".getBytes()))
+            .setCustomerId(tenant2)
+            .setEvent(createEvent("event-15", tenant2))
+            .build();
+    RawSpan span16 =
+        RawSpan.newBuilder()
+            .setTraceId(ByteBuffer.wrap("trace-4".getBytes()))
+            .setCustomerId(tenant2)
+            .setEvent(createEvent("event-16", tenant2))
+            .build();
+    RawSpan span17 =
+        RawSpan.newBuilder()
+            .setTraceId(ByteBuffer.wrap("trace-4".getBytes()))
+            .setCustomerId(tenant2)
+            .setEvent(createEvent("event-17", tenant2))
+            .build();
+    RawSpan span18 =
+        RawSpan.newBuilder()
+            .setTraceId(ByteBuffer.wrap("trace-4".getBytes()))
+            .setCustomerId(tenant2)
+            .setEvent(createEvent("event-18", tenant2))
+            .build();
+    RawSpan span19 =
+        RawSpan.newBuilder()
+            .setTraceId(ByteBuffer.wrap("trace-4".getBytes()))
+            .setCustomerId(tenant2)
+            .setEvent(createEvent("event-19", tenant2))
             .build();
 
     inputTopic.pipeInput(createTraceIdentity(tenantId, "trace-1"), span1);
@@ -199,6 +256,19 @@ public class RawSpansGrouperTest {
     // trace should be truncated with 5 spans
     trace = (StructuredTrace) outputTopic.readValue();
     assertEquals(5, trace.getEventList().size());
+
+    // input 8 spans of trace-4 for tenant2, as there is global upper limit apply, it will emit only 6
+    inputTopic.pipeInput(createTraceIdentity(tenant2, "trace-4"), span12);
+    inputTopic.pipeInput(createTraceIdentity(tenant2, "trace-4"), span13);
+    inputTopic.pipeInput(createTraceIdentity(tenant2, "trace-4"), span14);
+    inputTopic.pipeInput(createTraceIdentity(tenant2, "trace-4"), span15);
+    inputTopic.pipeInput(createTraceIdentity(tenant2, "trace-4"), span16);
+    inputTopic.pipeInput(createTraceIdentity(tenant2, "trace-4"), span17);
+    inputTopic.pipeInput(createTraceIdentity(tenant2, "trace-4"), span18);
+    inputTopic.pipeInput(createTraceIdentity(tenant2, "trace-4"), span19);
+    td.advanceWallClockTime(Duration.ofSeconds(35));
+    trace = (StructuredTrace) outputTopic.readValue();
+    assertEquals(6, trace.getEventList().size());
   }
 
   private Event createEvent(String eventId, String tenantId) {

--- a/raw-spans-grouper/raw-spans-grouper/src/test/resources/configs/raw-spans-grouper/application.conf
+++ b/raw-spans-grouper/raw-spans-grouper/src/test/resources/configs/raw-spans-grouper/application.conf
@@ -28,6 +28,7 @@ span.window.store.retention.time.mins = ${?SPAN_WINDOW_STORE_RETENTION_TIME_MINS
 span.window.store.segment.size.mins = 20
 span.window.store.segment.size.mins = ${?SPAN_WINDOW_STORE_SEGMENT_SIZE_MINS}
 
+upper.max.span.count = 6
 max.span.count = {
   tenant1 = 5
 }

--- a/raw-spans-grouper/raw-spans-grouper/src/test/resources/configs/raw-spans-grouper/application.conf
+++ b/raw-spans-grouper/raw-spans-grouper/src/test/resources/configs/raw-spans-grouper/application.conf
@@ -28,7 +28,7 @@ span.window.store.retention.time.mins = ${?SPAN_WINDOW_STORE_RETENTION_TIME_MINS
 span.window.store.segment.size.mins = 20
 span.window.store.segment.size.mins = ${?SPAN_WINDOW_STORE_SEGMENT_SIZE_MINS}
 
-upper.max.span.count = 6
+default.max.span.count = 6
 max.span.count = {
   tenant1 = 5
 }


### PR DESCRIPTION
The rawSpanGrouper, stitch the spans into traces. To cap the number of spans per tace, currently, we have config that controls per-tenant level. e.g
```
max.span.count = {
  tenant1 = 5
}
```

As part of this PR, we are enhancing this scheme by adding a global upper limit.  As shown in the below example config, `tenant1` is applying 5 spans/trace limit, but for other tenants (say tenant2), it will apply 6 spans/trace limit.
```
default.max.span.count = 6
max.span.count = {
  tenant1 = 5
}
```
