### PR TITLE
chore: upgrade data-model and avro version

### DIFF
--- a/hypertrace-ingester/build.gradle.kts
+++ b/hypertrace-ingester/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
   implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.25")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.43")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.43")
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.23")
   implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.4.1")
   implementation("com.typesafe:config:1.4.1")
   implementation("org.apache.commons:commons-lang3:3.12.0")

--- a/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
+++ b/hypertrace-trace-enricher/enriched-span-constants/build.gradle.kts
@@ -65,7 +65,7 @@ sourceSets {
 dependencies {
   api("com.google.protobuf:protobuf-java-util:3.21.1")
 
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.23")
   implementation(project(":span-normalizer:raw-span-constants"))
   implementation(project(":span-normalizer:span-normalizer-constants"))
   implementation(project(":semantic-convention-utils"))

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-api/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-api/build.gradle.kts
@@ -9,7 +9,7 @@ tasks.test {
 
 dependencies {
   implementation(project(":hypertrace-trace-enricher:enriched-span-constants"))
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.23")
 
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("org.apache.commons:commons-lang3:3.12.0")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   implementation(project(":semantic-convention-utils"))
   implementation(project(":hypertrace-trace-enricher:trace-reader"))
 
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.23")
   implementation("org.hypertrace.entity.service:entity-service-client:0.8.5")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.43")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.4")

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -31,7 +31,7 @@ tasks.test {
 dependencies {
   implementation(project(":hypertrace-trace-enricher:hypertrace-trace-enricher-impl"))
   implementation(project(":span-normalizer:span-normalizer-api"))
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.23")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.43")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.43")
   implementation("org.hypertrace.entity.service:entity-service-client:0.8.5")

--- a/hypertrace-trace-enricher/hypertrace-trace-visualizer/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-visualizer/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.23")
 
   implementation("org.json:json:20210307")
   implementation("org.apache.commons:commons-lang3:3.12.0")

--- a/hypertrace-trace-enricher/trace-reader/build.gradle.kts
+++ b/hypertrace-trace-enricher/trace-reader/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
   api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.3")
   api("org.hypertrace.entity.service:entity-type-service-rx-client:0.8.5")
   api("org.hypertrace.entity.service:entity-data-service-rx-client:0.8.5")
-  api("org.hypertrace.core.datamodel:data-model:0.1.22")
+  api("org.hypertrace.core.datamodel:data-model:0.1.23")
   implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.12.3")
   implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.7.4")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.7.4")

--- a/hypertrace-view-generator/hypertrace-view-generator-api/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator-api/build.gradle.kts
@@ -12,7 +12,7 @@ sourceSets {
 }
 
 dependencies {
-  api("org.apache.avro:avro:1.10.2")
+  api("org.apache.avro:avro:1.11.0")
   constraints {
     api("org.apache.commons:commons-compress:1.21") {
       because("Multiple vulnerabilities in avro-declared version")

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -34,12 +34,12 @@ dependencies {
 
   // TODO: migrate in core
   implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.4.1")
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.23")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.43")
 
   implementation("org.hypertrace.entity.service:entity-service-api:0.8.5")
 
-  implementation("org.apache.avro:avro:1.10.2")
+  implementation("org.apache.avro:avro:1.11.0")
   implementation("org.apache.commons:commons-lang3:3.12.0")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")

--- a/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
+++ b/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
         because("https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-1255637")
     }
     implementation(project(":span-normalizer:span-normalizer-api"))
-    implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
+    implementation("org.hypertrace.core.datamodel:data-model:0.1.23")
     implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.43")
     implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.43")
 

--- a/semantic-convention-utils/build.gradle.kts
+++ b/semantic-convention-utils/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation(project(":span-normalizer:raw-span-constants"))
     implementation(project(":span-normalizer:span-normalizer-constants"))
 
-    implementation("org.hypertrace.core.datamodel:data-model:0.1.22")
+    implementation("org.hypertrace.core.datamodel:data-model:0.1.23")
     implementation("org.apache.commons:commons-lang3:3.12.0")
     implementation("com.google.guava:guava:31.1-jre")
 


### PR DESCRIPTION
## Description
data-model version and avro version were upgraded in [this PR](https://github.com/hypertrace/hypertrace-ingester/pull/332/files#diff-fc460f912c3e92b13013deb0ec2660eaf7c49471037b56face890f8080d17ae1R60) in span-normalizer only. This PR makes similar changes in the rest of the modules.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->
