### PR TITLE
change root project name to avoid duplicate project names. 

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ plugins {
   id("org.hypertrace.version-settings") version "0.2.0"
 }
 
-rootProject.name = "hypertrace-ingester"
+rootProject.name = "hypertrace-ingester-root"
 
 // trace-enricher
 include("hypertrace-trace-enricher:enriched-span-constants")


### PR DESCRIPTION
Running gradlew projects command will display all the project names to verify. 

