### PR TITLE
chore: convert logging from info to debug message for span drop criteria

### DIFF
--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanFilter.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanFilter.java
@@ -123,8 +123,8 @@ public class SpanFilter {
       Map<String, JaegerSpanInternalModel.KeyValue> tags,
       Map<String, JaegerSpanInternalModel.KeyValue> processTags) {
     if (anyCriteriaMatch(tags, spanDropCriterion)) {
-      if (DROPPED_SPANS_RATE_LIMITER.tryAcquire()) {
-        LOG.info("Dropping span: [{}] with drop criterion: [{}]", span, spanDropCriterion);
+      if (LOG.isDebugEnabled() && DROPPED_SPANS_RATE_LIMITER.tryAcquire()) {
+        LOG.debug("Dropping span: [{}] with drop criterion: [{}]", span, spanDropCriterion);
       }
       return true;
     }


### PR DESCRIPTION
As part of this PR,
- reducing the logging level to debug if we drop the span
- we already have dropped span counter for the same