### PR TITLE
Add support to look for http scheme from origin header

### DIFF
--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -125,8 +125,7 @@ public class HttpSemanticConventionUtils {
   private static final List<String> SCHEME_ATTRIBUTES =
       List.of(
           HttpSemanticConventions.HTTP_REQUEST_X_FORWARDED_PROTO.getValue(),
-          OTelHttpSemanticConventions.HTTP_SCHEME.getValue(),
-          HttpSemanticConventions.HTTP_REQUEST_ORIGIN.getValue());
+          OTelHttpSemanticConventions.HTTP_SCHEME.getValue());
 
   public static final List<String> FULL_URL_ATTRIBUTES =
       List.of(

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -40,6 +40,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.micrometer.core.instrument.util.StringUtils;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
@@ -91,6 +93,8 @@ public class HttpSemanticConventionUtils {
   private static final String SLASH = "/";
 
   private static final String HTTP_REQUEST_FORWARDED_ATTRIBUTE = HTTP_REQUEST_FORWARDED.getValue();
+  private static final String HTTP_REQUEST_ORIGIN =
+      HttpSemanticConventions.HTTP_REQUEST_ORIGIN.getValue();
 
   private static final List<String> USER_AGENT_ATTRIBUTES =
       List.of(
@@ -121,7 +125,8 @@ public class HttpSemanticConventionUtils {
   private static final List<String> SCHEME_ATTRIBUTES =
       List.of(
           HttpSemanticConventions.HTTP_REQUEST_X_FORWARDED_PROTO.getValue(),
-          OTelHttpSemanticConventions.HTTP_SCHEME.getValue());
+          OTelHttpSemanticConventions.HTTP_SCHEME.getValue(),
+          HttpSemanticConventions.HTTP_REQUEST_ORIGIN.getValue());
 
   public static final List<String> FULL_URL_ATTRIBUTES =
       List.of(
@@ -425,15 +430,39 @@ public class HttpSemanticConventionUtils {
 
   public static Optional<String> getHttpScheme(Event event) {
 
+    Optional<String> scheme = Optional.empty();
+    // 1. check for http.url attribute and extract scheme from it if it is a full URL
     Optional<String> url = getHttpUrlFromRawAttributes(event);
     if (url.isPresent() && isAbsoluteUrl(url.get())) {
       try {
-        return Optional.of(getNormalizedUrl(url.get()).getProtocol());
+        scheme = Optional.of(getNormalizedUrl(url.get()).getProtocol());
       } catch (MalformedURLException e) {
         LOGGER.warn(
             "On extracting httpScheme, received an invalid URL: {}, {}", url.get(), e.getMessage());
       }
     }
+
+    // 2. if scheme was extracted from step 1) then check if it is 'https' and return it.
+    Optional<String> schemeFromOtherRawAttributes;
+    if (scheme.isPresent()) {
+      if (scheme.get().equalsIgnoreCase("https")) {
+        return scheme;
+      }
+      // 3. else check if there are other attributes that like 'origin', 'x-forwarded-proto' etc
+      // that have the actual scheme
+      //    this is for scenarios where a LB fronts the service and terminates SSL.
+      //    If this scheme is 'https' then return this instead
+      else {
+        schemeFromOtherRawAttributes = getHttpSchemeFromRawAttributes(event);
+        if (schemeFromOtherRawAttributes.isPresent()
+            && schemeFromOtherRawAttributes.get().equalsIgnoreCase("https")) {
+          return schemeFromOtherRawAttributes;
+        }
+      }
+      // 4. Just return the scheme which should be 'http'
+      return scheme;
+    }
+    // 5. If scheme from URL couldn't be extracted then try the raw attributes
     return getHttpSchemeFromRawAttributes(event);
   }
 
@@ -460,6 +489,24 @@ public class HttpSemanticConventionUtils {
         return optionalExtractedProtoValue;
       }
     }
+
+    AttributeValue httpRequestOriginValue = attributeValueMap.get(HTTP_REQUEST_ORIGIN);
+    if (httpRequestOriginValue != null && !StringUtils.isEmpty(httpRequestOriginValue.getValue())) {
+      String origin = httpRequestOriginValue.getValue();
+      /** Syntax: Origin: null Origin: <scheme>://<hostname> Origin: <scheme>://<hostname>:<port> */
+      if (StringUtils.isNotEmpty(origin)) {
+        try {
+          String scheme = new URI(origin).getScheme();
+          return Optional.of(scheme);
+        } catch (URISyntaxException e) {
+          LOGGER.warn(
+              "On extracting scheme, received an invalid origin header: {}, {}",
+              origin,
+              e.getMessage());
+        }
+      }
+    }
+
     for (String scheme : SCHEME_ATTRIBUTES) {
       if (attributeValueMap.get(scheme) != null
           && !StringUtils.isEmpty(attributeValueMap.get(scheme).getValue())) {

--- a/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtilsTest.java
+++ b/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtilsTest.java
@@ -340,6 +340,51 @@ public class HttpSemanticConventionUtilsTest {
                 .build());
     when(e.getEnrichedAttributes()).thenReturn(null);
     assertEquals(Optional.of("https"), HttpSemanticConventionUtils.getHttpScheme(e));
+
+    // when only origin header exists expect whatever is the scheme of the origin header
+    // when origin header has 'https'
+    event =
+        createMockEventWithAttribute(
+            HttpSemanticConventions.HTTP_REQUEST_ORIGIN.getValue(), "https://abc.xyz");
+    assertEquals(Optional.of("https"), HttpSemanticConventionUtils.getHttpScheme(event));
+
+    // when origin header has 'http'
+    event =
+        createMockEventWithAttribute(
+            HttpSemanticConventions.HTTP_REQUEST_ORIGIN.getValue(), "http://abc.xyz");
+    assertEquals(Optional.of("http"), HttpSemanticConventionUtils.getHttpScheme(event));
+
+    // when http url and origin header exists with scheme https then expect https
+    event = mock(Event.class);
+    when(event.getAttributes())
+        .thenReturn(
+            Attributes.newBuilder()
+                .setAttributeMap(
+                    Map.of(
+                        HttpSemanticConventions.HTTP_REQUEST_ORIGIN.getValue(),
+                        AttributeValue.newBuilder().setValue("https://abc.xyz.ai").build(),
+                        RawSpanConstants.getValue(Http.HTTP_URL),
+                        AttributeValue.newBuilder()
+                            .setValue("http://abc.xyz.ai/apis/5673/events?a1=v1&a2=v2")
+                            .build()))
+                .build());
+    assertEquals(Optional.of("https"), HttpSemanticConventionUtils.getHttpScheme(event));
+
+    // when http url and origin header exists with scheme http then expect http
+    event = mock(Event.class);
+    when(event.getAttributes())
+        .thenReturn(
+            Attributes.newBuilder()
+                .setAttributeMap(
+                    Map.of(
+                        HttpSemanticConventions.HTTP_REQUEST_ORIGIN.getValue(),
+                        AttributeValue.newBuilder().setValue("http://abc.xyz.ai").build(),
+                        RawSpanConstants.getValue(Http.HTTP_URL),
+                        AttributeValue.newBuilder()
+                            .setValue("http://abc.xyz.ai/apis/5673/events?a1=v1&a2=v2")
+                            .build()))
+                .build());
+    assertEquals(Optional.of("http"), HttpSemanticConventionUtils.getHttpScheme(event));
   }
 
   @Test

--- a/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/http/HttpSemanticConventions.java
+++ b/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/http/HttpSemanticConventions.java
@@ -3,7 +3,8 @@ package org.hypertrace.core.semantic.convention.constants.http;
 /** Request forwarded specific attributes for Http */
 public enum HttpSemanticConventions {
   HTTP_REQUEST_X_FORWARDED_PROTO("http.request.header.x-forwarded-proto"),
-  HTTP_REQUEST_FORWARDED("http.request.header.forwarded");
+  HTTP_REQUEST_FORWARDED("http.request.header.forwarded"),
+  HTTP_REQUEST_ORIGIN("http.request.header.origin");
 
   private final String value;
 


### PR DESCRIPTION
## Description
This change introduces 2 changes:
1. If a full http url is present and the scheme is 'http' then other attributes are considered to extract scheme and checked if any of them have 'https'. If any of them have 'https' then we use that as the scheme. Ex: if http.url = http://foo.com and x-forwarded-proto = https or origin = https://foo.com then the resolved scheme will be 'https'. This scenario can happen if there is a frontend load balancer that terminates SSL traffic.
2. Add support for extracting scheme from http origin request header



### Testing
Added unit tests

