### PR TITLE
Extract protocol from x-forwarded-proto and other headers

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,5 +5,5 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: no available replacement
-        expires: 2022-01-31T00:00:00.000Z
+        expires: 2022-03-31T00:00:00.000Z
 patch: {}

--- a/.snyk
+++ b/.snyk
@@ -6,4 +6,8 @@ ignore:
     - '*':
         reason: no available replacement
         expires: 2022-03-31T00:00:00.000Z
+  SNYK-JAVA-COMGOOGLEPROTOBUF-2331703:
+    - '*':
+        reason: introduced by io.opentelemetry:opentelemetry-proto@1.6.0-alpha
+        expires: 2022-03-31T00:00:00.000Z
 patch: {}

--- a/hypertrace-metrics-generator/hypertrace-metrics-generator-api/build.gradle.kts
+++ b/hypertrace-metrics-generator/hypertrace-metrics-generator-api/build.gradle.kts
@@ -21,7 +21,7 @@ sourceSets {
 }
 
 dependencies {
-  implementation("com.google.protobuf:protobuf-java:3.17.3")
+  implementation("com.google.protobuf:protobuf-java:3.18.2")
   implementation("org.apache.kafka:kafka-clients:6.0.1-ccs")
   implementation("io.opentelemetry:opentelemetry-proto:1.6.0-alpha")
 }

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -89,6 +89,8 @@ public class HttpSemanticConventionUtils {
 
   private static final String SLASH = "/";
 
+  private static final String HTTP_REQUEST_FORWARDED_ATTRIBUTE = HTTP_REQUEST_FORWARDED.getValue();
+
   private static final List<String> USER_AGENT_ATTRIBUTES =
       List.of(
           RawSpanConstants.getValue(HTTP_USER_DOT_AGENT),
@@ -435,7 +437,7 @@ public class HttpSemanticConventionUtils {
     // dealing with the Forwarded header separately as it may have
     // more info than just the protocol
     AttributeValue httpRequestForwardedAttributeValue =
-        attributeValueMap.get(HTTP_REQUEST_FORWARDED.getValue());
+        attributeValueMap.get(HTTP_REQUEST_FORWARDED_ATTRIBUTE);
     if (httpRequestForwardedAttributeValue != null
         && !StringUtils.isEmpty(httpRequestForwardedAttributeValue.getValue())) {
       String schemeValue = httpRequestForwardedAttributeValue.getValue();

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -434,10 +434,11 @@ public class HttpSemanticConventionUtils {
       Map<String, AttributeValue> attributeValueMap) {
     // dealing with the Forwarded header separately as it may have
     // more info than just the protocol
-    if (attributeValueMap.get(HTTP_REQUEST_FORWARDED.getValue()) != null
-        && !StringUtils.isEmpty(
-            attributeValueMap.get(HTTP_REQUEST_FORWARDED.getValue()).getValue())) {
-      String schemeValue = attributeValueMap.get(HTTP_REQUEST_FORWARDED.getValue()).getValue();
+    AttributeValue httpRequestForwardedAttributeValue =
+        attributeValueMap.get(HTTP_REQUEST_FORWARDED.getValue());
+    if (httpRequestForwardedAttributeValue != null
+        && !StringUtils.isEmpty(httpRequestForwardedAttributeValue.getValue())) {
+      String schemeValue = httpRequestForwardedAttributeValue.getValue();
       Optional<String> optionalExtractedProtoValue = getProtocolFromForwarded(schemeValue);
       if (optionalExtractedProtoValue.isPresent()) {
         return optionalExtractedProtoValue;

--- a/span-normalizer/raw-span-constants/build.gradle.kts
+++ b/span-normalizer/raw-span-constants/build.gradle.kts
@@ -57,7 +57,7 @@ sourceSets {
 }
 
 dependencies {
-  api("com.google.protobuf:protobuf-java-util:3.17.3")
+  api("com.google.protobuf:protobuf-java-util:3.18.2")
   implementation("org.slf4j:slf4j-api:1.7.30")
   constraints {
     implementation("com.google.code.gson:gson:2.8.9") {

--- a/span-normalizer/span-normalizer-api/build.gradle.kts
+++ b/span-normalizer/span-normalizer-api/build.gradle.kts
@@ -56,7 +56,7 @@ sourceSets {
   }
 }
 dependencies {
-  api("com.google.api.grpc:proto-google-common-protos:2.1.0")
+  api("com.google.api.grpc:proto-google-common-protos:2.7.1")
   api("org.apache.avro:avro:1.10.2")
   constraints {
     api("org.apache.commons:commons-compress:1.21") {

--- a/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/http/HttpSemanticConventions.java
+++ b/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/http/HttpSemanticConventions.java
@@ -1,0 +1,17 @@
+package org.hypertrace.core.semantic.convention.constants.http;
+
+/** Request forwarded specific attributes for Http */
+public enum HttpSemanticConventions {
+  HTTP_REQUEST_X_FORWARDED_PROTO("http.request.header.x-forwarded-proto"),
+  HTTP_REQUEST_FORWARDED("http.request.header.forwarded");
+
+  private final String value;
+
+  HttpSemanticConventions(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+}

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java
@@ -461,7 +461,8 @@ public class HttpFieldsGenerator extends ProtocolFieldsGenerator<Http.Builder> {
     // more info than just the protocol
     if (optionalScheme.isPresent()) {
       optionalScheme = getProtocolFromForwarded(optionalScheme.get());
-    } else {
+    }
+    if (optionalScheme.isEmpty()) {
       optionalScheme =
           FirstMatchingKeyFinder.getStringValueByFirstMatchingKey(
               tagsMap,

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java
@@ -79,6 +79,9 @@ public class HttpFieldsGenerator extends ProtocolFieldsGenerator<Http.Builder> {
   private static final String RESPONSE_COOKIE_PREFIX =
       RawSpanConstants.getValue(HTTP_RESPONSE_COOKIE) + DOT;
   private static final String SLASH = "/";
+  private static final String HTTP_REQUEST_X_FORWARDED_PROTO =
+      "http.request.header.x-forwarded-proto";
+  private static final String HTTP_REQUEST_FORWARDED = "http.request.header.forwarded";
 
   private static final List<String> FULL_URL_ATTRIBUTES =
       List.of(
@@ -302,8 +305,7 @@ public class HttpFieldsGenerator extends ProtocolFieldsGenerator<Http.Builder> {
     // set scheme if specified
     fieldGeneratorMap.put(
         OTelHttpSemanticConventions.HTTP_SCHEME.getValue(),
-        (key, keyValue, builder, tagsMap) ->
-            builder.getRequestBuilder().setScheme(keyValue.getVStr()));
+        (key, keyValue, builder, tagsMap) -> setScheme(builder, tagsMap));
 
     // User Agent handlers
     fieldGeneratorMap.put(
@@ -448,6 +450,38 @@ public class HttpFieldsGenerator extends ProtocolFieldsGenerator<Http.Builder> {
             // populateUrlParts method
             s -> !StringUtils.isBlank(s) && isValidUrl(s))
         .ifPresent(url -> httpBuilder.getRequestBuilder().setUrl(url));
+  }
+
+  private static void setScheme(
+      Http.Builder httpBuilder, Map<String, JaegerSpanInternalModel.KeyValue> tagsMap) {
+    Optional<String> optionalScheme =
+        FirstMatchingKeyFinder.getStringValueByFirstMatchingKey(
+            tagsMap, List.of(HTTP_REQUEST_FORWARDED), s -> !StringUtils.isBlank(s));
+    // dealing with the Forwarded header separately as it may have
+    // more info than just the protocol
+    if (optionalScheme.isPresent()) {
+      optionalScheme = getProtocolFromForwarded(optionalScheme.get());
+    } else {
+      optionalScheme =
+          FirstMatchingKeyFinder.getStringValueByFirstMatchingKey(
+              tagsMap,
+              List.of(
+                  HTTP_REQUEST_X_FORWARDED_PROTO,
+                  OTelHttpSemanticConventions.HTTP_SCHEME.getValue()),
+              s -> !StringUtils.isBlank(s));
+    }
+    optionalScheme.ifPresent(s -> httpBuilder.getRequestBuilder().setScheme(s));
+  }
+
+  private static Optional<String> getProtocolFromForwarded(String body) {
+    String forwardedInfo[] = body.split(";");
+    for (String info : forwardedInfo) {
+      String subInfo[] = info.split("=");
+      if (subInfo[0] == "proto") {
+        return Optional.of(subInfo[1]);
+      }
+    }
+    return Optional.empty();
   }
 
   private static void setMethod(


### PR DESCRIPTION
In scenarios where a client connects to a LB/Proxy and a downstream server receives it the http.scheme span attribute will contain the protocol b/w the proxy and server and not the actual protocol b/w client and proxy. In such scenarios we should enrich the http.scheme attribute by first checking for presence of x-forwarded-proto and other forwarded headers and then proceed with the usual logic.
