### PR TITLE
chore: adding late event timer metrics

### DIFF
--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -64,8 +64,8 @@ public class JaegerSpanNormalizer {
   private final JaegerResourceNormalizer resourceNormalizer = new JaegerResourceNormalizer();
   private final TenantIdHandler tenantIdHandler;
 
-  // measure the span's start time and its processing time
-  private static final String DELAY_IN_SPAN_PROCESSED_TIME_METRIC = "span.processed.delay.time";
+  // measure the difference between span's start time and its processing tim
+  private static final String SPAN_PROCESSING_DELAY_TIME_METRIC = "span.processing.delay.time";
   private final ConcurrentMap<String, Timer> tenantToDelayInSpanProcessedTimer =
       new ConcurrentHashMap<>();
 
@@ -138,13 +138,13 @@ public class JaegerSpanNormalizer {
       }
 
       // register and update timer per tenant
-      // its uses absolute value to take care if any clock skewness too.
+      // it uses absolute value to take care of any clock skewness too.
       tenantToDelayInSpanProcessedTimer
           .computeIfAbsent(
               tenantId,
               tenant ->
                   PlatformMetricsRegistry.registerTimer(
-                      DELAY_IN_SPAN_PROCESSED_TIME_METRIC, Map.of("tenantId", tenant), true))
+                      SPAN_PROCESSING_DELAY_TIME_METRIC, Map.of("tenantId", tenant), true))
           .record(Math.abs(spanProcessedTime - spanStartTime), TimeUnit.MILLISECONDS);
       return rawSpan;
     };

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -65,8 +65,8 @@ public class JaegerSpanNormalizer {
   private final TenantIdHandler tenantIdHandler;
 
   // measure the difference between span's start time and its processing time
-  private static final String SPAN_PROCESSING_DELAY_TIME_METRIC = "span.processing.delay.time";
-  private final ConcurrentMap<String, Timer> tenantToDelayInSpanProcessedTimer =
+  private static final String SPAN_ARRIVAL_DELAY = "span.arrival.delay";
+  private final ConcurrentMap<String, Timer> tenantToSpanArrivalDelayTimer =
       new ConcurrentHashMap<>();
 
   public static JaegerSpanNormalizer get(Config config) {
@@ -88,8 +88,8 @@ public class JaegerSpanNormalizer {
     return tenantToSpanNormalizationTimer.get(tenantId);
   }
 
-  public Timer getDelayInSpanProcessedTimer(String tenantId) {
-    return tenantToDelayInSpanProcessedTimer.get(tenantId);
+  public Timer getSpanArrivalDelayTimer(String tenantId) {
+    return tenantToSpanArrivalDelayTimer.get(tenantId);
   }
 
   @Nullable
@@ -139,12 +139,12 @@ public class JaegerSpanNormalizer {
 
       // register and update timer per tenant
       // it uses absolute value to take care of any clock skewness too.
-      tenantToDelayInSpanProcessedTimer
+      tenantToSpanArrivalDelayTimer
           .computeIfAbsent(
               tenantId,
               tenant ->
                   PlatformMetricsRegistry.registerTimer(
-                      SPAN_PROCESSING_DELAY_TIME_METRIC, Map.of("tenantId", tenant)))
+                      SPAN_ARRIVAL_DELAY, Map.of("tenantId", tenant)))
           .record(Math.abs(spanProcessedTime - spanStartTime), TimeUnit.MILLISECONDS);
       return rawSpan;
     };

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -64,7 +64,7 @@ public class JaegerSpanNormalizer {
   private final JaegerResourceNormalizer resourceNormalizer = new JaegerResourceNormalizer();
   private final TenantIdHandler tenantIdHandler;
 
-  // measure the difference between span's start time and its processing tim
+  // measure the difference between span's start time and its processing time
   private static final String SPAN_PROCESSING_DELAY_TIME_METRIC = "span.processing.delay.time";
   private final ConcurrentMap<String, Timer> tenantToDelayInSpanProcessedTimer =
       new ConcurrentHashMap<>();

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -88,7 +88,7 @@ public class JaegerSpanNormalizer {
     return tenantToSpanNormalizationTimer.get(tenantId);
   }
 
-  public Timer getSpanDelayInSpanProcessedTimer(String tenantId) {
+  public Timer getDelayInSpanProcessedTimer(String tenantId) {
     return tenantToDelayInSpanProcessedTimer.get(tenantId);
   }
 

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -138,14 +138,14 @@ public class JaegerSpanNormalizer {
       }
 
       // register and update timer per tenant
+      // its uses absolute value to take care if any clock skewness too.
       tenantToDelayInSpanProcessedTimer
           .computeIfAbsent(
               tenantId,
               tenant ->
                   PlatformMetricsRegistry.registerTimer(
                       DELAY_IN_SPAN_PROCESSED_TIME_METRIC, Map.of("tenantId", tenant), true))
-          .record(spanProcessedTime - spanStartTime, TimeUnit.MILLISECONDS);
-
+          .record(Math.abs(spanProcessedTime - spanStartTime), TimeUnit.MILLISECONDS);
       return rawSpan;
     };
   }

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -144,7 +144,7 @@ public class JaegerSpanNormalizer {
               tenantId,
               tenant ->
                   PlatformMetricsRegistry.registerTimer(
-                      SPAN_PROCESSING_DELAY_TIME_METRIC, Map.of("tenantId", tenant), true))
+                      SPAN_PROCESSING_DELAY_TIME_METRIC, Map.of("tenantId", tenant)))
           .record(Math.abs(spanProcessedTime - spanStartTime), TimeUnit.MILLISECONDS);
       return rawSpan;
     };

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
@@ -112,6 +112,8 @@ public class JaegerSpanPreProcessor
       return null;
     }
 
+    // should drop late span
+
     return new PreProcessedSpan(tenantId, span);
   }
 

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
@@ -219,6 +219,12 @@ public class JaegerSpanNormalizerTest {
 
     // Assert that metrics are collected.
     Assertions.assertEquals(1, timer.count());
+
+    Timer timer1 = normalizer.getSpanDelayInSpanProcessedTimer(tenantId);
+    Assertions.assertNotNull(timer1);
+
+    // Assert that metrics are collected.
+    Assertions.assertEquals(1, timer1.count());
   }
 
   @Test

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
@@ -220,7 +220,7 @@ public class JaegerSpanNormalizerTest {
     // Assert that metrics are collected.
     Assertions.assertEquals(1, timer.count());
 
-    Timer timer1 = normalizer.getSpanDelayInSpanProcessedTimer(tenantId);
+    Timer timer1 = normalizer.getDelayInSpanProcessedTimer(tenantId);
     Assertions.assertNotNull(timer1);
 
     // Assert that metrics are collected.

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
@@ -220,7 +220,7 @@ public class JaegerSpanNormalizerTest {
     // Assert that metrics are collected.
     Assertions.assertEquals(1, timer.count());
 
-    Timer timer1 = normalizer.getDelayInSpanProcessedTimer(tenantId);
+    Timer timer1 = normalizer.getSpanArrivalDelayTimer(tenantId);
     Assertions.assertNotNull(timer1);
 
     // Assert that metrics are collected.


### PR DESCRIPTION
## Description
There are cases when we would like to if the event arrived late or not. As part of this PR, it added the metrics to measure that.
So, the metric `span.processed.delay.time` measure the different of current time to span start_time.



### Testing
Added basic unit test

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

