### PR TITLE
fix: adds support for default max spans limit helm config

### DIFF
--- a/raw-spans-grouper/helm/templates/raw-spans-grouper-config.yaml
+++ b/raw-spans-grouper/helm/templates/raw-spans-grouper-config.yaml
@@ -56,6 +56,10 @@ data:
 
     span.groupby.session.window.interval = {{ .Values.rawSpansGrouperConfig.span.groupby.internal }}
 
+    {{- if hasKey .Values.rawSpansGrouperConfig "defaultMaxSpanCount" }}
+    default.max.span.count = {{ .Values.rawSpansGrouperConfig.defaultMaxSpanCount }}
+    {{- end }}
+
     {{- if hasKey .Values.rawSpansGrouperConfig "maxSpanCount" }}
     max.span.count = {
     {{- range $k, $v := .Values.rawSpansGrouperConfig.maxSpanCount }}

--- a/raw-spans-grouper/helm/values.yaml
+++ b/raw-spans-grouper/helm/values.yaml
@@ -128,8 +128,6 @@ rawSpansGrouperConfig:
     groupby:
       internal: 30
 
-  defaultMaxSpanCount: 1000
-
 logConfig:
   name: raw-spans-grouper-log-config
   monitorInterval: 30

--- a/raw-spans-grouper/helm/values.yaml
+++ b/raw-spans-grouper/helm/values.yaml
@@ -128,6 +128,8 @@ rawSpansGrouperConfig:
     groupby:
       internal: 30
 
+  defaultMaxSpanCount: 1000
+
 logConfig:
   name: raw-spans-grouper-log-config
   monitorInterval: 30

--- a/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpansProcessor.java
+++ b/raw-spans-grouper/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpansProcessor.java
@@ -175,10 +175,9 @@ public class RawSpansProcessor
     long maxSpanCountTenantLimit =
         maxSpanCountMap.containsKey(key.getTenantId())
             ? maxSpanCountMap.get(key.getTenantId())
-            : Long.MAX_VALUE;
+            : defaultMaxSpanCountLimit;
 
-    if (inFlightSpansPerTrace >= defaultMaxSpanCountLimit
-        || inFlightSpansPerTrace >= maxSpanCountTenantLimit) {
+    if (inFlightSpansPerTrace >= maxSpanCountTenantLimit) {
 
       if (logger.isDebugEnabled()) {
         logger.debug(
@@ -199,8 +198,7 @@ public class RawSpansProcessor
           .increment();
 
       // increment the counter when the number of spans reaches the max.span.count limit.
-      if (inFlightSpansPerTrace == defaultMaxSpanCountLimit
-          || inFlightSpansPerTrace == maxSpanCountTenantLimit) {
+      if (inFlightSpansPerTrace == maxSpanCountTenantLimit) {
         truncatedTracesCounter
             .computeIfAbsent(
                 key.getTenantId(),


### PR DESCRIPTION
As described as part of this PR (https://github.com/hypertrace/hypertrace-ingester/pull/290), we have added support for limiting trace size across all tenants.

This PR,
- expose the helm config for `default.max.span.count` 
- address the comments as suggested here of making the config as override than upper limit - https://github.com/hypertrace/hypertrace-ingester/pull/290#discussion_r756209776

