### PR TITLE
feat: update view-gen framework to use multiple input topics

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,9 +5,9 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: no available replacement
-        expires: 2022-03-31T00:00:00.000Z
+        expires: 2022-05-31T00:00:00.000Z
   SNYK-JAVA-COMGOOGLEPROTOBUF-2331703:
     - '*':
         reason: introduced by io.opentelemetry:opentelemetry-proto@1.6.0-alpha
-        expires: 2022-03-31T00:00:00.000Z
+        expires: 2022-05-31T00:00:00.000Z
 patch: {}

--- a/hypertrace-ingester/build.gradle.kts
+++ b/hypertrace-ingester/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.33")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
   implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
-  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.3.9")
+  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.4.1")
   implementation("com.typesafe:config:1.4.1")
   implementation("org.apache.commons:commons-lang3:3.12.0")
 

--- a/hypertrace-ingester/build.gradle.kts
+++ b/hypertrace-ingester/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
   implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.25")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.33")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
   implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.4.1")
   implementation("com.typesafe:config:1.4.1")
   implementation("org.apache.commons:commons-lang3:3.12.0")

--- a/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
+++ b/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
 
   // constrains
   constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.2") {
       because("Denial of Service (DoS) " +
           "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] " +
           "in com.fasterxml.jackson.core:jackson-databind@2.13.1")

