### PR TITLE
chore: adds sl4j impl lib for runtime

### DIFF
--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -42,6 +42,9 @@ dependencies {
   implementation("org.apache.avro:avro:1.11.0")
   implementation("org.apache.commons:commons-lang3:3.12.0")
 
+  // logging
+  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
+
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("com.google.code.gson:gson:2.8.9")


### PR DESCRIPTION
The dependent test case are still failing - https://github.com/hypertrace/query-service/runs/8187425254?check_suite_focus=true 

```
worker.jar:?]
    2022-09-05 11:27:00.556 [Test worker] ERROR 🐳 [hypertrace/hypertrace-view-generator:main] - Log output from the failed container:
    SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
    SLF4J: Defaulting to no-operation (NOP) logger implementation
    SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
    2022-09-05 11:27:00.557 [Test worker] INFO  🐳 [hypertrace/hypertrace-view-generator:main] - Creating container for image: hypertrace/hypertrace-view-generator:main
    2022-09-05 11:27:00.632 [Test worker] INFO  🐳 [hypertrace/hypertrace-view-generator:main] - Starting container with ID: 9ecc304a296fb5d05b7db66a[895](https://github.com/hypertrace/query-service/runs/8187425254?check_suite_focus=true#step:8:895)4fe21941bb1824d8ddbd4ad540b60478b7464
    2022-09-05 11:27:00.757 [docker-java-stream-1042598163] INFO  o.h.c.q.s.h.HTPinotQueriesTest - STDOUT: 2022-09-05T11:27:00.755+0000 I NETWORK  [conn23] received client metadata from 127.0.0.1:42760 conn23: { application: { name: "MongoDB Shell" }, driver: { name: "MongoDB Internal Client", version: "4.0.5" }, os: { type: "Linux", name: "NAME="Alpine Linux"", architecture: "x86_64", version: "Kernel 5.15.0-1017-azure" } }
```

As, view-gen-framework, only adds at test level, this one adds for runtime.