### PR TITLE
chore: extend the helm template for spanDropFilter

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,5 +5,5 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: no available replacement
-        expires: 2021-12-31T00:00:00.000Z
+        expires: 2021-01-31T00:00:00.000Z
 patch: {}

--- a/.snyk
+++ b/.snyk
@@ -5,5 +5,5 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: no available replacement
-        expires: 2021-01-31T00:00:00.000Z
+        expires: 2022-01-31T00:00:00.000Z
 patch: {}

--- a/hypertrace-ingester/build.gradle.kts
+++ b/hypertrace-ingester/build.gradle.kts
@@ -25,9 +25,9 @@ hypertraceDocker {
 }
 
 dependencies {
-  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.21")
-  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.30")
-  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.30")
+  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.23")
+  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.33")
+  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
   implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
   implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.3.9")
   implementation("com.typesafe:config:1.4.1")

--- a/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
+++ b/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
@@ -43,6 +43,15 @@ dependencies {
   // kafka
   implementation("org.apache.kafka:kafka-clients:2.7.2")
 
+  // constrains
+  constraints {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+      because("Denial of Service (DoS) " +
+          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+    }
+  }
+
   // test
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")

--- a/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
+++ b/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
@@ -26,8 +26,8 @@ tasks.test {
 
 dependencies {
   // common and framework
-  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.30")
-  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.30")
+  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.33")
+  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
 
   // open telemetry
   implementation("io.opentelemetry:opentelemetry-sdk-metrics:1.7.0-alpah")

--- a/hypertrace-metrics-generator/hypertrace-metrics-generator/build.gradle.kts
+++ b/hypertrace-metrics-generator/hypertrace-metrics-generator/build.gradle.kts
@@ -28,9 +28,9 @@ dependencies {
   // common and framework
   implementation(project(":hypertrace-metrics-generator:hypertrace-metrics-generator-api"))
   implementation(project(":hypertrace-view-generator:hypertrace-view-generator-api"))
-  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.31")
-  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.31")
-  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.21")
+  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.33")
+  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
+  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.23")
 
   // open telemetry proto
   implementation("io.opentelemetry:opentelemetry-proto:1.6.0-alpha")

--- a/hypertrace-metrics-generator/hypertrace-metrics-generator/build.gradle.kts
+++ b/hypertrace-metrics-generator/hypertrace-metrics-generator/build.gradle.kts
@@ -40,6 +40,11 @@ dependencies {
     implementation("org.glassfish.jersey.core:jersey-common:2.34") {
       because("https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-1255637")
     }
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+      because("Denial of Service (DoS) " +
+          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+    }
   }
 
   // test

--- a/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
+++ b/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
@@ -43,6 +43,11 @@ dependencies {
           "io.confluent:kafka-schema-registry-client@6.0.1 > " +
           "org.glassfish.jersey.core:jersey-common@2.30")
     }
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+      because("Denial of Service (DoS) " +
+          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+    }
   }
 
   // test

--- a/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
+++ b/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
@@ -29,9 +29,9 @@ dependencies {
   implementation(project(":hypertrace-view-generator:hypertrace-view-generator-api"))
 
   // frameworks
-  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.30")
-  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.30")
-  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.21")
+  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.33")
+  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
+  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.23")
 
   // open telemetry proto
   implementation("io.opentelemetry:opentelemetry-proto:1.6.0-alpha")

--- a/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
+++ b/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
@@ -71,6 +71,14 @@ dependencies {
   implementation(project(":semantic-convention-utils"))
   implementation("org.hypertrace.entity.service:entity-service-api:0.8.5")
 
+  constraints {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+      because("Denial of Service (DoS) " +
+          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+    }
+  }
+
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")
 }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/build.gradle.kts
@@ -13,6 +13,15 @@ dependencies {
 
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("org.apache.commons:commons-lang3:3.12.0")
+
+  constraints {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+      because("Denial of Service (DoS) " +
+          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+    }
+  }
+
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.9.0")
   testImplementation("org.mockito:mockito-inline:3.9.0")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
@@ -30,6 +30,14 @@ dependencies {
   implementation("net.sf.uadetector:uadetector-resources:2014.10")
   implementation("io.reactivex.rxjava3:rxjava:3.0.11")
 
+  constraints {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+      because("Denial of Service (DoS) " +
+          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+    }
+  }
+
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 
   implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
   implementation("org.hypertrace.entity.service:entity-service-client:0.8.5")
-  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.28")
+  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.2")
   implementation("org.hypertrace.config.service:spaces-config-service-api:0.1.0")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.2")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -43,6 +43,11 @@ dependencies {
     implementation("org.glassfish.jersey.core:jersey-common:2.34") {
       because("https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-1255637")
     }
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+      because("Denial of Service (DoS) " +
+          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+    }
   }
 
   // Required for the GRPC clients.

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")
-  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.0")
+  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
 
   testImplementation(project(":hypertrace-trace-enricher:hypertrace-trace-enricher"))
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -31,12 +31,12 @@ tasks.test {
 dependencies {
   implementation(project(":hypertrace-trace-enricher:hypertrace-trace-enricher-impl"))
   implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
-  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.30")
-  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.30")
+  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.33")
+  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
   implementation("org.hypertrace.entity.service:entity-service-client:0.8.5")
 
   implementation("com.typesafe:config:1.4.1")
-  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.21")
+  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.23")
   constraints {
     runtimeOnly("io.netty:netty-codec-http2:4.1.71.Final")
     runtimeOnly("io.netty:netty-handler-proxy:4.1.71.Final")

--- a/hypertrace-trace-enricher/hypertrace-trace-visualizer/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-visualizer/build.gradle.kts
@@ -7,6 +7,14 @@ dependencies {
 
   implementation("org.json:json:20210307")
   implementation("org.apache.commons:commons-lang3:3.12.0")
+
+  constraints {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+      because("Denial of Service (DoS) " +
+          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+    }
+  }
 }
 
 description = "Trace Visualizer to help visualize a structured trace."

--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-inline:3.8.0")
   testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")
-  testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.0")
+  testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
 
   tasks.test {
     useJUnitPlatform()

--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -19,6 +19,14 @@ dependencies {
   annotationProcessor("org.projectlombok:lombok:1.18.20")
   compileOnly("org.projectlombok:lombok:1.18.20")
 
+  constraints {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+      because("Denial of Service (DoS) " +
+          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+    }
+  }
+
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-inline:3.8.0")
   testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")

--- a/hypertrace-view-generator/hypertrace-view-creator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-creator/build.gradle.kts
@@ -23,6 +23,11 @@ dependencies {
     implementation("org.apache.calcite:calcite-babel:1.26.0") {
       because("https://snyk.io/vuln/SNYK-JAVA-ORGAPACHECALCITE-1038296")
     }
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+      because("Denial of Service (DoS) " +
+          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+    }
   }
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")

--- a/hypertrace-view-generator/hypertrace-view-creator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-creator/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.test {
 
 dependencies {
   implementation(project(":hypertrace-view-generator:hypertrace-view-generator-api"))
-  implementation("org.hypertrace.core.viewcreator:view-creator-framework:0.3.9")
+  implementation("org.hypertrace.core.viewcreator:view-creator-framework:0.3.10")
   constraints {
     // to have calcite libs on the same version
     implementation("org.apache.calcite:calcite-babel:1.26.0") {
@@ -27,10 +27,6 @@ dependencies {
       because("Denial of Service (DoS) " +
           "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
           "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
-    }
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1") {
-      because("Arbitrary Code Execution [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2327339] " +
-          "in org.apache.logging.log4j:log4j-core@2.17.0")
     }
   }
 

--- a/hypertrace-view-generator/hypertrace-view-creator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-creator/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
           "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
           "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
     }
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl@2.17.1") {
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1") {
       because("Arbitrary Code Execution [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2327339] " +
           "in org.apache.logging.log4j:log4j-core@2.17.0")
     }

--- a/hypertrace-view-generator/hypertrace-view-creator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-creator/build.gradle.kts
@@ -28,6 +28,10 @@ dependencies {
           "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
           "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
     }
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl@2.17.1") {
+      because("Arbitrary Code Execution [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2327339] " +
+          "in org.apache.logging.log4j:log4j-core@2.17.0")
+    }
   }
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")

--- a/hypertrace-view-generator/hypertrace-view-generator-api/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator-api/build.gradle.kts
@@ -17,5 +17,10 @@ dependencies {
     api("org.apache.commons:commons-compress:1.21") {
       because("Multiple vulnerabilities in avro-declared version")
     }
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+      because("Denial of Service (DoS) " +
+          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+    }
   }
 }

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
   implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1")
 
   constraints {
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl@2.17.1") {
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1") {
       because("Arbitrary Code Execution [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2327339] " +
           "in org.apache.logging.log4j:log4j-core@2.17.0")
     }

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -34,13 +34,13 @@ dependencies {
   // TODO: migrate in core
   implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.3.9")
   implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
-  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.26")
+  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
 
   implementation("org.hypertrace.entity.service:entity-service-api:0.8.5")
 
   implementation("org.apache.avro:avro:1.10.2")
   implementation("org.apache.commons:commons-lang3:3.12.0")
-  implementation("com.fasterxml.jackson.core:jackson-databind:2.12.2")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   implementation(project(":semantic-convention-utils"))
 
   // TODO: migrate in core
-  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.3.9")
+  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.3.10")
   implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
 
@@ -41,13 +41,6 @@ dependencies {
   implementation("org.apache.avro:avro:1.10.2")
   implementation("org.apache.commons:commons-lang3:3.12.0")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1")
-
-  constraints {
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1") {
-      because("Arbitrary Code Execution [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2327339] " +
-          "in org.apache.logging.log4j:log4j-core@2.17.0")
-    }
-  }
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -42,6 +42,13 @@ dependencies {
   implementation("org.apache.commons:commons-lang3:3.12.0")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1")
 
+  constraints {
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl@2.17.1") {
+      because("Arbitrary Code Execution [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2327339] " +
+          "in org.apache.logging.log4j:log4j-core@2.17.0")
+    }
+  }
+
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("com.google.code.gson:gson:2.8.9")

--- a/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
+++ b/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
@@ -34,10 +34,10 @@ dependencies {
     }
     implementation(project(":span-normalizer:span-normalizer-api"))
     implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
-    implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.30")
-    implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.30")
+    implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.33")
+    implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
 
-    implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.21")
+    implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.23")
     implementation("com.typesafe:config:1.4.1")
     implementation("de.javakaffee:kryo-serializers:0.45")
     implementation("io.confluent:kafka-avro-serializer:5.5.0")

--- a/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
+++ b/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
 
     // Logging
     implementation("org.slf4j:slf4j-api:1.7.30")
-    runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.0")
+    runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
     testImplementation("org.mockito:mockito-core:3.8.0")

--- a/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
+++ b/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
@@ -47,6 +47,14 @@ dependencies {
     implementation("org.slf4j:slf4j-api:1.7.30")
     runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
 
+    constraints {
+        implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+            because("Denial of Service (DoS) " +
+                "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
+                "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+        }
+    }
+
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
     testImplementation("org.mockito:mockito-core:3.8.0")
     testImplementation("org.junit-pioneer:junit-pioneer:1.3.8")

--- a/semantic-convention-utils/build.gradle.kts
+++ b/semantic-convention-utils/build.gradle.kts
@@ -14,6 +14,14 @@ dependencies {
     implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
     implementation("org.apache.commons:commons-lang3:3.12.0")
 
+    constraints {
+        implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+            because("Denial of Service (DoS) " +
+                "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
+                "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+        }
+    }
+
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
     testImplementation("org.mockito:mockito-core:3.8.0")
 }

--- a/span-normalizer/helm/templates/span-normalizer-config.yaml
+++ b/span-normalizer/helm/templates/span-normalizer-config.yaml
@@ -58,7 +58,7 @@ data:
       {{- end }}
 
       {{- if hasKey .Values.spanNormalizerConfig.processor "spanDropFilters" }}
-      spanDropFilters = {{ .Values.spanNormalizerConfig.processor.spanDropFilters | indent 4 | trim }}
+      spanDropFilters = {{ .Values.spanNormalizerConfig.processor.spanDropFilters | toJson }}
       {{- end }}
 
       {{- if hasKey .Values.spanNormalizerConfig.processor "rootExitSpanDropCriterion" }}

--- a/span-normalizer/helm/templates/span-normalizer-config.yaml
+++ b/span-normalizer/helm/templates/span-normalizer-config.yaml
@@ -57,6 +57,10 @@ data:
       spanDropCriterion = {{ .Values.spanNormalizerConfig.processor.spanDropCriterion | toJson }}
       {{- end }}
 
+      {{- if hasKey .Values.spanNormalizerConfig.processor "spanDropFilters" }}
+      spanDropFilters = {{ .Values.spanNormalizerConfig.processor.spanDropFilters | indent 4 | trim }}
+      {{- end }}
+
       {{- if hasKey .Values.spanNormalizerConfig.processor "rootExitSpanDropCriterion" }}
       rootExitSpanDropCriterion = {{ .Values.spanNormalizerConfig.processor.rootExitSpanDropCriterion | toJson }}
       {{- end }}

--- a/span-normalizer/span-normalizer-api/build.gradle.kts
+++ b/span-normalizer/span-normalizer-api/build.gradle.kts
@@ -62,5 +62,10 @@ dependencies {
     api("org.apache.commons:commons-compress:1.21") {
       because("Multiple vulnerabilities in avro-declared version")
     }
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+      because("Denial of Service (DoS) " +
+          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+    }
   }
 }

--- a/span-normalizer/span-normalizer/build.gradle.kts
+++ b/span-normalizer/span-normalizer/build.gradle.kts
@@ -47,6 +47,11 @@ dependencies {
     implementation("org.glassfish.jersey.core:jersey-common:2.34") {
       because("https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-1255637")
     }
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+      because("Denial of Service (DoS) " +
+          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+    }
   }
 
   implementation("com.typesafe:config:1.4.1")

--- a/span-normalizer/span-normalizer/build.gradle.kts
+++ b/span-normalizer/span-normalizer/build.gradle.kts
@@ -35,9 +35,9 @@ dependencies {
   implementation(project(":semantic-convention-utils"))
 
   implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
-  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.30")
-  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.30")
-  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.21")
+  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.33")
+  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
+  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.23")
 
   // Required for the GRPC clients.
   runtimeOnly("io.grpc:grpc-netty:1.42.0")
@@ -60,7 +60,7 @@ dependencies {
   runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
-  testImplementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.26")
+  testImplementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
   testImplementation("org.junit-pioneer:junit-pioneer:1.3.8")
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("org.apache.kafka:kafka-streams-test-utils:6.0.1-ccs")

--- a/span-normalizer/span-normalizer/build.gradle.kts
+++ b/span-normalizer/span-normalizer/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")
-  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.0")
+  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.26")


### PR DESCRIPTION
This PR makes spanDropFilter configurable via helm tempale.

Tested locally by running `helm template ./helm`

Input into values.yaml file:
```
processor:
    spanDropFilters: |-
      [
        [
          {
            "tagKey": "http.method",
            "operator": "EQ",
            "tagValue": "GET"
          },
          {
            "tagKey": "http.url",
            "operator": "CONTAINS",
            "tagValue": "health"
          }
        ],
        [
          {
            "tagKey": "grpc.url",
            "operator": "NEQ",
            "tagValue": "Sent.TestServiceGetEchos"
          }
        ]
      ]
```

Output:
```
# Source: span-normalizer/templates/span-normalizer-config.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: span-normalizer-config
  labels:
    release: RELEASE-NAME
data:
  application.conf: |-
    kafka.streams.config {
      application.id = jaeger-spans-to-raw-spans-job
      <removed>
    }
    processor {
      spanDropFilters = [
      [
        {
          "tagKey": "http.method",
          "operator": "EQ",
          "tagValue": "GET"
        },
        {
          "tagKey": "http.url",
          "operator": "CONTAINS",
          "tagValue": "health"
        }
      ],
      [
        {
          "tagKey": "grpc.url",
          "operator": "NEQ",
          "tagValue": "Sent.TestServiceGetEchos"
        }
      ]
    ]
    }
---
# Source: span-normalizer/templates/deployment.yaml
```

Test example: https://github.com/hypertrace/hypertrace-ingester/blob/main/span-normalizer/span-normalizer/src/test/resources/configs/span-normalizer/application.conf#L30


