### PR TITLE
Drop spans based on event

### DIFF
--- a/hypertrace-ingester/src/test/java/org/hypertrace/migration/MigrationTestHttp.java
+++ b/hypertrace-ingester/src/test/java/org/hypertrace/migration/MigrationTestHttp.java
@@ -20,6 +20,7 @@ import static org.hypertrace.core.span.constants.v1.Http.HTTP_USER_DOT_AGENT;
 import static org.hypertrace.core.span.constants.v1.OTSpanTag.OT_SPAN_TAG_HTTP_METHOD;
 import static org.hypertrace.core.span.constants.v1.OTSpanTag.OT_SPAN_TAG_HTTP_STATUS_CODE;
 import static org.hypertrace.core.span.constants.v1.OTSpanTag.OT_SPAN_TAG_HTTP_URL;
+import static org.hypertrace.core.spannormalizer.util.EventBuilder.buildEvent;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -32,6 +33,7 @@ import io.jaegertracing.api_v2.JaegerSpanInternalModel.Span;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -96,7 +98,8 @@ public class MigrationTestHttp {
         };
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -136,7 +139,8 @@ public class MigrationTestHttp {
       throws Exception {
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -151,7 +155,8 @@ public class MigrationTestHttp {
       throws Exception {
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -165,7 +170,8 @@ public class MigrationTestHttp {
       throws Exception {
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -179,7 +185,8 @@ public class MigrationTestHttp {
       throws Exception {
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -196,7 +203,8 @@ public class MigrationTestHttp {
             Map.of(
                 RawSpanConstants.getValue(HTTP_REQUEST_PATH), "path1",
                 RawSpanConstants.getValue(HTTP_PATH), "  "));
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     assertFalse(HttpSemanticConventionUtils.getHttpPath(rawSpan.getEvent()).isPresent());
 
@@ -205,7 +213,8 @@ public class MigrationTestHttp {
             Map.of(
                 RawSpanConstants.getValue(HTTP_REQUEST_PATH), "path1",
                 RawSpanConstants.getValue(HTTP_PATH), "/"));
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     assertEquals("/", HttpSemanticConventionUtils.getHttpPath(rawSpan.getEvent()).get());
   }
@@ -216,7 +225,8 @@ public class MigrationTestHttp {
       throws Exception {
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -230,7 +240,8 @@ public class MigrationTestHttp {
       throws Exception {
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -245,7 +256,8 @@ public class MigrationTestHttp {
       throws Exception {
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -259,7 +271,8 @@ public class MigrationTestHttp {
 
     Span span =
         createSpanFromTags(Map.of(RawSpanConstants.getValue(HTTP_URL), "/dispatch/test?a=b&k1=v1"));
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
     assertFalse(HttpSemanticConventionUtils.getHttpUrl(rawSpan.getEvent()).isPresent());
   }
 
@@ -269,7 +282,8 @@ public class MigrationTestHttp {
     Span span =
         createSpanFromTags(
             Map.of(RawSpanConstants.getValue(HTTP_URL), "http://abc.xyz/dispatch/test?a=b&k1=v1"));
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -292,7 +306,8 @@ public class MigrationTestHttp {
                     .setVStr("https://example.ai/apis/5673/events?a1=v1&a2=v2"))
             .build();
 
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -313,7 +328,8 @@ public class MigrationTestHttp {
                     .setVStr("https://example.ai/apis/5673/events/?a1=v1&a2=v2"))
             .build();
 
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -334,7 +350,8 @@ public class MigrationTestHttp {
                     .setVStr("https://example.ai/apis/5673/events"))
             .build();
 
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -354,7 +371,8 @@ public class MigrationTestHttp {
                     .setVStr("https://example.ai"))
             .build();
 
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -373,7 +391,8 @@ public class MigrationTestHttp {
                     .setVStr("/apis/5673/events?a1=v1&a2=v2"))
             .build();
 
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -395,7 +414,8 @@ public class MigrationTestHttp {
                     .setVStr("http://example.ai:9000/?a1=v1&a2=v2"))
             .build();
 
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -425,7 +445,8 @@ public class MigrationTestHttp {
                     .setVStr("/some-test-path"))
             .build();
 
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -457,7 +478,8 @@ public class MigrationTestHttp {
         };
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -490,7 +512,8 @@ public class MigrationTestHttp {
   @Test
   public void testPopulateOtherFieldsOTelSpan() throws Exception {
     Span span = Span.newBuilder().build();
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     assertFalse(HttpSemanticConventionUtils.getHttpUrl(rawSpan.getEvent()).isPresent());
     assertFalse(HttpSemanticConventionUtils.getHttpScheme(rawSpan.getEvent()).isPresent());
@@ -506,7 +529,8 @@ public class MigrationTestHttp {
                     .setVStr("https://example.ai/apis/5673/events?a1=v1&a2=v2"))
             .build();
 
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -527,7 +551,8 @@ public class MigrationTestHttp {
                     .setVStr("https://example.ai/apis/5673/events/?a1=v1&a2=v2"))
             .build();
 
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
 
@@ -547,7 +572,8 @@ public class MigrationTestHttp {
                     .setVStr("https://example.ai/apis/5673/events"))
             .build();
 
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -567,7 +593,8 @@ public class MigrationTestHttp {
                     .setVStr("https://example.ai"))
             .build();
 
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
 
@@ -585,7 +612,8 @@ public class MigrationTestHttp {
                     .setVStr("/apis/5673/events?a1=v1&a2=v2"))
             .build();
 
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
 
@@ -606,7 +634,8 @@ public class MigrationTestHttp {
                     .setVStr("http://example.ai:9000/?a1=v1&a2=v2"))
             .build();
 
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
 
@@ -635,7 +664,8 @@ public class MigrationTestHttp {
                     .setVStr("/some-test-path"))
             .build();
 
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
     assertEquals(
@@ -673,7 +703,8 @@ public class MigrationTestHttp {
                         "/api/v1/gatekeeper/check?url=%2Fpixel%2Factivities%3Fadvertisable%3DTRHRT&method=GET&service=pixel"))
             .build();
 
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
     assertEquals(
@@ -689,7 +720,8 @@ public class MigrationTestHttp {
             Map.of(
                 OTelHttpSemanticConventions.HTTP_TARGET.getValue(),
                 "/api/v1/gatekeeper/check?url=%2Fpixel%2Factivities%3Fadvertisable%3DTRHRT&method=GET&service=pixel"));
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
 

--- a/hypertrace-ingester/src/test/java/org/hypertrace/migration/MigrationTestRpc.java
+++ b/hypertrace-ingester/src/test/java/org/hypertrace/migration/MigrationTestRpc.java
@@ -14,6 +14,7 @@ import static org.hypertrace.core.span.normalizer.constants.OTelRpcSystem.OTEL_R
 import static org.hypertrace.core.span.normalizer.constants.OTelSpanTag.OTEL_SPAN_TAG_RPC_SYSTEM;
 import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_METADATA_AUTHORITY;
 import static org.hypertrace.core.span.normalizer.constants.RpcSpanTag.RPC_REQUEST_METADATA_USER_AGENT;
+import static org.hypertrace.core.spannormalizer.util.EventBuilder.buildEvent;
 import static org.hypertrace.migration.MigrationTestHttp.createSpanFromTags;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,6 +27,7 @@ import io.jaegertracing.api_v2.JaegerSpanInternalModel.Span;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Stream;
 import org.hypertrace.core.datamodel.RawSpan;
@@ -87,7 +89,8 @@ public class MigrationTestRpc {
         };
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
@@ -121,7 +124,8 @@ public class MigrationTestRpc {
             RawSpanConstants.getValue(ENVOY_RESPONSE_SIZE), "400");
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
@@ -137,7 +141,8 @@ public class MigrationTestRpc {
       throws Exception {
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
@@ -155,7 +160,8 @@ public class MigrationTestRpc {
         Map.of(RPC_REQUEST_METADATA_USER_AGENT.getValue(), rpcRequestMetadataUserAgentValue);
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     assertNull(rawSpan.getEvent().getGrpc());
     assertTrue(RpcSemanticConventionUtils.getGrpcUserAgent(rawSpan.getEvent()).isEmpty());
@@ -168,7 +174,8 @@ public class MigrationTestRpc {
             OTEL_RPC_SYSTEM_GRPC.getValue());
 
     span = createSpanFromTags(tagsMap);
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
     assertEquals(
@@ -183,7 +190,8 @@ public class MigrationTestRpc {
         Map.of(RPC_REQUEST_METADATA_AUTHORITY.getValue(), rpcRequestMetadataAuthorityValue);
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     assertNull(rawSpan.getEvent().getGrpc());
     assertTrue(RpcSemanticConventionUtils.getGrpcAuthority(rawSpan.getEvent()).isEmpty());
@@ -196,7 +204,8 @@ public class MigrationTestRpc {
             OTEL_RPC_SYSTEM_GRPC.getValue());
 
     span = createSpanFromTags(tagsMap);
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
@@ -234,7 +243,8 @@ public class MigrationTestRpc {
       Map<String, String> tagsMap, String statusMessage) throws Exception {
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
@@ -270,7 +280,8 @@ public class MigrationTestRpc {
             OTelRpcSemanticConventions.RPC_SYSTEM_VALUE_GRPC.getValue());
 
     Span span = createSpanFromTags(tagMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     assertEquals(
         "resource not found", RpcSemanticConventionUtils.getGrpcErrorMsg(rawSpan.getEvent()));
@@ -283,7 +294,8 @@ public class MigrationTestRpc {
         Map.of(OTelRpcSemanticConventions.GRPC_STATUS_CODE.getValue(), "5");
 
     Span span = createSpanFromTags(tagMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
@@ -301,7 +313,8 @@ public class MigrationTestRpc {
             RPC_REQUEST_METADATA_USER_AGENT.getValue(), "grpc-go/1.17.0");
 
     Span span = createSpanFromTags(tagMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
@@ -323,7 +336,8 @@ public class MigrationTestRpc {
             RPC_REQUEST_METADATA_USER_AGENT.getValue(), "grpc-go/1.17.0");
 
     Span span = createSpanFromTags(tagsMap);
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
 
     assertAll(
         () ->

--- a/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/utils/EnrichedSpanUtils.java
+++ b/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/utils/EnrichedSpanUtils.java
@@ -315,10 +315,7 @@ public class EnrichedSpanUtils {
   }
 
   public static Optional<String> getFullHttpUrl(Event event) {
-    Optional<String> fullHttpUrl = HttpSemanticConventionUtils.getHttpUrl(event);
-    return fullHttpUrl.isPresent()
-        ? fullHttpUrl
-        : HttpSemanticConventionUtils.getValidHttpUrl(event).map(AttributeValue::getValue);
+    return HttpSemanticConventionUtils.getFullHttpUrl(event);
   }
 
   public static Optional<String> getPath(Event event) {

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -47,6 +47,7 @@ import java.util.Optional;
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.shared.SpanAttributeUtils;
+import org.hypertrace.core.semantic.convention.constants.deployment.OTelDeploymentSemanticConventions;
 import org.hypertrace.core.semantic.convention.constants.http.HttpSemanticConventions;
 import org.hypertrace.core.semantic.convention.constants.http.OTelHttpSemanticConventions;
 import org.hypertrace.core.semantic.convention.constants.span.OTelSpanSemanticConventions;
@@ -181,6 +182,12 @@ public class HttpSemanticConventionUtils {
     return fullHttpUrl.isPresent()
         ? fullHttpUrl
         : getValidHttpUrl(event).map(AttributeValue::getValue);
+  }
+
+  public static Optional<String> getEnvironmentForSpan(Event event) {
+    return Optional.ofNullable(
+        SpanAttributeUtils.getStringAttribute(
+            event, OTelDeploymentSemanticConventions.DEPLOYMENT_ENVIRONMENT.getValue()));
   }
 
   /**

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -176,6 +176,13 @@ public class HttpSemanticConventionUtils {
     return false;
   }
 
+  public static Optional<String> getFullHttpUrl(Event event) {
+    Optional<String> fullHttpUrl = getHttpUrl(event);
+    return fullHttpUrl.isPresent()
+        ? fullHttpUrl
+        : getValidHttpUrl(event).map(AttributeValue::getValue);
+  }
+
   /**
    * OTel mandates one of the following set to be present for http server span - http.scheme,
    * http.host, http.target - http.scheme, http.server_name, net.host.port, http.target -

--- a/span-normalizer/span-normalizer/build.gradle.kts
+++ b/span-normalizer/span-normalizer/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
   implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.23")
   implementation("org.hypertrace.config.service:span-processing-config-service-api:0.1.27")
+  implementation("org.hypertrace.config.service:config-utils:0.1.30")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.1")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.7.1")
 

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ExcludeSpanRuleEvaluator.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ExcludeSpanRuleEvaluator.java
@@ -94,6 +94,7 @@ public class ExcludeSpanRuleEvaluator {
       Map<String, JaegerSpanInternalModel.KeyValue> processTags,
       String serviceName) {
     return excludeSpanRules.stream()
+        .filter(excludeSpanRule -> !excludeSpanRule.getRuleInfo().getDisabled())
         .anyMatch(
             excludeSpanRule ->
                 applyFilter(
@@ -102,6 +103,7 @@ public class ExcludeSpanRuleEvaluator {
 
   private boolean applyExcludeSpanRules(List<ExcludeSpanRule> excludeSpanRules, Event event) {
     return excludeSpanRules.stream()
+        .filter(excludeSpanRule -> !excludeSpanRule.getRuleInfo().getDisabled())
         .anyMatch(excludeSpanRule -> applyFilter(excludeSpanRule.getRuleInfo().getFilter(), event));
   }
 

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ExcludeSpanRuleEvaluator.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ExcludeSpanRuleEvaluator.java
@@ -10,16 +10,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.hypertrace.config.utils.SpanFilterMatcher;
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.spannormalizer.util.JaegerHTTagsConverter;
+import org.hypertrace.semantic.convention.utils.http.HttpSemanticConventionUtils;
 import org.hypertrace.span.processing.config.service.v1.ExcludeSpanRule;
 import org.hypertrace.span.processing.config.service.v1.Field;
-import org.hypertrace.span.processing.config.service.v1.ListValue;
 import org.hypertrace.span.processing.config.service.v1.LogicalOperator;
 import org.hypertrace.span.processing.config.service.v1.LogicalSpanFilterExpression;
 import org.hypertrace.span.processing.config.service.v1.RelationalOperator;
@@ -30,16 +30,18 @@ import org.hypertrace.span.processing.config.service.v1.SpanFilterValue;
 @Slf4j
 public class ExcludeSpanRuleEvaluator {
   // rename and replace SpanFilter later.
-
   private final ExcludeSpanRulesCache excludeSpanRulesCache;
+  private final SpanFilterMatcher spanFilterMatcher;
 
   public ExcludeSpanRuleEvaluator(Config config) {
     this.excludeSpanRulesCache = ExcludeSpanRulesCache.getInstance(config);
+    this.spanFilterMatcher = new SpanFilterMatcher();
   }
 
   @VisibleForTesting
   public ExcludeSpanRuleEvaluator(ExcludeSpanRulesCache excludeSpanRulesCache) {
     this.excludeSpanRulesCache = excludeSpanRulesCache;
+    this.spanFilterMatcher = new SpanFilterMatcher();
   }
 
   private static final String ENVIRONMENT_ATTRIBUTE = "deployment.environment";
@@ -77,8 +79,15 @@ public class ExcludeSpanRuleEvaluator {
     return applyExcludeSpanRules(excludeSpanRules, tags, processTags, serviceName);
   }
 
-  public boolean shouldDropEvent(Event event) {
-    return false;
+  @SneakyThrows
+  public boolean shouldDropEvent(Event event, String tenantId) {
+    List<ExcludeSpanRule> excludeSpanRules = excludeSpanRulesCache.get(tenantId);
+    if (excludeSpanRules.isEmpty()) {
+      return false;
+    }
+    //    boolean a = applyExcludeSpanRules(excludeSpanRules, event);
+    //    return a;
+    return applyExcludeSpanRules(excludeSpanRules, event);
   }
 
   private boolean applyExcludeSpanRules(
@@ -91,6 +100,11 @@ public class ExcludeSpanRuleEvaluator {
             excludeSpanRule ->
                 applyFilter(
                     excludeSpanRule.getRuleInfo().getFilter(), tags, processTags, serviceName));
+  }
+
+  private boolean applyExcludeSpanRules(List<ExcludeSpanRule> excludeSpanRules, Event event) {
+    return excludeSpanRules.stream()
+        .anyMatch(excludeSpanRule -> applyFilter(excludeSpanRule.getRuleInfo().getFilter(), event));
   }
 
   private boolean applyFilter(
@@ -116,6 +130,24 @@ public class ExcludeSpanRuleEvaluator {
     }
   }
 
+  private boolean applyFilter(SpanFilter filter, Event event) {
+    if (filter.hasRelationalSpanFilter()) {
+      return matchesRelationalSpanFilter(filter.getRelationalSpanFilter(), event);
+    } else {
+      LogicalSpanFilterExpression logicalSpanFilterExpression = filter.getLogicalSpanFilter();
+      if (filter
+          .getLogicalSpanFilter()
+          .getOperator()
+          .equals(LogicalOperator.LOGICAL_OPERATOR_AND)) {
+        return logicalSpanFilterExpression.getOperandsList().stream()
+            .allMatch(spanFilter -> applyFilter(spanFilter, event));
+      } else {
+        return logicalSpanFilterExpression.getOperandsList().stream()
+            .anyMatch(spanFilter -> applyFilter(spanFilter, event));
+      }
+    }
+  }
+
   private boolean matchesRelationalSpanFilter(
       RelationalSpanFilterExpression relationalSpanFilterExpression,
       Map<String, JaegerSpanInternalModel.KeyValue> tags,
@@ -134,7 +166,7 @@ public class ExcludeSpanRuleEvaluator {
       Field field = relationalSpanFilterExpression.getField();
       switch (field) {
         case FIELD_SERVICE_NAME:
-          return matches(
+          return spanFilterMatcher.matches(
               serviceName,
               relationalSpanFilterExpression.getRightOperand(),
               relationalSpanFilterExpression.getOperator());
@@ -162,67 +194,54 @@ public class ExcludeSpanRuleEvaluator {
     }
   }
 
+  private boolean matchesRelationalSpanFilter(
+      RelationalSpanFilterExpression relationalSpanFilterExpression, Event event) {
+
+    if (relationalSpanFilterExpression.hasSpanAttributeKey()) {
+      return false;
+    } else {
+      Field field = relationalSpanFilterExpression.getField();
+      switch (field) {
+        case FIELD_SERVICE_NAME:
+          return spanFilterMatcher.matches(
+              event.getServiceName(),
+              relationalSpanFilterExpression.getRightOperand(),
+              relationalSpanFilterExpression.getOperator());
+        case FIELD_ENVIRONMENT_NAME:
+          Optional<String> environmentMaybe =
+              HttpSemanticConventionUtils.getEnvironmentForSpan(event);
+          if (environmentMaybe.isEmpty()) {
+            return false;
+          }
+          return spanFilterMatcher.matches(
+              environmentMaybe.get(),
+              relationalSpanFilterExpression.getRightOperand(),
+              relationalSpanFilterExpression.getOperator());
+        case FIELD_URL:
+          Optional<String> fullHttpUrlMaybe = HttpSemanticConventionUtils.getFullHttpUrl(event);
+          if (fullHttpUrlMaybe.isEmpty()) {
+            return false;
+          }
+          return spanFilterMatcher.matches(
+              fullHttpUrlMaybe.get(),
+              relationalSpanFilterExpression.getRightOperand(),
+              relationalSpanFilterExpression.getOperator());
+        default:
+          log.error("Unknown filter field: {}", field);
+          return false;
+      }
+    }
+  }
+
   private boolean matches(
       Map<String, JaegerSpanInternalModel.KeyValue> tags,
       Map<String, JaegerSpanInternalModel.KeyValue> processTags,
       RelationalOperator operator,
       String lhs,
       SpanFilterValue rhs) {
-    return (tags.containsKey(lhs) && matches(tags.get(lhs).getVStr(), rhs, operator))
-        || (processTags.containsKey(lhs) && matches(processTags.get(lhs).getVStr(), rhs, operator));
-  }
-
-  private boolean matches(
-      String lhs,
-      String rhs,
-      org.hypertrace.span.processing.config.service.v1.RelationalOperator relationalOperator) {
-    switch (relationalOperator) {
-      case RELATIONAL_OPERATOR_CONTAINS:
-        return lhs.contains(rhs);
-      case RELATIONAL_OPERATOR_EQUALS:
-        return lhs.equals(rhs);
-      case RELATIONAL_OPERATOR_NOT_EQUALS:
-        return !lhs.equals(rhs);
-      case RELATIONAL_OPERATOR_STARTS_WITH:
-        return lhs.startsWith(rhs);
-      case RELATIONAL_OPERATOR_ENDS_WITH:
-        return lhs.endsWith(rhs);
-      case RELATIONAL_OPERATOR_REGEX_MATCH:
-        return lhs.matches(rhs);
-      default:
-        log.error("Unsupported relational operator for string value rhs:{}", relationalOperator);
-        return false;
-    }
-  }
-
-  private boolean matches(
-      String lhs,
-      ListValue rhs,
-      org.hypertrace.span.processing.config.service.v1.RelationalOperator relationalOperator) {
-    switch (relationalOperator) {
-      case RELATIONAL_OPERATOR_IN:
-        return rhs.getValuesList().stream()
-            .map(org.hypertrace.span.processing.config.service.v1.SpanFilterValue::getStringValue)
-            .collect(Collectors.toUnmodifiableList())
-            .contains(lhs);
-      default:
-        log.error("Unsupported relational operator for list value rhs:{}", relationalOperator);
-        return false;
-    }
-  }
-
-  private boolean matches(
-      String lhs,
-      org.hypertrace.span.processing.config.service.v1.SpanFilterValue rhs,
-      org.hypertrace.span.processing.config.service.v1.RelationalOperator relationalOperator) {
-    switch (rhs.getValueCase()) {
-      case STRING_VALUE:
-        return matches(lhs, rhs.getStringValue(), relationalOperator);
-      case LIST_VALUE:
-        return matches(lhs, rhs.getListValue(), relationalOperator);
-      default:
-        log.error("Unknown span filter value type:{}", rhs);
-        return false;
-    }
+    return (tags.containsKey(lhs)
+            && spanFilterMatcher.matches(tags.get(lhs).getVStr(), rhs, operator))
+        || (processTags.containsKey(lhs)
+            && spanFilterMatcher.matches(processTags.get(lhs).getVStr(), rhs, operator));
   }
 }

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ExcludeSpanRuleEvaluator.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ExcludeSpanRuleEvaluator.java
@@ -85,8 +85,6 @@ public class ExcludeSpanRuleEvaluator {
     if (excludeSpanRules.isEmpty()) {
       return false;
     }
-    //    boolean a = applyExcludeSpanRules(excludeSpanRules, event);
-    //    return a;
     return applyExcludeSpanRules(excludeSpanRules, event);
   }
 

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ExcludeSpanRuleEvaluator.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ExcludeSpanRuleEvaluator.java
@@ -15,6 +15,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.hypertrace.core.datamodel.AttributeValue;
+import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.spannormalizer.util.JaegerHTTagsConverter;
 import org.hypertrace.span.processing.config.service.v1.ExcludeSpanRule;
 import org.hypertrace.span.processing.config.service.v1.Field;
@@ -74,6 +75,10 @@ public class ExcludeSpanRuleEvaluator {
                 : StringUtils.EMPTY;
 
     return applyExcludeSpanRules(excludeSpanRules, tags, processTags, serviceName);
+  }
+
+  public boolean shouldDropEvent(Event event) {
+    return false;
   }
 
   private boolean applyExcludeSpanRules(

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -2,26 +2,15 @@ package org.hypertrace.core.spannormalizer.jaeger;
 
 import static org.hypertrace.core.datamodel.shared.AvroBuilderCache.fastNewBuilder;
 
-import com.google.protobuf.ProtocolStringList;
-import com.google.protobuf.util.Timestamps;
 import com.typesafe.config.Config;
-import io.jaegertracing.api_v2.JaegerSpanInternalModel;
-import io.jaegertracing.api_v2.JaegerSpanInternalModel.KeyValue;
 import io.jaegertracing.api_v2.JaegerSpanInternalModel.Span;
 import io.micrometer.core.instrument.Timer;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.avro.Schema;
@@ -30,22 +19,10 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.JsonEncoder;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.specific.SpecificRecordBase;
-import org.apache.commons.lang3.StringUtils;
-import org.hypertrace.core.datamodel.AttributeValue;
-import org.hypertrace.core.datamodel.Attributes;
 import org.hypertrace.core.datamodel.Event;
-import org.hypertrace.core.datamodel.EventRef;
-import org.hypertrace.core.datamodel.EventRefType;
-import org.hypertrace.core.datamodel.MetricValue;
-import org.hypertrace.core.datamodel.Metrics;
 import org.hypertrace.core.datamodel.RawSpan;
 import org.hypertrace.core.datamodel.RawSpan.Builder;
-import org.hypertrace.core.datamodel.eventfields.jaeger.JaegerFields;
-import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;
 import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
-import org.hypertrace.core.span.constants.RawSpanConstants;
-import org.hypertrace.core.span.constants.v1.JaegerAttribute;
-import org.hypertrace.core.spannormalizer.util.JaegerHTTagsConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,10 +60,7 @@ public class JaegerSpanNormalizer {
   }
 
   @Nullable
-  public RawSpan convert(String tenantId, Span jaegerSpan) throws Exception {
-    Map<String, KeyValue> tags =
-        jaegerSpan.getTagsList().stream()
-            .collect(Collectors.toMap(t -> t.getKey().toLowerCase(), t -> t, (v1, v2) -> v2));
+  public RawSpan convert(String tenantId, Span jaegerSpan, Event event) throws Exception {
 
     // Record the time taken for converting the span, along with the tenant id tag.
     return tenantToSpanNormalizationTimer
@@ -95,23 +69,23 @@ public class JaegerSpanNormalizer {
             tenant ->
                 PlatformMetricsRegistry.registerTimer(
                     SPAN_NORMALIZATION_TIME_METRIC, Map.of("tenantId", tenant)))
-        .recordCallable(getRawSpanNormalizerCallable(jaegerSpan, tags, tenantId));
+        .recordCallable(getRawSpanNormalizerCallable(jaegerSpan, tenantId, event));
   }
 
   @Nonnull
   private Callable<RawSpan> getRawSpanNormalizerCallable(
-      Span jaegerSpan, Map<String, KeyValue> spanTags, String tenantId) {
+      Span jaegerSpan, String tenantId, Event event) {
     return () -> {
       Builder rawSpanBuilder = fastNewBuilder(RawSpan.Builder.class);
       rawSpanBuilder.setCustomerId(tenantId);
       rawSpanBuilder.setTraceId(jaegerSpan.getTraceId().asReadOnlyByteBuffer());
       // Build Event
-      Event event =
-          buildEvent(
-              tenantId,
-              jaegerSpan,
-              spanTags,
-              tenantIdHandler.getTenantIdProvider().getTenantIdTagKey());
+      //      Event event =
+      //          buildEvent(
+      //              tenantId,
+      //              jaegerSpan,
+      //              spanTags,
+      //              tenantIdHandler.getTenantIdProvider().getTenantIdTagKey());
       rawSpanBuilder.setEvent(event);
       rawSpanBuilder.setReceivedTimeMillis(System.currentTimeMillis());
       resourceNormalizer
@@ -127,106 +101,109 @@ public class JaegerSpanNormalizer {
     };
   }
 
-  /**
-   * Builds the event object from the jaeger span. Note: tagsMap should contain keys that have
-   * already been converted to lowercase by the caller.
-   */
-  private Event buildEvent(
-      String tenantId,
-      Span jaegerSpan,
-      @Nonnull Map<String, KeyValue> tagsMap,
-      Optional<String> tenantIdKey) {
-    Event.Builder eventBuilder = fastNewBuilder(Event.Builder.class);
-    eventBuilder.setCustomerId(tenantId);
-    eventBuilder.setEventId(jaegerSpan.getSpanId().asReadOnlyByteBuffer());
-    eventBuilder.setEventName(jaegerSpan.getOperationName());
-
-    // time related stuff
-    long startTimeMillis = Timestamps.toMillis(jaegerSpan.getStartTime());
-    eventBuilder.setStartTimeMillis(startTimeMillis);
-    long endTimeMillis =
-        Timestamps.toMillis(Timestamps.add(jaegerSpan.getStartTime(), jaegerSpan.getDuration()));
-    eventBuilder.setEndTimeMillis(endTimeMillis);
-
-    // SPAN REFS
-    List<JaegerSpanInternalModel.SpanRef> referencesList = jaegerSpan.getReferencesList();
-    if (referencesList.size() > 0) {
-      eventBuilder.setEventRefList(new ArrayList<>());
-      // Convert the reflist to a set to remove duplicate references. This has been observed in the
-      // field.
-      Set<JaegerSpanInternalModel.SpanRef> referencesSet = new HashSet<>(referencesList);
-      for (JaegerSpanInternalModel.SpanRef spanRef : referencesSet) {
-        EventRef.Builder builder = fastNewBuilder(EventRef.Builder.class);
-        builder.setTraceId(spanRef.getTraceId().asReadOnlyByteBuffer());
-        builder.setEventId(spanRef.getSpanId().asReadOnlyByteBuffer());
-        builder.setRefType(EventRefType.valueOf(spanRef.getRefType().toString()));
-        eventBuilder.getEventRefList().add(builder.build());
-      }
-    }
-
-    // span attributes to event attributes
-    Map<String, AttributeValue> attributeFieldMap = new HashMap<>();
-    eventBuilder.setAttributesBuilder(
-        fastNewBuilder(Attributes.Builder.class).setAttributeMap(attributeFieldMap));
-
-    List<KeyValue> tagsList = jaegerSpan.getTagsList();
-    // Stop populating first class fields for - grpc, rpc, http, and sql.
-    // see more details:
-    // https://github.com/hypertrace/hypertrace/issues/244
-    // https://github.com/hypertrace/hypertrace/issues/245
-    for (KeyValue keyValue : tagsList) {
-      // Convert all attributes to lower case so that we don't have to
-      // deal with the case sensitivity across different layers in the
-      // platform.
-      String key = keyValue.getKey().toLowerCase();
-      // Do not add the tenant id to the tags.
-      if ((tenantIdKey.isPresent() && key.equals(tenantIdKey.get()))) {
-        continue;
-      }
-      attributeFieldMap.put(key, JaegerHTTagsConverter.createFromJaegerKeyValue(keyValue));
-    }
-
-    // Jaeger Fields - flags, warnings, logs, jaeger service name in the Process
-    JaegerFields.Builder jaegerFieldsBuilder = eventBuilder.getJaegerFieldsBuilder();
-    // FLAGS
-    jaegerFieldsBuilder.setFlags(jaegerSpan.getFlags());
-
-    // WARNINGS
-    ProtocolStringList warningsList = jaegerSpan.getWarningsList();
-    if (warningsList.size() > 0) {
-      jaegerFieldsBuilder.setWarnings(warningsList);
-    }
-
-    // Jaeger service name can come from either first class field in Span or the tag
-    // `jaeger.servicename`
-    String serviceName =
-        !StringUtils.isEmpty(jaegerSpan.getProcess().getServiceName())
-            ? jaegerSpan.getProcess().getServiceName()
-            : attributeFieldMap.containsKey(OLD_JAEGER_SERVICENAME_KEY)
-                ? attributeFieldMap.get(OLD_JAEGER_SERVICENAME_KEY).getValue()
-                : StringUtils.EMPTY;
-
-    if (!StringUtils.isEmpty(serviceName)) {
-      eventBuilder.setServiceName(serviceName);
-      // in case `jaeger.servicename` is present in the map, remove it
-      attributeFieldMap.remove(OLD_JAEGER_SERVICENAME_KEY);
-      attributeFieldMap.put(
-          RawSpanConstants.getValue(JaegerAttribute.JAEGER_ATTRIBUTE_SERVICE_NAME),
-          AttributeValueCreator.create(serviceName));
-    }
-
-    // EVENT METRICS
-    Map<String, MetricValue> metricMap = new HashMap<>();
-    MetricValue durationMetric =
-        fastNewBuilder(MetricValue.Builder.class)
-            .setValue((double) (endTimeMillis - startTimeMillis))
-            .build();
-    metricMap.put("Duration", durationMetric);
-
-    eventBuilder.setMetrics(fastNewBuilder(Metrics.Builder.class).setMetricMap(metricMap).build());
-
-    return eventBuilder.build();
-  }
+  //  /**
+  //   * Builds the event object from the jaeger span. Note: tagsMap should contain keys that have
+  //   * already been converted to lowercase by the caller.
+  //   */
+  //  private Event buildEvent(
+  //      String tenantId,
+  //      Span jaegerSpan,
+  //      @Nonnull Map<String, KeyValue> tagsMap,
+  //      Optional<String> tenantIdKey) {
+  //    Event.Builder eventBuilder = fastNewBuilder(Event.Builder.class);
+  //    eventBuilder.setCustomerId(tenantId);
+  //    eventBuilder.setEventId(jaegerSpan.getSpanId().asReadOnlyByteBuffer());
+  //    eventBuilder.setEventName(jaegerSpan.getOperationName());
+  //
+  //    // time related stuff
+  //    long startTimeMillis = Timestamps.toMillis(jaegerSpan.getStartTime());
+  //    eventBuilder.setStartTimeMillis(startTimeMillis);
+  //    long endTimeMillis =
+  //        Timestamps.toMillis(Timestamps.add(jaegerSpan.getStartTime(),
+  // jaegerSpan.getDuration()));
+  //    eventBuilder.setEndTimeMillis(endTimeMillis);
+  //
+  //    // SPAN REFS
+  //    List<JaegerSpanInternalModel.SpanRef> referencesList = jaegerSpan.getReferencesList();
+  //    if (referencesList.size() > 0) {
+  //      eventBuilder.setEventRefList(new ArrayList<>());
+  //      // Convert the reflist to a set to remove duplicate references. This has been observed in
+  // the
+  //      // field.
+  //      Set<JaegerSpanInternalModel.SpanRef> referencesSet = new HashSet<>(referencesList);
+  //      for (JaegerSpanInternalModel.SpanRef spanRef : referencesSet) {
+  //        EventRef.Builder builder = fastNewBuilder(EventRef.Builder.class);
+  //        builder.setTraceId(spanRef.getTraceId().asReadOnlyByteBuffer());
+  //        builder.setEventId(spanRef.getSpanId().asReadOnlyByteBuffer());
+  //        builder.setRefType(EventRefType.valueOf(spanRef.getRefType().toString()));
+  //        eventBuilder.getEventRefList().add(builder.build());
+  //      }
+  //    }
+  //
+  //    // span attributes to event attributes
+  //    Map<String, AttributeValue> attributeFieldMap = new HashMap<>();
+  //    eventBuilder.setAttributesBuilder(
+  //        fastNewBuilder(Attributes.Builder.class).setAttributeMap(attributeFieldMap));
+  //
+  //    List<KeyValue> tagsList = jaegerSpan.getTagsList();
+  //    // Stop populating first class fields for - grpc, rpc, http, and sql.
+  //    // see more details:
+  //    // https://github.com/hypertrace/hypertrace/issues/244
+  //    // https://github.com/hypertrace/hypertrace/issues/245
+  //    for (KeyValue keyValue : tagsList) {
+  //      // Convert all attributes to lower case so that we don't have to
+  //      // deal with the case sensitivity across different layers in the
+  //      // platform.
+  //      String key = keyValue.getKey().toLowerCase();
+  //      // Do not add the tenant id to the tags.
+  //      if ((tenantIdKey.isPresent() && key.equals(tenantIdKey.get()))) {
+  //        continue;
+  //      }
+  //      attributeFieldMap.put(key, JaegerHTTagsConverter.createFromJaegerKeyValue(keyValue));
+  //    }
+  //
+  //    // Jaeger Fields - flags, warnings, logs, jaeger service name in the Process
+  //    JaegerFields.Builder jaegerFieldsBuilder = eventBuilder.getJaegerFieldsBuilder();
+  //    // FLAGS
+  //    jaegerFieldsBuilder.setFlags(jaegerSpan.getFlags());
+  //
+  //    // WARNINGS
+  //    ProtocolStringList warningsList = jaegerSpan.getWarningsList();
+  //    if (warningsList.size() > 0) {
+  //      jaegerFieldsBuilder.setWarnings(warningsList);
+  //    }
+  //
+  //    // Jaeger service name can come from either first class field in Span or the tag
+  //    // `jaeger.servicename`
+  //    String serviceName =
+  //        !StringUtils.isEmpty(jaegerSpan.getProcess().getServiceName())
+  //            ? jaegerSpan.getProcess().getServiceName()
+  //            : attributeFieldMap.containsKey(OLD_JAEGER_SERVICENAME_KEY)
+  //                ? attributeFieldMap.get(OLD_JAEGER_SERVICENAME_KEY).getValue()
+  //                : StringUtils.EMPTY;
+  //
+  //    if (!StringUtils.isEmpty(serviceName)) {
+  //      eventBuilder.setServiceName(serviceName);
+  //      // in case `jaeger.servicename` is present in the map, remove it
+  //      attributeFieldMap.remove(OLD_JAEGER_SERVICENAME_KEY);
+  //      attributeFieldMap.put(
+  //          RawSpanConstants.getValue(JaegerAttribute.JAEGER_ATTRIBUTE_SERVICE_NAME),
+  //          AttributeValueCreator.create(serviceName));
+  //    }
+  //
+  //    // EVENT METRICS
+  //    Map<String, MetricValue> metricMap = new HashMap<>();
+  //    MetricValue durationMetric =
+  //        fastNewBuilder(MetricValue.Builder.class)
+  //            .setValue((double) (endTimeMillis - startTimeMillis))
+  //            .build();
+  //    metricMap.put("Duration", durationMetric);
+  //
+  //
+  // eventBuilder.setMetrics(fastNewBuilder(Metrics.Builder.class).setMetricMap(metricMap).build());
+  //
+  //    return eventBuilder.build();
+  //  }
 
   // Check if debug log is enabled before calling this method
   private void logSpanConversion(Span jaegerSpan, RawSpan rawSpan) {

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -79,13 +79,6 @@ public class JaegerSpanNormalizer {
       Builder rawSpanBuilder = fastNewBuilder(RawSpan.Builder.class);
       rawSpanBuilder.setCustomerId(tenantId);
       rawSpanBuilder.setTraceId(jaegerSpan.getTraceId().asReadOnlyByteBuffer());
-      // Build Event
-      //      Event event =
-      //          buildEvent(
-      //              tenantId,
-      //              jaegerSpan,
-      //              spanTags,
-      //              tenantIdHandler.getTenantIdProvider().getTenantIdTagKey());
       rawSpanBuilder.setEvent(event);
       rawSpanBuilder.setReceivedTimeMillis(System.currentTimeMillis());
       resourceNormalizer
@@ -100,110 +93,6 @@ public class JaegerSpanNormalizer {
       return rawSpan;
     };
   }
-
-  //  /**
-  //   * Builds the event object from the jaeger span. Note: tagsMap should contain keys that have
-  //   * already been converted to lowercase by the caller.
-  //   */
-  //  private Event buildEvent(
-  //      String tenantId,
-  //      Span jaegerSpan,
-  //      @Nonnull Map<String, KeyValue> tagsMap,
-  //      Optional<String> tenantIdKey) {
-  //    Event.Builder eventBuilder = fastNewBuilder(Event.Builder.class);
-  //    eventBuilder.setCustomerId(tenantId);
-  //    eventBuilder.setEventId(jaegerSpan.getSpanId().asReadOnlyByteBuffer());
-  //    eventBuilder.setEventName(jaegerSpan.getOperationName());
-  //
-  //    // time related stuff
-  //    long startTimeMillis = Timestamps.toMillis(jaegerSpan.getStartTime());
-  //    eventBuilder.setStartTimeMillis(startTimeMillis);
-  //    long endTimeMillis =
-  //        Timestamps.toMillis(Timestamps.add(jaegerSpan.getStartTime(),
-  // jaegerSpan.getDuration()));
-  //    eventBuilder.setEndTimeMillis(endTimeMillis);
-  //
-  //    // SPAN REFS
-  //    List<JaegerSpanInternalModel.SpanRef> referencesList = jaegerSpan.getReferencesList();
-  //    if (referencesList.size() > 0) {
-  //      eventBuilder.setEventRefList(new ArrayList<>());
-  //      // Convert the reflist to a set to remove duplicate references. This has been observed in
-  // the
-  //      // field.
-  //      Set<JaegerSpanInternalModel.SpanRef> referencesSet = new HashSet<>(referencesList);
-  //      for (JaegerSpanInternalModel.SpanRef spanRef : referencesSet) {
-  //        EventRef.Builder builder = fastNewBuilder(EventRef.Builder.class);
-  //        builder.setTraceId(spanRef.getTraceId().asReadOnlyByteBuffer());
-  //        builder.setEventId(spanRef.getSpanId().asReadOnlyByteBuffer());
-  //        builder.setRefType(EventRefType.valueOf(spanRef.getRefType().toString()));
-  //        eventBuilder.getEventRefList().add(builder.build());
-  //      }
-  //    }
-  //
-  //    // span attributes to event attributes
-  //    Map<String, AttributeValue> attributeFieldMap = new HashMap<>();
-  //    eventBuilder.setAttributesBuilder(
-  //        fastNewBuilder(Attributes.Builder.class).setAttributeMap(attributeFieldMap));
-  //
-  //    List<KeyValue> tagsList = jaegerSpan.getTagsList();
-  //    // Stop populating first class fields for - grpc, rpc, http, and sql.
-  //    // see more details:
-  //    // https://github.com/hypertrace/hypertrace/issues/244
-  //    // https://github.com/hypertrace/hypertrace/issues/245
-  //    for (KeyValue keyValue : tagsList) {
-  //      // Convert all attributes to lower case so that we don't have to
-  //      // deal with the case sensitivity across different layers in the
-  //      // platform.
-  //      String key = keyValue.getKey().toLowerCase();
-  //      // Do not add the tenant id to the tags.
-  //      if ((tenantIdKey.isPresent() && key.equals(tenantIdKey.get()))) {
-  //        continue;
-  //      }
-  //      attributeFieldMap.put(key, JaegerHTTagsConverter.createFromJaegerKeyValue(keyValue));
-  //    }
-  //
-  //    // Jaeger Fields - flags, warnings, logs, jaeger service name in the Process
-  //    JaegerFields.Builder jaegerFieldsBuilder = eventBuilder.getJaegerFieldsBuilder();
-  //    // FLAGS
-  //    jaegerFieldsBuilder.setFlags(jaegerSpan.getFlags());
-  //
-  //    // WARNINGS
-  //    ProtocolStringList warningsList = jaegerSpan.getWarningsList();
-  //    if (warningsList.size() > 0) {
-  //      jaegerFieldsBuilder.setWarnings(warningsList);
-  //    }
-  //
-  //    // Jaeger service name can come from either first class field in Span or the tag
-  //    // `jaeger.servicename`
-  //    String serviceName =
-  //        !StringUtils.isEmpty(jaegerSpan.getProcess().getServiceName())
-  //            ? jaegerSpan.getProcess().getServiceName()
-  //            : attributeFieldMap.containsKey(OLD_JAEGER_SERVICENAME_KEY)
-  //                ? attributeFieldMap.get(OLD_JAEGER_SERVICENAME_KEY).getValue()
-  //                : StringUtils.EMPTY;
-  //
-  //    if (!StringUtils.isEmpty(serviceName)) {
-  //      eventBuilder.setServiceName(serviceName);
-  //      // in case `jaeger.servicename` is present in the map, remove it
-  //      attributeFieldMap.remove(OLD_JAEGER_SERVICENAME_KEY);
-  //      attributeFieldMap.put(
-  //          RawSpanConstants.getValue(JaegerAttribute.JAEGER_ATTRIBUTE_SERVICE_NAME),
-  //          AttributeValueCreator.create(serviceName));
-  //    }
-  //
-  //    // EVENT METRICS
-  //    Map<String, MetricValue> metricMap = new HashMap<>();
-  //    MetricValue durationMetric =
-  //        fastNewBuilder(MetricValue.Builder.class)
-  //            .setValue((double) (endTimeMillis - startTimeMillis))
-  //            .build();
-  //    metricMap.put("Duration", durationMetric);
-  //
-  //
-  // eventBuilder.setMetrics(fastNewBuilder(Metrics.Builder.class).setMetricMap(metricMap).build());
-  //
-  //    return eventBuilder.build();
-  //  }
 
   // Check if debug log is enabled before calling this method
   private void logSpanConversion(Span jaegerSpan, RawSpan rawSpan) {

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
@@ -103,8 +103,8 @@ public class JaegerSpanPreProcessor
     Event event =
         buildEvent(tenantId, span, tenantIdHandler.getTenantIdProvider().getTenantIdTagKey());
 
-    if (spanDropManager.shouldDropSpan(span, spanTags, processTags)
-        || spanDropManager.shouldDropEvent(event)) {
+    if (spanDropManager.shouldDropSpan(span, tenantId)
+        || spanDropManager.shouldDropEvent(event, tenantId)) {
       return null;
     }
 

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
@@ -1,6 +1,7 @@
 package org.hypertrace.core.spannormalizer.jaeger;
 
 import static org.hypertrace.core.spannormalizer.constants.SpanNormalizerConstants.SPAN_NORMALIZER_JOB_CONFIG;
+import static org.hypertrace.core.spannormalizer.util.EventBuilder.buildEvent;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.typesafe.config.Config;
@@ -8,12 +9,14 @@ import io.jaegertracing.api_v2.JaegerSpanInternalModel;
 import io.jaegertracing.api_v2.JaegerSpanInternalModel.Span;
 import io.micrometer.core.instrument.Counter;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.processor.ProcessorContext;
+import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,14 +94,23 @@ public class JaegerSpanPreProcessor
         span.getProcess().getTagsList().stream()
             .collect(Collectors.toMap(t -> t.getKey().toLowerCase(), t -> t, (v1, v2) -> v2));
 
-    if (spanDropManager.shouldDropSpan(span, spanTags, processTags)) {
+    Optional<String> tenantIdMaybe =
+        tenantIdHandler.getAllowedTenantId(span, spanTags, processTags);
+    if (tenantIdMaybe.isEmpty()) {
+      return null;
+    }
+    String tenantId = tenantIdMaybe.get();
+    Event event =
+        buildEvent(tenantId, span, tenantIdHandler.getTenantIdProvider().getTenantIdTagKey());
+
+    if (spanDropManager.shouldDropSpan(span, spanTags, processTags)
+        || spanDropManager.shouldDropEvent(event)) {
       return null;
     }
 
     // filter tags
-    String tenantId = tenantIdHandler.getAllowedTenantId(span, spanTags, processTags).get();
     Span processedSpan = tagsFilter.apply(tenantId, span);
-    return new PreProcessedSpan(tenantId, processedSpan);
+    return new PreProcessedSpan(tenantId, processedSpan, event);
   }
 
   @Override

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
@@ -100,21 +100,17 @@ public class JaegerSpanPreProcessor
       return null;
     }
     String tenantId = tenantIdMaybe.get();
+    // filter tags
+    Span processedSpan = tagsFilter.apply(tenantId, span);
     Event event =
-        buildEvent(tenantId, span, tenantIdHandler.getTenantIdProvider().getTenantIdTagKey());
+        buildEvent(
+            tenantId, processedSpan, tenantIdHandler.getTenantIdProvider().getTenantIdTagKey());
 
-    if (spanDropManager.shouldDropSpan(span, tenantId)
-        || spanDropManager.shouldDropEvent(event, tenantId)) {
+    if (spanDropManager.shouldDropSpan(span, event, tenantId)) {
       return null;
     }
 
-    // filter tags
-    Span processedSpan = tagsFilter.apply(tenantId, span);
-    return new PreProcessedSpan(
-        tenantId,
-        processedSpan,
-        buildEvent(
-            tenantId, processedSpan, tenantIdHandler.getTenantIdProvider().getTenantIdTagKey()));
+    return new PreProcessedSpan(tenantId, processedSpan, event);
   }
 
   @Override

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
@@ -110,7 +110,11 @@ public class JaegerSpanPreProcessor
 
     // filter tags
     Span processedSpan = tagsFilter.apply(tenantId, span);
-    return new PreProcessedSpan(tenantId, processedSpan, event);
+    return new PreProcessedSpan(
+        tenantId,
+        processedSpan,
+        buildEvent(
+            tenantId, processedSpan, tenantIdHandler.getTenantIdProvider().getTenantIdTagKey()));
   }
 
   @Override

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanToAvroRawSpanTransformer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanToAvroRawSpanTransformer.java
@@ -45,7 +45,7 @@ public class JaegerSpanToAvroRawSpanTransformer
     Span value = preProcessedSpan.getSpan();
     String tenantId = preProcessedSpan.getTenantId();
     try {
-      RawSpan rawSpan = converter.convert(tenantId, value);
+      RawSpan rawSpan = converter.convert(tenantId, value, preProcessedSpan.getEvent());
       if (null != rawSpan) {
         // these are spans per tenant that we were able to parse / convert, and had tenantId.
         tenantToSpanReceivedCount

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/PreProcessedSpan.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/PreProcessedSpan.java
@@ -1,15 +1,18 @@
 package org.hypertrace.core.spannormalizer.jaeger;
 
 import io.jaegertracing.api_v2.JaegerSpanInternalModel.Span;
+import org.hypertrace.core.datamodel.Event;
 
 public class PreProcessedSpan {
 
   private final String tenantId;
   private final Span span;
+  private final Event event;
 
-  public PreProcessedSpan(String tenantId, Span span) {
+  public PreProcessedSpan(String tenantId, Span span, Event event) {
     this.tenantId = tenantId;
     this.span = span;
+    this.event = event;
   }
 
   public String getTenantId() {
@@ -18,5 +21,9 @@ public class PreProcessedSpan {
 
   public Span getSpan() {
     return span;
+  }
+
+  public Event getEvent() {
+    return event;
   }
 }

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanDropManager.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanDropManager.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import lombok.extern.slf4j.Slf4j;
+import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
 
 @Slf4j
@@ -88,6 +89,10 @@ public class SpanDropManager {
         || shouldDropSpansBasedOnSpanFilter(tenantId, span, spanTags, processTags)
         || shouldDropSpansBasedOnExcludeRules(tenantId, span, spanTags, processTags)
         || shouldDropSpansBasedOnLateArrival(tenantId, span);
+  }
+
+  public boolean shouldDropEvent(Event event) {
+    return excludeSpanRuleEvaluator.shouldDropEvent(event);
   }
 
   private boolean shouldDropSpansBasedOnSpanFilter(

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/util/EventBuilder.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/util/EventBuilder.java
@@ -1,0 +1,123 @@
+package org.hypertrace.core.spannormalizer.util;
+
+import static org.hypertrace.core.datamodel.shared.AvroBuilderCache.fastNewBuilder;
+import static org.hypertrace.core.spannormalizer.jaeger.JaegerSpanNormalizer.OLD_JAEGER_SERVICENAME_KEY;
+
+import com.google.protobuf.ProtocolStringList;
+import com.google.protobuf.util.Timestamps;
+import io.jaegertracing.api_v2.JaegerSpanInternalModel;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
+import org.hypertrace.core.datamodel.AttributeValue;
+import org.hypertrace.core.datamodel.Attributes;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.EventRef;
+import org.hypertrace.core.datamodel.EventRefType;
+import org.hypertrace.core.datamodel.MetricValue;
+import org.hypertrace.core.datamodel.Metrics;
+import org.hypertrace.core.datamodel.eventfields.jaeger.JaegerFields;
+import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;
+import org.hypertrace.core.span.constants.RawSpanConstants;
+import org.hypertrace.core.span.constants.v1.JaegerAttribute;
+
+public class EventBuilder {
+  public static Event buildEvent(
+      String tenantId, JaegerSpanInternalModel.Span jaegerSpan, Optional<String> tenantIdKey) {
+    Event.Builder eventBuilder = fastNewBuilder(Event.Builder.class);
+    eventBuilder.setCustomerId(tenantId);
+    eventBuilder.setEventId(jaegerSpan.getSpanId().asReadOnlyByteBuffer());
+    eventBuilder.setEventName(jaegerSpan.getOperationName());
+
+    // time related stuff
+    long startTimeMillis = Timestamps.toMillis(jaegerSpan.getStartTime());
+    eventBuilder.setStartTimeMillis(startTimeMillis);
+    long endTimeMillis =
+        Timestamps.toMillis(Timestamps.add(jaegerSpan.getStartTime(), jaegerSpan.getDuration()));
+    eventBuilder.setEndTimeMillis(endTimeMillis);
+
+    // SPAN REFS
+    List<JaegerSpanInternalModel.SpanRef> referencesList = jaegerSpan.getReferencesList();
+    if (referencesList.size() > 0) {
+      eventBuilder.setEventRefList(new ArrayList<>());
+      // Convert the reflist to a set to remove duplicate references. This has been observed in the
+      // field.
+      Set<JaegerSpanInternalModel.SpanRef> referencesSet = new HashSet<>(referencesList);
+      for (JaegerSpanInternalModel.SpanRef spanRef : referencesSet) {
+        EventRef.Builder builder = fastNewBuilder(EventRef.Builder.class);
+        builder.setTraceId(spanRef.getTraceId().asReadOnlyByteBuffer());
+        builder.setEventId(spanRef.getSpanId().asReadOnlyByteBuffer());
+        builder.setRefType(EventRefType.valueOf(spanRef.getRefType().toString()));
+        eventBuilder.getEventRefList().add(builder.build());
+      }
+    }
+
+    // span attributes to event attributes
+    Map<String, AttributeValue> attributeFieldMap = new HashMap<>();
+    eventBuilder.setAttributesBuilder(
+        fastNewBuilder(Attributes.Builder.class).setAttributeMap(attributeFieldMap));
+
+    List<JaegerSpanInternalModel.KeyValue> tagsList = jaegerSpan.getTagsList();
+    // Stop populating first class fields for - grpc, rpc, http, and sql.
+    // see more details:
+    // https://github.com/hypertrace/hypertrace/issues/244
+    // https://github.com/hypertrace/hypertrace/issues/245
+    for (JaegerSpanInternalModel.KeyValue keyValue : tagsList) {
+      // Convert all attributes to lower case so that we don't have to
+      // deal with the case sensitivity across different layers in the
+      // platform.
+      String key = keyValue.getKey().toLowerCase();
+      // Do not add the tenant id to the tags.
+      if ((tenantIdKey.isPresent() && key.equals(tenantIdKey.get()))) {
+        continue;
+      }
+      attributeFieldMap.put(key, JaegerHTTagsConverter.createFromJaegerKeyValue(keyValue));
+    }
+
+    // Jaeger Fields - flags, warnings, logs, jaeger service name in the Process
+    JaegerFields.Builder jaegerFieldsBuilder = eventBuilder.getJaegerFieldsBuilder();
+    // FLAGS
+    jaegerFieldsBuilder.setFlags(jaegerSpan.getFlags());
+
+    // WARNINGS
+    ProtocolStringList warningsList = jaegerSpan.getWarningsList();
+    if (warningsList.size() > 0) {
+      jaegerFieldsBuilder.setWarnings(warningsList);
+    }
+
+    // Jaeger service name can come from either first class field in Span or the tag
+    // `jaeger.servicename`
+    String serviceName =
+        !StringUtils.isEmpty(jaegerSpan.getProcess().getServiceName())
+            ? jaegerSpan.getProcess().getServiceName()
+            : attributeFieldMap.containsKey(OLD_JAEGER_SERVICENAME_KEY)
+                ? attributeFieldMap.get(OLD_JAEGER_SERVICENAME_KEY).getValue()
+                : StringUtils.EMPTY;
+
+    if (!StringUtils.isEmpty(serviceName)) {
+      eventBuilder.setServiceName(serviceName);
+      // in case `jaeger.servicename` is present in the map, remove it
+      attributeFieldMap.remove(OLD_JAEGER_SERVICENAME_KEY);
+      attributeFieldMap.put(
+          RawSpanConstants.getValue(JaegerAttribute.JAEGER_ATTRIBUTE_SERVICE_NAME),
+          AttributeValueCreator.create(serviceName));
+    }
+
+    // EVENT METRICS
+    Map<String, MetricValue> metricMap = new HashMap<>();
+    MetricValue durationMetric =
+        fastNewBuilder(MetricValue.Builder.class)
+            .setValue((double) (endTimeMillis - startTimeMillis))
+            .build();
+    metricMap.put("Duration", durationMetric);
+
+    eventBuilder.setMetrics(fastNewBuilder(Metrics.Builder.class).setMetricMap(metricMap).build());
+
+    return eventBuilder.build();
+  }
+}

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
@@ -1,6 +1,7 @@
 package org.hypertrace.core.spannormalizer.jaeger;
 
 import static org.hypertrace.core.span.constants.v1.Http.HTTP_REQUEST_METHOD;
+import static org.hypertrace.core.spannormalizer.util.EventBuilder.buildEvent;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -13,6 +14,7 @@ import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.RawSpan;
@@ -141,7 +143,8 @@ public class JaegerSpanNormalizerTest {
     JaegerSpanNormalizer normalizer = JaegerSpanNormalizer.get(ConfigFactory.parseMap(configs));
     Process process = Process.newBuilder().setServiceName("testService").build();
     Span span = Span.newBuilder().setProcess(process).build();
-    RawSpan rawSpan = normalizer.convert("tenant-key", span);
+    RawSpan rawSpan =
+        normalizer.convert(tenantId, span, buildEvent(tenantId, span, Optional.empty()));
     Assertions.assertEquals("testService", rawSpan.getEvent().getServiceName());
     Assertions.assertEquals(
         "testService",
@@ -167,7 +170,7 @@ public class JaegerSpanNormalizerTest {
                     .setKey(RawSpanConstants.getValue(HTTP_REQUEST_METHOD))
                     .setVStr("GET"))
             .build();
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan = normalizer.convert("tenant-key", span, buildEvent(tenantId, span, Optional.empty()));
     Assertions.assertEquals("testService", rawSpan.getEvent().getServiceName());
     Assertions.assertEquals(
         "testService",
@@ -186,7 +189,7 @@ public class JaegerSpanNormalizerTest {
         Span.newBuilder()
             .addTags(KeyValue.newBuilder().setKey("someKey").setVStr("someValue"))
             .build();
-    rawSpan = normalizer.convert("tenant-key", span);
+    rawSpan = normalizer.convert("tenant-key", span, buildEvent(tenantId, span, Optional.empty()));
     Assertions.assertNull(rawSpan.getEvent().getServiceName());
     Assertions.assertNotNull(rawSpan.getEvent().getAttributes().getAttributeMap());
     Assertions.assertNull(
@@ -206,7 +209,8 @@ public class JaegerSpanNormalizerTest {
     Process process = Process.newBuilder().build();
     Span span = Span.newBuilder().setProcess(process).build();
 
-    RawSpan rawSpan = normalizer.convert(tenantId, span);
+    RawSpan rawSpan =
+        normalizer.convert(tenantId, span, buildEvent(tenantId, span, Optional.empty()));
     Assertions.assertNull(rawSpan.getEvent().getServiceName());
     Assertions.assertNull(
         rawSpan

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessorTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessorTest.java
@@ -1123,6 +1123,25 @@ class JaegerSpanPreProcessorTest {
             .build();
     preProcessedSpan = jaegerSpanPreProcessor.preProcessSpan(span);
     Assertions.assertNull(preProcessedSpan);
+
+    // case8: same as above but with rule disabled. So don't drop span
+    when(excludeSpanRulesCache.get(any()))
+        .thenReturn(
+            List.of(
+                ExcludeSpanRule.newBuilder()
+                    .setRuleInfo(
+                        ExcludeSpanRuleInfo.newBuilder()
+                            .setDisabled(true)
+                            .setFilter(
+                                buildRelationalFilter(
+                                    Field.FIELD_URL,
+                                    null,
+                                    RelationalOperator.RELATIONAL_OPERATOR_CONTAINS,
+                                    "health"))
+                            .build())
+                    .build()));
+    preProcessedSpan = jaegerSpanPreProcessor.preProcessSpan(span);
+    Assertions.assertNotNull(preProcessedSpan);
   }
 
   @Test

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanToLogRecordsTransformerTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanToLogRecordsTransformerTest.java
@@ -1,5 +1,7 @@
 package org.hypertrace.core.spannormalizer.jaeger;
 
+import static org.hypertrace.core.spannormalizer.util.EventBuilder.buildEvent;
+
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 import com.typesafe.config.ConfigFactory;
@@ -9,6 +11,7 @@ import io.jaegertracing.api_v2.JaegerSpanInternalModel.Span;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.hypertrace.core.datamodel.LogEvents;
@@ -45,7 +48,11 @@ public class JaegerSpanToLogRecordsTransformerTest {
     jaegerSpanToLogRecordsTransformer.init(processorContext);
     KeyValue<String, LogEvents> keyValue =
         jaegerSpanToLogRecordsTransformer.transform(
-            null, new PreProcessedSpan("tenant-1", getTestSpan()));
+            null,
+            new PreProcessedSpan(
+                "tenant-1",
+                getTestSpan(),
+                buildEvent("tenant-1", getTestSpan(), Optional.of("tenant-key"))));
     Assertions.assertNull(keyValue);
   }
 


### PR DESCRIPTION
This PR makes one major change in adding `Event` to `PreprocessedSpan`. The reason being the following:
 We observed that the dropping of spans  via Exclude span rules was not working on few of the spans.  The reason for this is as follows. There are different ways in which the full url can be constructed from the span using the various attributes. It could either be available directly under some span attribute(say like `http.url`) or would have to be constructed from multiple such attributes(like in OTel format, construct from `http.scheme`, `http.host` and `http.target`). We have a method called `getFullHttpUrl` which takes into account all the factors and builds the full http url. However, it takes in `Event` object and constructs it. 
To make use of this method in span exclusion using Exclude span rules, we have added `Event` into `PreProcessedSpan`.