### PR TITLE
feat: adds support for filtering of un-used tags

### DIFF
--- a/span-normalizer/helm/templates/span-normalizer-config.yaml
+++ b/span-normalizer/helm/templates/span-normalizer-config.yaml
@@ -69,8 +69,12 @@ data:
       late.arrival.threshold.duration = "{{ .Values.spanNormalizerConfig.processor.lateArrivalThresholdDuration }}"
       {{- end }}
 
-      {{- if hasKey .Values.spanNormalizerConfig.processor "allowedExtensionAttributes" }}
-      allowed.extension.attributes = {{ .Values.spanNormalizerConfig.processor.allowedExtensionAttributes | toJson }}
+      {{- if hasKey .Values.spanNormalizerConfig.processor "allowedAttributesPrefixes" }}
+      allowed.attributes.prefixes = {{ .Values.spanNormalizerConfig.processor.allowedAttributesPrefixes | toJson }}
+      {{- end }}
+
+      {{- if hasKey .Values.spanNormalizerConfig.processor "prefixedMatchedAllowedAttributes" }}
+      prefixed.matched.allowed.attributes = {{ .Values.spanNormalizerConfig.processor.prefixedMatchedAllowedAttributes | toJson }}
       {{- end }}
 
       {{- if hasKey .Values.spanNormalizerConfig.processor "rootExitSpanDropCriterion" }}

--- a/span-normalizer/helm/templates/span-normalizer-config.yaml
+++ b/span-normalizer/helm/templates/span-normalizer-config.yaml
@@ -69,6 +69,10 @@ data:
       late.arrival.threshold.duration = "{{ .Values.spanNormalizerConfig.processor.lateArrivalThresholdDuration }}"
       {{- end }}
 
+      {{- if hasKey .Values.spanNormalizerConfig.processor "allowedExtensionAttributes" }}
+      allowed.extension.attributes = {{ .Values.spanNormalizerConfig.processor.allowedExtensionAttributes | toJson }}
+      {{- end }}
+
       {{- if hasKey .Values.spanNormalizerConfig.processor "rootExitSpanDropCriterion" }}
       rootExitSpanDropCriterion = {{ .Values.spanNormalizerConfig.processor.rootExitSpanDropCriterion | toJson }}
       {{- end }}

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
@@ -157,7 +157,7 @@ public class JaegerSpanPreProcessor
     }
 
     // filter tags
-    Span processedSpan = tagsFilter.apply(span);
+    Span processedSpan = tagsFilter.apply(tenantId, span);
     return new PreProcessedSpan(tenantId, processedSpan);
   }
 

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/TagsFilter.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/TagsFilter.java
@@ -1,0 +1,61 @@
+package org.hypertrace.core.spannormalizer.jaeger;
+
+import com.google.common.util.concurrent.RateLimiter;
+import com.typesafe.config.Config;
+import io.jaegertracing.api_v2.JaegerSpanInternalModel.KeyValue;
+import io.jaegertracing.api_v2.JaegerSpanInternalModel.Span;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TagsFilter {
+  private static final Logger LOG = LoggerFactory.getLogger(TagsFilter.class);
+  private static final RateLimiter DROPPED_TAGS_LIMITER = RateLimiter.create(0.001);
+
+  private static final String ALLOWED_ATTRIBUTES_PREFIXES_CONFIG_KEY =
+      "processor.allowed.attributes.prefixes";
+  private static final String ALLOWED_ATTRIBUTES_CONFIG_KEY =
+      "processor.prefixed.matched.allowed.attributes";
+
+  private Set<String> allowedAttributesPrefixes = new TreeSet<>();
+  private Set<String> prefixedMatchedAllowedAttributes = new TreeSet<>();
+
+  public TagsFilter(Config config) {
+    if (config.hasPath(ALLOWED_ATTRIBUTES_PREFIXES_CONFIG_KEY)) {
+      config
+          .getStringList(ALLOWED_ATTRIBUTES_PREFIXES_CONFIG_KEY)
+          .forEach(e -> allowedAttributesPrefixes.add(e.toLowerCase()));
+    }
+
+    if (config.hasPath(ALLOWED_ATTRIBUTES_CONFIG_KEY)) {
+      config
+          .getStringList(ALLOWED_ATTRIBUTES_CONFIG_KEY)
+          .forEach(e -> prefixedMatchedAllowedAttributes.add(e.toLowerCase()));
+    }
+  }
+
+  public Span apply(Span span) {
+    if (allowedAttributesPrefixes.isEmpty() || prefixedMatchedAllowedAttributes.isEmpty())
+      return span;
+    // remove extension attributes (x-) if they are not in allowedExtensionAttributes
+    // and starts with http(s).request.header or http(s).response.header
+    List<KeyValue> updatedTags =
+        span.getTagsList().stream()
+            .filter(
+                keyValue -> {
+                  String keyInLowerCase = keyValue.getKey().toLowerCase();
+                  String matched =
+                      allowedAttributesPrefixes.stream()
+                          .filter(prefix -> keyInLowerCase.startsWith(prefix))
+                          .findFirst()
+                          .orElse(null);
+                  return (matched == null
+                      || prefixedMatchedAllowedAttributes.contains(keyInLowerCase));
+                })
+            .collect(Collectors.toList());
+    return Span.newBuilder(span).clearTags().addAllTags(updatedTags).build();
+  }
+}

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/TagsFilter.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/TagsFilter.java
@@ -4,10 +4,15 @@ import com.google.common.util.concurrent.RateLimiter;
 import com.typesafe.config.Config;
 import io.jaegertracing.api_v2.JaegerSpanInternalModel.KeyValue;
 import io.jaegertracing.api_v2.JaegerSpanInternalModel.Span;