--- a/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
+++ b/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
@@ -45,10 +45,10 @@ dependencies {
 
   // constrains
   constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
       because("Denial of Service (DoS) " +
-          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
 

--- a/hypertrace-metrics-generator/hypertrace-metrics-generator/build.gradle.kts
+++ b/hypertrace-metrics-generator/hypertrace-metrics-generator/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     implementation("org.glassfish.jersey.core:jersey-common:2.34") {
       because("https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-1255637")
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.2") {
       because("Denial of Service (DoS) " +
           "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] " +
           "in com.fasterxml.jackson.core:jackson-databind@2.13.1")

--- a/hypertrace-metrics-generator/hypertrace-metrics-generator/build.gradle.kts
+++ b/hypertrace-metrics-generator/hypertrace-metrics-generator/build.gradle.kts
@@ -40,10 +40,10 @@ dependencies {
     implementation("org.glassfish.jersey.core:jersey-common:2.34") {
       because("https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-1255637")
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
       because("Denial of Service (DoS) " +
-          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
 

--- a/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
+++ b/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
@@ -43,10 +43,10 @@ dependencies {
           "io.confluent:kafka-schema-registry-client@6.0.1 > " +
           "org.glassfish.jersey.core:jersey-common@2.30")
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
       because("Denial of Service (DoS) " +
-          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
+          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
 

--- a/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
+++ b/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
           "io.confluent:kafka-schema-registry-client@6.0.1 > " +
           "org.glassfish.jersey.core:jersey-common@2.30")
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.2") {
       because("Denial of Service (DoS) " +
           "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
           "com.fasterxml.jackson.core:jackson-databind@2.13.1")

--- a/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
+++ b/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
@@ -72,10 +72,10 @@ dependencies {
   implementation("org.hypertrace.entity.service:entity-service-api:0.8.5")
 
   constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
       because("Denial of Service (DoS) " +
-          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
+          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
 

--- a/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
+++ b/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
@@ -65,19 +65,11 @@ sourceSets {
 dependencies {
   api("com.google.protobuf:protobuf-java-util:3.17.3")
 
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
   implementation(project(":span-normalizer:raw-span-constants"))
   implementation(project(":span-normalizer:span-normalizer-constants"))
   implementation(project(":semantic-convention-utils"))
   implementation("org.hypertrace.entity.service:entity-service-api:0.8.5")
-
-  constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
-      because("Denial of Service (DoS) " +
-          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
-          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
-    }
-  }
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/build.gradle.kts
@@ -9,18 +9,10 @@ tasks.test {
 
 dependencies {
   implementation(project(":hypertrace-trace-enricher:enriched-span-constants"))
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
 
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("org.apache.commons:commons-lang3:3.12.0")
-
-  constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
-      because("Denial of Service (DoS) " +
-          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
-          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
-    }
-  }
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.9.0")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/build.gradle.kts
@@ -15,10 +15,10 @@ dependencies {
   implementation("org.apache.commons:commons-lang3:3.12.0")
 
   constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
       because("Denial of Service (DoS) " +
-          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
+          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
 

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   implementation(project(":semantic-convention-utils"))
   implementation(project(":hypertrace-trace-enricher:trace-reader"))
 
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
   implementation("org.hypertrace.entity.service:entity-service-client:0.8.5")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.2")
@@ -29,14 +29,6 @@ dependencies {
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("net.sf.uadetector:uadetector-resources:2014.10")
   implementation("io.reactivex.rxjava3:rxjava:3.0.11")
-
-  constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
-      because("Denial of Service (DoS) " +
-          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.13.1")
-    }
-  }
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
@@ -31,10 +31,10 @@ dependencies {
   implementation("io.reactivex.rxjava3:rxjava:3.0.11")
 
   constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
       because("Denial of Service (DoS) " +
-          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
 

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -31,7 +31,7 @@ tasks.test {
 dependencies {
   implementation(project(":hypertrace-trace-enricher:hypertrace-trace-enricher-impl"))
   implementation(project(":span-normalizer:span-normalizer-api"))
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.33")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
   implementation("org.hypertrace.entity.service:entity-service-client:0.8.5")
@@ -43,11 +43,6 @@ dependencies {
     runtimeOnly("io.netty:netty-handler-proxy:4.1.71.Final")
     implementation("org.glassfish.jersey.core:jersey-common:2.34") {
       because("https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-1255637")
-    }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
-      because("Denial of Service (DoS) " +
-          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
-          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
 

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -44,10 +44,10 @@ dependencies {
     implementation("org.glassfish.jersey.core:jersey-common:2.34") {
       because("https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-1255637")
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
       because("Denial of Service (DoS) " +
-          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
+          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
 

--- a/hypertrace-trace-enricher/hypertrace-trace-visualizer/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-visualizer/build.gradle.kts
@@ -9,10 +9,10 @@ dependencies {
   implementation("org.apache.commons:commons-lang3:3.12.0")
 
   constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
       because("Denial of Service (DoS) " +
-          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
+          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
 }

--- a/hypertrace-trace-enricher/hypertrace-trace-visualizer/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-visualizer/build.gradle.kts
@@ -3,18 +3,10 @@ plugins {
 }
 
 dependencies {
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
 
   implementation("org.json:json:20210307")
   implementation("org.apache.commons:commons-lang3:3.12.0")
-
-  constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
-      because("Denial of Service (DoS) " +
-          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
-          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
-    }
-  }
 }
 
 description = "Trace Visualizer to help visualize a structured trace."

--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -20,10 +20,10 @@ dependencies {
   compileOnly("org.projectlombok:lombok:1.18.20")
 
   constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
       because("Denial of Service (DoS) " +
-          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
+          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
 

--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
   api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.3")
   api("org.hypertrace.entity.service:entity-type-service-rx-client:0.8.5")
   api("org.hypertrace.entity.service:entity-data-service-rx-client:0.8.5")
-  api("org.hypertrace.core.datamodel:data-model:0.1.20")
+  api("org.hypertrace.core.datamodel:data-model:0.1.22")
   implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.12.3")
   implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.6.2")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.2")
@@ -18,14 +18,6 @@ dependencies {
 
   annotationProcessor("org.projectlombok:lombok:1.18.20")
   compileOnly("org.projectlombok:lombok:1.18.20")
-
-  constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
-      because("Denial of Service (DoS) " +
-          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
-          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
-    }
-  }
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-inline:3.8.0")

--- a/hypertrace-view-generator/helm/templates/view-generation/view-gen-individual-config.yaml
+++ b/hypertrace-view-generator/helm/templates/view-generation/view-gen-individual-config.yaml
@@ -9,6 +9,6 @@ metadata:
     release: {{ $global.Release.Name }}
 data:
   application.conf: |-
-    input.topic = {{ $val.inputTopic }}
+    input.topics = {{ $val.inputTopics | toJson }}
     output.topic = {{ $val.outputTopic }}
 {{- end }}

--- a/hypertrace-view-generator/helm/values.yaml
+++ b/hypertrace-view-generator/helm/values.yaml
@@ -64,22 +64,22 @@ creator:
 ############################################
 viewGenIndividualConfigs:
   view-gen-backend-entity:
-    inputTopic: "enriched-structured-traces"
+    inputTopics: ["enriched-structured-traces"]
     outputTopic: "backend-entity-view-events"
   view-gen-raw-service:
-    inputTopic: "enriched-structured-traces"
+    inputTopics: ["enriched-structured-traces"]
     outputTopic: "raw-service-view-events"
   view-gen-raw-traces:
-    inputTopic: "enriched-structured-traces"
+    inputTopics: ["enriched-structured-traces"]
     outputTopic: "raw-trace-view-events"
   view-gen-service-call:
-    inputTopic: "enriched-structured-traces"
+    inputTopics: ["enriched-structured-traces"]
     outputTopic: "service-call-view-events"
   view-gen-span-event:
-    inputTopic: "enriched-structured-traces"
+    inputTopics: ["enriched-structured-traces"]
     outputTopic: "span-event-view"
   view-gen-log-event:
-    inputTopic: "raw-logs"
+    inputTopics: ["raw-logs"]
     outputTopic: "log-event-view"
 
 viewGeneratorGroups:

--- a/hypertrace-view-generator/hypertrace-view-creator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-creator/build.gradle.kts
@@ -23,10 +23,10 @@ dependencies {
     implementation("org.apache.calcite:calcite-babel:1.26.0") {
       because("https://snyk.io/vuln/SNYK-JAVA-ORGAPACHECALCITE-1038296")
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
       because("Denial of Service (DoS) " +
-          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
+          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
 

--- a/hypertrace-view-generator/hypertrace-view-creator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-creator/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation("org.apache.calcite:calcite-babel:1.26.0") {
       because("https://snyk.io/vuln/SNYK-JAVA-ORGAPACHECALCITE-1038296")
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.2") {
       because("Denial of Service (DoS) " +
           "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
           "com.fasterxml.jackson.core:jackson-databind@2.13.1")

--- a/hypertrace-view-generator/hypertrace-view-generator-api/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator-api/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     api("org.apache.commons:commons-compress:1.21") {
       because("Multiple vulnerabilities in avro-declared version")
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.2") {
       because("Denial of Service (DoS) " +
           "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
           "com.fasterxml.jackson.core:jackson-databind@2.13.1")

--- a/hypertrace-view-generator/hypertrace-view-generator-api/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator-api/build.gradle.kts
@@ -17,10 +17,10 @@ dependencies {
     api("org.apache.commons:commons-compress:1.21") {
       because("Multiple vulnerabilities in avro-declared version")
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
       because("Denial of Service (DoS) " +
-          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
+          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
 }

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -33,23 +33,13 @@ dependencies {
 
   // TODO: migrate in core
   implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.4.1")
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
 
   implementation("org.hypertrace.entity.service:entity-service-api:0.8.5")
 
   implementation("org.apache.avro:avro:1.10.2")
   implementation("org.apache.commons:commons-lang3:3.12.0")
-
-  constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
-      because(
-        "Denial of Service (DoS) " +
-            "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] " +
-            "in com.fasterxml.jackson.core:jackson-databind@2.13.1"
-      )
-    }
-  }
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   implementation(project(":semantic-convention-utils"))
 
   // TODO: migrate in core
-  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.3.10")
+  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.4.1")
   implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
 

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -40,7 +40,16 @@ dependencies {
 
   implementation("org.apache.avro:avro:1.10.2")
   implementation("org.apache.commons:commons-lang3:3.12.0")
-  implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1")
+
+  constraints {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
+      because(
+        "Denial of Service (DoS) " +
+            "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] " +
+            "in com.fasterxml.jackson.core:jackson-databind@2.13.1"
+      )
+    }
+  }
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/resources/configs/view-gen-backend-entity/application.conf
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/resources/configs/view-gen-backend-entity/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = "enriched-structured-traces"
+input.topics = ["enriched-structured-traces"]
 output.topic = "backend-entity-view-events"
 input.class = org.hypertrace.core.datamodel.StructuredTrace
 

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/resources/configs/view-gen-log-event/application.conf
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/resources/configs/view-gen-log-event/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = "raw-logs"
+input.topics = ["raw-logs"]
 output.topic = "log-event-view"
 input.class = org.hypertrace.core.datamodel.LogEvents
 precreate.topics = false

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/resources/configs/view-gen-raw-service/application.conf
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/resources/configs/view-gen-raw-service/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = "enriched-structured-traces"
+input.topics = ["enriched-structured-traces"]
 output.topic = "raw-service-view-events"
 input.class = org.hypertrace.core.datamodel.StructuredTrace
 precreate.topics = false

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/resources/configs/view-gen-raw-traces/application.conf
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/resources/configs/view-gen-raw-traces/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = "enriched-structured-traces"
+input.topics = ["enriched-structured-traces"]
 output.topic = "raw-trace-view-events"
 input.class = org.hypertrace.core.datamodel.StructuredTrace
 

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/resources/configs/view-gen-service-call/application.conf
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/resources/configs/view-gen-service-call/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = "enriched-structured-traces"
+input.topics = ["enriched-structured-traces"]
 output.topic = "service-call-view-events"
 input.class = org.hypertrace.core.datamodel.StructuredTrace
 precreate.topics = false

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/resources/configs/view-gen-span-event/application.conf
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/resources/configs/view-gen-span-event/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = "enriched-structured-traces"
+input.topics = ["enriched-structured-traces"]
 output.topic = "span-event-view"
 input.class = org.hypertrace.core.datamodel.StructuredTrace
 

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/resources/configs/view-gen-backend-entity/application.conf
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/resources/configs/view-gen-backend-entity/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = "enriched-structured-traces"
+input.topics = ["enriched-structured-traces"]
 output.topic = "backend-entity-view-events"
 input.class = org.hypertrace.core.datamodel.StructuredTrace
 

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/resources/configs/view-gen-log-event/application.conf
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/resources/configs/view-gen-log-event/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = "raw-logs"
+input.topics = ["raw-logs"]
 output.topic = "log-event-view"
 input.class = org.hypertrace.core.datamodel.LogEvents
 precreate.topics = false

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/resources/configs/view-gen-raw-service/application.conf
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/resources/configs/view-gen-raw-service/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = "enriched-structured-traces"
+input.topics = ["enriched-structured-traces"]
 output.topic = "raw-service-view-events"
 input.class = org.hypertrace.core.datamodel.StructuredTrace
 precreate.topics = false

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/resources/configs/view-gen-raw-traces/application.conf
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/resources/configs/view-gen-raw-traces/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = "enriched-structured-traces"
+input.topics = ["enriched-structured-traces"]
 output.topic = "raw-trace-view-events"
 input.class = org.hypertrace.core.datamodel.StructuredTrace
 

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/resources/configs/view-gen-service-call/application.conf
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/resources/configs/view-gen-service-call/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = "enriched-structured-traces"
+input.topics = ["enriched-structured-traces"]
 output.topic = "service-call-view-events"
 input.class = org.hypertrace.core.datamodel.StructuredTrace
 precreate.topics = false

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/resources/configs/view-gen-span-event/application.conf
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/resources/configs/view-gen-span-event/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = "enriched-structured-traces"
+input.topics = ["enriched-structured-traces"]
 output.topic = "span-event-view"
 input.class = org.hypertrace.core.datamodel.StructuredTrace
 

--- a/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
+++ b/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
         because("https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-1255637")
     }
     implementation(project(":span-normalizer:span-normalizer-api"))
-    implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
+    implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
     implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.33")
     implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
 
@@ -46,14 +46,6 @@ dependencies {
     // Logging
     implementation("org.slf4j:slf4j-api:1.7.30")
     runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
-
-    constraints {
-        implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
-            because("Denial of Service (DoS) " +
-                "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
-                "com.fasterxml.jackson.core:jackson-databind@2.13.1")
-        }
-    }
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
     testImplementation("org.mockito:mockito-core:3.8.0")

--- a/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
+++ b/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
@@ -48,10 +48,10 @@ dependencies {
     runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
 
     constraints {
-        implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+        implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
             because("Denial of Service (DoS) " +
-                "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-                "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+                "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
+                "com.fasterxml.jackson.core:jackson-databind@2.13.1")
         }
     }
 

--- a/semantic-convention-utils/build.gradle.kts
+++ b/semantic-convention-utils/build.gradle.kts
@@ -11,16 +11,8 @@ dependencies {
     implementation(project(":span-normalizer:raw-span-constants"))
     implementation(project(":span-normalizer:span-normalizer-constants"))
 
-    implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
+    implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
     implementation("org.apache.commons:commons-lang3:3.12.0")
-
-    constraints {
-        implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
-            because("Denial of Service (DoS) " +
-                "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
-                "com.fasterxml.jackson.core:jackson-databind@2.13.1")
-        }
-    }
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
     testImplementation("org.mockito:mockito-core:3.8.0")

--- a/semantic-convention-utils/build.gradle.kts
+++ b/semantic-convention-utils/build.gradle.kts
@@ -15,10 +15,10 @@ dependencies {
     implementation("org.apache.commons:commons-lang3:3.12.0")
 
     constraints {
-        implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+        implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
             because("Denial of Service (DoS) " +
-                "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-                "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+                "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
+                "com.fasterxml.jackson.core:jackson-databind@2.13.1")
         }
     }
 

--- a/span-normalizer/span-normalizer-api/build.gradle.kts
+++ b/span-normalizer/span-normalizer-api/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     api("org.apache.commons:commons-compress:1.21") {
       because("Multiple vulnerabilities in avro-declared version")
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.2") {
       because("Denial of Service (DoS) " +
           "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
           "com.fasterxml.jackson.core:jackson-databind@2.13.1")

--- a/span-normalizer/span-normalizer-api/build.gradle.kts
+++ b/span-normalizer/span-normalizer-api/build.gradle.kts
@@ -62,10 +62,10 @@ dependencies {
     api("org.apache.commons:commons-compress:1.21") {
       because("Multiple vulnerabilities in avro-declared version")
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
       because("Denial of Service (DoS) " +
-          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
+          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
 }

--- a/span-normalizer/span-normalizer/build.gradle.kts
+++ b/span-normalizer/span-normalizer/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
   implementation(project(":span-normalizer:span-normalizer-constants"))
   implementation(project(":semantic-convention-utils"))
 
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.20")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.33")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
   implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.25")
@@ -50,11 +50,6 @@ dependencies {
     runtimeOnly("io.netty:netty-handler-proxy:4.1.71.Final")
     implementation("org.glassfish.jersey.core:jersey-common:2.34") {
       because("https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-1255637")
-    }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
-      because("Denial of Service (DoS) " +
-          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
-          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
   annotationProcessor("org.projectlombok:lombok:1.18.18")

--- a/span-normalizer/span-normalizer/build.gradle.kts
+++ b/span-normalizer/span-normalizer/build.gradle.kts
@@ -51,10 +51,10 @@ dependencies {
     implementation("org.glassfish.jersey.core:jersey-common:2.34") {
       because("https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-1255637")
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
       because("Denial of Service (DoS) " +
-          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+          "[High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in " +
+          "com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
   annotationProcessor("org.projectlombok:lombok:1.18.18")


### PR DESCRIPTION
## Description
As part of view-gen framework release - https://github.com/hypertrace/view-generator-framework/releases/tag/0.4.1, we have added the support for reading from multiple input topics.

As part of this PR, 
- upgrading the view-gen framework
- updates all helm and application.conf changes to incorporate multiple inputs


### Testing
- existing the full topology tests passes
- e2e test passes

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
It will be as part of the release doc
