### PR TITLE
fix: incorrect usage of metrics hashmap for late arrival counter

### DIFF
--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
@@ -35,6 +35,8 @@ public class JaegerSpanPreProcessor
       new ConcurrentHashMap<>();
   private static final ConcurrentMap<String, Counter> tenantToSpansDroppedCount =
       new ConcurrentHashMap<>();
+  private static final ConcurrentMap<String, Counter> tenantToLateArrivalSpansDroppedCount =
+      new ConcurrentHashMap<>();
   private static final Duration minArrivalThreshold = Duration.of(30, ChronoUnit.SECONDS);
   private TenantIdHandler tenantIdHandler;
   private SpanFilter spanFilter;
@@ -138,7 +140,7 @@ public class JaegerSpanPreProcessor
         Duration.of(Math.abs(spanProcessedTime - spanStartTime), ChronoUnit.MILLIS);
 
     if (spanStartTime > 0 && spanArrivalDelay.compareTo(lateArrivalThresholdDuration) > 0) {
-      tenantToSpansDroppedCount
+      tenantToLateArrivalSpansDroppedCount
           .computeIfAbsent(
               tenantId,
               tenant ->


### PR DESCRIPTION
As part of my previous PR - https://github.com/hypertrace/hypertrace-ingester/pull/306, made the mistake of using the existing regular dropped counter map for registering new metrics for later arrival span.  This was causing the issue of not reporting metrics.

Fixing it as part of this PR.