+import io.micrometer.core.instrument.DistributionSummary;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,6 +28,13 @@ public class TagsFilter {
   private Set<String> allowedAttributesPrefixes = new TreeSet<>();
   private Set<String> prefixedMatchedAllowedAttributes = new TreeSet<>();
 
+  private static final String TAGS_BYTES = "hypertrace.span.tags.bytes";
+  private static final String TAGS_PROCESSED_BYTES = "hypertrace.span.tags.processed.bytes";
+  private static final ConcurrentMap<String, DistributionSummary> tenantToTagsTotalSize =
+      new ConcurrentHashMap<>();
+  private static final ConcurrentMap<String, DistributionSummary> tenantToTagsProcessedSize =
+      new ConcurrentHashMap<>();
+
   public TagsFilter(Config config) {
     if (config.hasPath(ALLOWED_ATTRIBUTES_PREFIXES_CONFIG_KEY)) {
       config
@@ -37,25 +49,88 @@ public class TagsFilter {
     }
   }
 
-  public Span apply(Span span) {
+  /**
+   * Filter out the tags based on prefix matched configuration. allowedAttributesPrefixes: List of
+   * prefix keys that are consider as subsets prefixedMatchedAllowedAttributes : allowed keys from
+   * the prefixed matched subset.
+   *
+   * <p>e.g if, we want to drop all the http request extension attributes except few one
+   * allowedAttributesPrefixes = ["http.request.header.x-"] prefixedMatchedAllowedAttributes =
+   * ["http.request.header.x-tenant-id"]
+   *
+   * <p>Based on above configuration, from all the keys that starts with "http.request.header.x-",
+   * it will retains on "http.request.header.x-tenant-id". However, this will not impact any other
+   * tags which don't start with the prefix. So, keys like "http.method" will all be retain.
+   */
+  public Span apply(String tenantId, Span span) {
     if (allowedAttributesPrefixes.isEmpty() || prefixedMatchedAllowedAttributes.isEmpty())
       return span;
-    // remove extension attributes (x-) if they are not in allowedExtensionAttributes
-    // and starts with http(s).request.header or http(s).response.header
-    List<KeyValue> updatedTags =
-        span.getTagsList().stream()
-            .filter(
-                keyValue -> {
-                  String keyInLowerCase = keyValue.getKey().toLowerCase();
-                  String matched =
-                      allowedAttributesPrefixes.stream()
-                          .filter(prefix -> keyInLowerCase.startsWith(prefix))
-                          .findFirst()
-                          .orElse(null);
-                  return (matched == null
-                      || prefixedMatchedAllowedAttributes.contains(keyInLowerCase));
-                })
-            .collect(Collectors.toList());
+
+    long totalTagsBytes = 0;
+    long updatedTagsBytes = 0;
+
+    List<KeyValue> updatedTags = new ArrayList<>();
+    List<KeyValue> droppedTags = new ArrayList<>();
+
+    for (KeyValue tag : span.getTagsList()) {
+      long tagBytes = calculateSize(tag);
+      totalTagsBytes += tagBytes;
+
+      String keyInLowerCase = tag.getKey().toLowerCase();
+      String matched =
+          allowedAttributesPrefixes.stream()
+              .filter(prefix -> keyInLowerCase.startsWith(prefix))
+              .findFirst()
+              .orElse(null);
+      if (matched == null || prefixedMatchedAllowedAttributes.contains(keyInLowerCase)) {
+        updatedTags.add(tag);
+        updatedTagsBytes += tagBytes;
+      } else {
+        droppedTags.add(tag);
+      }
+    }
+
+    if (LOG.isDebugEnabled() && DROPPED_TAGS_LIMITER.tryAcquire()) {
+      LOG.debug("Dropped List of tags:{} for tenant:{}", droppedTags, tenantId);
+    }
+
+    recordMetrics(tenantId, totalTagsBytes, updatedTagsBytes);
+
     return Span.newBuilder(span).clearTags().addAllTags(updatedTags).build();
+  }
+
+  private int calculateSize(KeyValue tag) {
+    switch (tag.getVType()) {
+      case BINARY:
+        return tag.getVBinary() != null ? tag.getVBinary().size() : 0;
+      case STRING:
+        return tag.getVStr() != null ? tag.getVStr().getBytes().length : 0;
+      case FLOAT64:
+        return Double.BYTES;
+      case INT64:
+        return Integer.BYTES;
+      case BOOL:
+        return 2;
+      default:
+        return 0;
+    }
+  }
+
+  private void recordMetrics(String tenantId, long totalTagsBytes, long updatedTagsBytes) {
+    tenantToTagsTotalSize
+        .computeIfAbsent(
+            tenantId,
+            tenant ->
+                PlatformMetricsRegistry.registerDistributionSummary(
+                    TAGS_BYTES, Map.of("tenantId", tenantId)))
+        .record(totalTagsBytes);
+
+    tenantToTagsProcessedSize
+        .computeIfAbsent(
+            tenantId,
+            tenant ->
+                PlatformMetricsRegistry.registerDistributionSummary(
+                    TAGS_PROCESSED_BYTES, Map.of("tenantId", tenantId)))
+        .record(updatedTagsBytes);
   }
 }

--- a/span-normalizer/span-normalizer/src/main/resources/configs/common/application.conf
+++ b/span-normalizer/span-normalizer/src/main/resources/configs/common/application.conf
@@ -27,6 +27,18 @@ kafka.streams.config = {
 processor {
   defaultTenantId = ${?DEFAULT_TENANT_ID}
   late.arrival.threshold.duration = 365d
+
+  # Configuration for dropping certain attributes that are captured by agent, but doesn't require in
+  # the processing pipeline.
+  #
+  # allowed.attributes.prefixes : the list of prefixes that should match for which allowed keys
+  # prefixed.matched.allowed.attributes : allowed keys from the subset of keys where prefix matched
+  #
+  # If either of config is empty allowed.attributes.prefixes or prefixed.matched.allowed.attributes,
+  # it will not drop any attributes.
+  # The above configuration doesn't impact if the key doesn't start with prefix.
+  allowed.attributes.prefixes = []
+  prefixed.matched.allowed.attributes = []
 }
 
 logger.names = ["file"]

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessorTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessorTest.java
@@ -827,6 +827,385 @@ class JaegerSpanPreProcessorTest {
         });
   }
 
+  @Test
+  public void testTagsFiltersForHttpXAttributes() {
+    // Config note:
+    // Configured to drop non-allowed keys from the subset of http extension attributes
+    // allowed.attributes.prefixes : ["http.request.header.x-", "http.response.header.x-"]
+    // So, all the keys which doesn't start with above prefix will be retains, and
+    // the keys that start with above prefix will be checked against allowed list.
+
+    // In this test case, we expects 2 attributes to be dropped as it matches configured criteria.
+    // prefixed.matched.allowed.attributes: ["http.request.header.x-allowed-1",
+    // "http.response.header.x-allowed-2"]
+    // So, http.request.header.x-not-allowed-1 and http.response.header.x-not-allowed-2 will be
+    // dropped.
+
+    String tenantId = "tenant-" + random.nextLong();
+    Map<String, Object> configs = new HashMap<>(getCommonConfig());
+    configs.putAll(
+        Map.of(
+            "processor",
+            Map.of(
+                "tenantIdTagKey",
+                "tenant-key",
+                "late.arrival.threshold.duration",
+                "1d",
+                "allowed.attributes.prefixes",
+                List.of("http.request.header.x-", "http.response.header.x-"),
+                "prefixed.matched.allowed.attributes",
+                List.of("http.request.header.x-allowed-1", "http.response.header.x-allowed-2"))));
+
+    JaegerSpanPreProcessor jaegerSpanPreProcessor =
+        new JaegerSpanPreProcessor(ConfigFactory.parseMap(configs));
+    Process process = Process.newBuilder().setServiceName("testService").build();
+
+    KeyValue allowed1 =
+        KeyValue.newBuilder()
+            .setKey("http.request.header.x-allowed-1")
+            .setVStr("allowed-1-value")
+            .build();
+    KeyValue allowed2 =
+        KeyValue.newBuilder()
+            .setKey("http.response.header.x-allowed-2")
+            .setVStr("allowed-2-value")
+            .build();
+    KeyValue notAllowed1 =
+        KeyValue.newBuilder()
+            .setKey("http.request.header.x-not-allowed-1")
+            .setVStr("not-allowed-1-value")
+            .build();
+    KeyValue notAllowed2 =
+        KeyValue.newBuilder()
+            .setKey("http.response.header.x-not-allowed-2")
+            .setVStr("not-allowed-2-value")
+            .build();
+
+    Span span =
+        Span.newBuilder()
+            .setProcess(process)
+            .addTags(KeyValue.newBuilder().setKey("tenant-key").setVStr(tenantId).build())
+            .addTags(KeyValue.newBuilder().setKey("http.method").setVStr("GET").build())
+            .addTags(KeyValue.newBuilder().setKey("extra.tag").setVStr("extra-test-value").build())
+            .addTags(allowed1)
+            .addTags(allowed2)
+            .addTags(notAllowed1)
+            .addTags(notAllowed2)
+            .build();
+    PreProcessedSpan preProcessedSpan = jaegerSpanPreProcessor.preProcessSpan(span);
+
+    Assertions.assertNotNull(preProcessedSpan);
+
+    Assertions.assertEquals(5, preProcessedSpan.getSpan().getTagsCount());
+    Assertions.assertEquals(7, span.getTagsCount());
+
+    Assertions.assertTrue(preProcessedSpan.getSpan().getTagsList().contains(allowed1));
+    Assertions.assertTrue(preProcessedSpan.getSpan().getTagsList().contains(allowed2));
+
+    Assertions.assertFalse(preProcessedSpan.getSpan().getTagsList().contains(notAllowed1));
+    Assertions.assertFalse(preProcessedSpan.getSpan().getTagsList().contains(notAllowed2));
+  }
+
+  @Test
+  public void testTagsFiltersForNoneHttpXAttributes() {
+    // Config note:
+    // Configured to drop non-allowed keys from the subset of http extension attributes
+    // allowed.attributes.prefixes : ["http.request.header.x-", "http.response.header.x-"]
+    // So, all the keys which doesn't start with above prefix will be retains, and
+    // the keys that start with above prefix will be checked against allowed list.
+
+    // In this test case, we expects nothing to be dropped as none of the attributes start with
+    // configured prefixes.
+    // prefixed.matched.allowed.attributes: ["http.request.header.x-allowed-1",
+    // "http.response.header.x-allowed-2"]
+
+    String tenantId = "tenant-" + random.nextLong();
+    Map<String, Object> configs = new HashMap<>(getCommonConfig());
+    configs.putAll(
+        Map.of(
+            "processor",
+            Map.of(
+                "tenantIdTagKey",
+                "tenant-key",
+                "late.arrival.threshold.duration",
+                "1d",
+                "allowed.attributes.prefixes",
+                List.of("http.request.header.x-", "http.response.header.x-"),
+                "prefixed.matched.allowed.attributes",
+                List.of("http.request.header.x-allowed-1", "http.response.header.x-allowed-2"))));
+
+    JaegerSpanPreProcessor jaegerSpanPreProcessor =
+        new JaegerSpanPreProcessor(ConfigFactory.parseMap(configs));
+    Process process = Process.newBuilder().setServiceName("testService").build();
+
+    KeyValue allowed1 =
+        KeyValue.newBuilder().setKey("x-allowed-1").setVStr("allowed-1-value").build();
+    KeyValue allowed2 =
+        KeyValue.newBuilder().setKey("x-allowed-2").setVStr("allowed-2-value").build();
+    KeyValue notAllowed1 =
+        KeyValue.newBuilder().setKey("x-not-allowed-1").setVStr("not-allowed-1-value").build();
+    KeyValue notAllowed2 =
+        KeyValue.newBuilder().setKey("x-not-allowed-2").setVStr("not-allowed-2-value").build();
+
+    Span span =
+        Span.newBuilder()
+            .setProcess(process)
+            .addTags(KeyValue.newBuilder().setKey("tenant-key").setVStr(tenantId).build())
+            .addTags(KeyValue.newBuilder().setKey("http.method").setVStr("GET").build())
+            .addTags(KeyValue.newBuilder().setKey("extra.tag").setVStr("extra-test-value").build())
+            .addTags(allowed1)
+            .addTags(allowed2)
+            .addTags(notAllowed1)
+            .addTags(notAllowed2)
+            .build();
+
+    PreProcessedSpan preProcessedSpan = jaegerSpanPreProcessor.preProcessSpan(span);
+
+    Assertions.assertNotNull(preProcessedSpan);
+
+    Assertions.assertEquals(7, preProcessedSpan.getSpan().getTagsCount());
+    Assertions.assertEquals(7, span.getTagsCount());
+
+    Assertions.assertTrue(preProcessedSpan.getSpan().getTagsList().contains(allowed1));
+    Assertions.assertTrue(preProcessedSpan.getSpan().getTagsList().contains(allowed2));
+
+    Assertions.assertTrue(preProcessedSpan.getSpan().getTagsList().contains(notAllowed1));
+    Assertions.assertTrue(preProcessedSpan.getSpan().getTagsList().contains(notAllowed2));
+  }
+
+  @Test
+  public void testTagsFiltersConfiguredWithNoneHttpXAttributes() {
+    // Config note:
+    // Configured to drop non-allowed keys from the subset of http extension attributes
+    // allowed.attributes.prefixes : ["http.request.header.x-", "http.response.header.x-"]
+    // So, all the keys which doesn't start with above prefix will be retains, and
+    // the keys that start with above prefix will be checked against allowed list.
+
+    // In this test case, we have miss configured prefix key, and allowed list.
+    // So, it will drop all the keys matching prefix subset.
+    // prefixed.matched.allowed.attributes: ["x-allowed-1", "x-allowed-2"]
+
+    String tenantId = "tenant-" + random.nextLong();
+    Map<String, Object> configs = new HashMap<>(getCommonConfig());
+    configs.putAll(
+        Map.of(
+            "processor",
+            Map.of(
+                "tenantIdTagKey",
+                "tenant-key",
+                "late.arrival.threshold.duration",
+                "1d",
+                "allowed.attributes.prefixes",
+                List.of("http.request.header.x-", "http.response.header.x-"),
+                "prefixed.matched.allowed.attributes",
+                List.of("x-allowed-1", "x-allowed-2"))));
+
+    JaegerSpanPreProcessor jaegerSpanPreProcessor =
+        new JaegerSpanPreProcessor(ConfigFactory.parseMap(configs));
+    Process process = Process.newBuilder().setServiceName("testService").build();
+
+    KeyValue allowed1 =
+        KeyValue.newBuilder()
+            .setKey("http.request.header.x-allowed-1")
+            .setVStr("allowed-1-value")
+            .build();
+    KeyValue allowed2 =
+        KeyValue.newBuilder()
+            .setKey("http.response.header.x-allowed-2")
+            .setVStr("allowed-2-value")
+            .build();
+    KeyValue notAllowed1 =
+        KeyValue.newBuilder()
+            .setKey("http.request.header.x-not-allowed-1")
+            .setVStr("not-allowed-1-value")
+            .build();
+    KeyValue notAllowed2 =
+        KeyValue.newBuilder()
+            .setKey("http.response.header.x-not-allowed-2")
+            .setVStr("not-allowed-2-value")
+            .build();
+
+    Span span =
+        Span.newBuilder()
+            .setProcess(process)
+            .addTags(KeyValue.newBuilder().setKey("tenant-key").setVStr(tenantId).build())
+            .addTags(KeyValue.newBuilder().setKey("http.method").setVStr("GET").build())
+            .addTags(KeyValue.newBuilder().setKey("extra.tag").setVStr("extra-test-value").build())
+            .addTags(allowed1)
+            .addTags(allowed2)
+            .addTags(notAllowed1)
+            .addTags(notAllowed2)
+            .build();
+
+    PreProcessedSpan preProcessedSpan = jaegerSpanPreProcessor.preProcessSpan(span);
+
+    Assertions.assertNotNull(preProcessedSpan);
+
+    Assertions.assertEquals(3, preProcessedSpan.getSpan().getTagsCount());
+    Assertions.assertEquals(7, span.getTagsCount());
+
+    Assertions.assertFalse(preProcessedSpan.getSpan().getTagsList().contains(allowed1));
+    Assertions.assertFalse(preProcessedSpan.getSpan().getTagsList().contains(allowed2));
+
+    Assertions.assertFalse(preProcessedSpan.getSpan().getTagsList().contains(notAllowed1));
+    Assertions.assertFalse(preProcessedSpan.getSpan().getTagsList().contains(notAllowed2));
+  }
+
+  @Test
+  public void testTagsFiltersConfiguredEmptyAllowedAttributes() {
+    // Config note:
+    // Configured to drop non-allowed keys from the subset of http extension attributes
+    // allowed.attributes.prefixes : ["http.request.header.x-", "http.response.header.x-"]
+    // So, all the keys which doesn't start with above prefix will be retains, and
+    // the keys that start with above prefix will be checked against allowed list.
+
+    // In this test case, we have empty configuration for prefixed.matched.allowed.attributes
+    // So, this will behave as no-op.
+    // So, it will drop all the keys matching prefix subset.
+    // prefixed.matched.allowed.attributes: []
+
+    String tenantId = "tenant-" + random.nextLong();
+    Map<String, Object> configs = new HashMap<>(getCommonConfig());
+    configs.putAll(
+        Map.of(
+            "processor",
+            Map.of(
+                "tenantIdTagKey",
+                "tenant-key",
+                "late.arrival.threshold.duration",
+                "1d",
+                "allowed.attributes.prefixes",
+                List.of("http.request.header.x-", "http.response.header.x-"),
+                "prefixed.matched.allowed.attributes",
+                List.of())));
+
+    JaegerSpanPreProcessor jaegerSpanPreProcessor =
+        new JaegerSpanPreProcessor(ConfigFactory.parseMap(configs));
+    Process process = Process.newBuilder().setServiceName("testService").build();
+
+    // expects nothing to drop as allowed.extension.attributes configured to empty
+    KeyValue allowed1 =
+        KeyValue.newBuilder()
+            .setKey("http.request.header.x-allowed-1")
+            .setVStr("allowed-1-value")
+            .build();
+    KeyValue allowed2 =
+        KeyValue.newBuilder()
+            .setKey("http.response.header.x-allowed-2")
+            .setVStr("allowed-2-value")
+            .build();
+    KeyValue notAllowed1 =
+        KeyValue.newBuilder()
+            .setKey("http.request.header.x-not-allowed-1")
+            .setVStr("not-allowed-1-value")
+            .build();
+    KeyValue notAllowed2 =
+        KeyValue.newBuilder()
+            .setKey("http.response.header.x-not-allowed-2")
+            .setVStr("not-allowed-2-value")
+            .build();
+
+    Span span =
+        Span.newBuilder()
+            .setProcess(process)
+            .addTags(KeyValue.newBuilder().setKey("tenant-key").setVStr(tenantId).build())
+            .addTags(KeyValue.newBuilder().setKey("http.method").setVStr("GET").build())
+            .addTags(KeyValue.newBuilder().setKey("extra.tag").setVStr("extra-test-value").build())
+            .addTags(allowed1)
+            .addTags(allowed2)
+            .addTags(notAllowed1)
+            .addTags(notAllowed2)
+            .build();
+
+    PreProcessedSpan preProcessedSpan = jaegerSpanPreProcessor.preProcessSpan(span);
+
+    Assertions.assertNotNull(preProcessedSpan);
+
+    Assertions.assertEquals(7, preProcessedSpan.getSpan().getTagsCount());
+    Assertions.assertEquals(7, span.getTagsCount());
+
+    Assertions.assertTrue(preProcessedSpan.getSpan().getTagsList().contains(allowed1));
+    Assertions.assertTrue(preProcessedSpan.getSpan().getTagsList().contains(allowed2));
+
+    Assertions.assertTrue(preProcessedSpan.getSpan().getTagsList().contains(notAllowed1));
+    Assertions.assertTrue(preProcessedSpan.getSpan().getTagsList().contains(notAllowed2));
+  }
+
+  @Test
+  public void testTagsFiltersConfiguredEmptyPrefixForSubset() {
+    // Config note:
+    // There is no subset configuration.
+    // allowed.attributes.prefixes : []
+    // So, nothing will be dropped
+
+    // In this test case, expects all the keys.
+    String tenantId = "tenant-" + random.nextLong();
+    Map<String, Object> configs = new HashMap<>(getCommonConfig());
+    configs.putAll(
+        Map.of(
+            "processor",
+            Map.of(
+                "tenantIdTagKey",
+                "tenant-key",
+                "late.arrival.threshold.duration",
+                "1d",
+                "allowed.attributes.prefixes",
+                List.of("http.request.header.x-", "http.response.header.x-"),
+                "prefixed.matched.allowed.attributes",
+                List.of())));
+
+    JaegerSpanPreProcessor jaegerSpanPreProcessor =
+        new JaegerSpanPreProcessor(ConfigFactory.parseMap(configs));
+    Process process = Process.newBuilder().setServiceName("testService").build();
+
+    // expects nothing to drop as allowed.extension.attributes configured to empty
+    KeyValue allowed1 =
+        KeyValue.newBuilder()
+            .setKey("http.request.header.x-allowed-1")
+            .setVStr("allowed-1-value")
+            .build();
+    KeyValue allowed2 =
+        KeyValue.newBuilder()
+            .setKey("http.response.header.x-allowed-2")
+            .setVStr("allowed-2-value")
+            .build();
+    KeyValue notAllowed1 =
+        KeyValue.newBuilder()
+            .setKey("http.request.header.x-not-allowed-1")
+            .setVStr("not-allowed-1-value")
+            .build();
+    KeyValue notAllowed2 =
+        KeyValue.newBuilder()
+            .setKey("http.response.header.x-not-allowed-2")
+            .setVStr("not-allowed-2-value")
+            .build();
+
+    Span span =
+        Span.newBuilder()
+            .setProcess(process)
+            .addTags(KeyValue.newBuilder().setKey("tenant-key").setVStr(tenantId).build())
+            .addTags(KeyValue.newBuilder().setKey("http.method").setVStr("GET").build())
+            .addTags(KeyValue.newBuilder().setKey("extra.tag").setVStr("extra-test-value").build())
+            .addTags(allowed1)
+            .addTags(allowed2)
+            .addTags(notAllowed1)
+            .addTags(notAllowed2)
+            .build();
+
+    PreProcessedSpan preProcessedSpan = jaegerSpanPreProcessor.preProcessSpan(span);
+
+    Assertions.assertNotNull(preProcessedSpan);
+
+    Assertions.assertEquals(7, preProcessedSpan.getSpan().getTagsCount());
+    Assertions.assertEquals(7, span.getTagsCount());
+
+    Assertions.assertTrue(preProcessedSpan.getSpan().getTagsList().contains(allowed1));
+    Assertions.assertTrue(preProcessedSpan.getSpan().getTagsList().contains(allowed2));
+
+    Assertions.assertTrue(preProcessedSpan.getSpan().getTagsList().contains(notAllowed1));
+    Assertions.assertTrue(preProcessedSpan.getSpan().getTagsList().contains(notAllowed2));
+  }
+
   private Map<String, Object> getCommonConfig() {
     return Map.of(
         "span.type",

--- a/span-normalizer/span-normalizer/src/test/resources/configs/span-normalizer/application.conf
+++ b/span-normalizer/span-normalizer/src/test/resources/configs/span-normalizer/application.conf
@@ -55,6 +55,18 @@ processor {
 processor {
   bypass.key = "test.bypass"
   late.arrival.threshold.duration = "1d"
+
+  # Configuration for dropping certain attributes that are captured by agent, but doesn't require in
+  # the processing pipeline.
+  #
+  # allowed.attributes.prefixes : the list of prefixes that should match for which allowed keys
+  # prefixed.matched.allowed.attributes : allowed keys from the subset of keys where prefix matched
+  #
+  # If either of config is empty allowed.attributes.prefixes or prefixed.matched.allowed.attributes,
+  # it will not drop any attributes.
+  # The above configuration doesn't impact if the key doesn't start with prefix.
+  allowed.attributes.prefixes = []
+  prefixed.matched.allowed.attributes = []
 }
 
 

--- a/span-normalizer/span-normalizer/src/test/resources/configs/span-normalizer/application.conf
+++ b/span-normalizer/span-normalizer/src/test/resources/configs/span-normalizer/application.conf
@@ -65,8 +65,8 @@ processor {
   # If either of config is empty allowed.attributes.prefixes or prefixed.matched.allowed.attributes,
   # it will not drop any attributes.
   # The above configuration doesn't impact if the key doesn't start with prefix.
-  allowed.attributes.prefixes = []
-  prefixed.matched.allowed.attributes = []
+  allowed.attributes.prefixes = ["http.request.header.x-", "http.response.header.x-"]
+  prefixed.matched.allowed.attributes = ["http.request.header.x-allowed-1", "http.response.header.x-allowed-2"]
 }
 
 


### PR DESCRIPTION
## Description
There are cases that data-collection techniques used for collection can capture much more than required during the processing pipeline. And, we can't easily modify or control data collection module. So, based on request, as part of this PR, we are adding the configuration based functionality to drop un-used (or additional) tags as per need

The technique used here is that 
- identify the subset from which you want to drop or retain. This configuration can be provided using `allowed.attributes.prefixes`
- Provide the list of attribute keys that you won't retain for the subset of keys. This can be provided using `prefixed.matched.allowed.attributes`

As an example, I want to retain `x-allowed-1` attributes from all extension attributes of http request header.
So, in this case, we can configure as below:

Prepare the subset using `allowed.attributes.prefixes` that we are only interested in extension attributes related to http request header - `http.request.header.x-`
```
allowed.attributes.prefixes = ["http.request.header.x-"]
```

Now, provide the list of attributes that we want to retain:
```
prefixed.matched.allowed.attributes = ["http.request.header.x-allowed-1"]
```
In the above example, 
Only `http.request.header.x-allowed-1` will be retain form http request extension attributes.

Note: This configuration doesn't impact other keys which doesn't match the prefix criteria


### Testing
Have added unit test, and topology test

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
we will document it as part of the release.

