### PR TITLE
chore: upgrade view generation and creation framework libs

### DIFF
--- a/hypertrace-ingester/build.gradle.kts
+++ b/hypertrace-ingester/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.43")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.43")
   implementation("org.hypertrace.core.datamodel:data-model:0.1.23")
-  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.4.5")
+  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.4.7")
   implementation("com.typesafe:config:1.4.1")
   implementation("org.apache.commons:commons-lang3:3.12.0")
 

--- a/hypertrace-view-generator/hypertrace-view-creator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-creator/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.test {
 
 dependencies {
   implementation(project(":hypertrace-view-generator:hypertrace-view-generator-api"))
-  implementation("org.hypertrace.core.viewcreator:view-creator-framework:0.4.5")
+  implementation("org.hypertrace.core.viewcreator:view-creator-framework:0.4.7")
   constraints {
     // to have calcite libs on the same version
     implementation("org.apache.calcite:calcite-babel:1.26.0") {

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
   implementation("com.google.guava:guava:31.1-jre")
 
   // TODO: migrate in core
-  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.4.5")
+  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.4.7")
   implementation("org.hypertrace.core.datamodel:data-model:0.1.23")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.43")
 


### PR DESCRIPTION
Upgrading view-gen libs, the prior version was causing test case failure on - https://github.com/hypertrace/query-service/pull/174, which had deps on `main` tag image on `view-generation`. As the latest version of view-generation-framework revet the pinot client libs, this PR will help fixing the above - https://github.com/hypertrace/query-service/runs/8154986276?check_suite_focus=true