### PR TITLE
Added support for the new OTEL net.sock.peer.addr attribute

### DIFF
--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/span/SpanSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/span/SpanSemanticConventionUtils.java
@@ -39,7 +39,10 @@ public class SpanSemanticConventionUtils {
         SpanAttributeUtils.getStringAttributeWithDefault(
             event,
             OTEL_NET_PEER_NAME,
-            SpanAttributeUtils.getStringAttribute(event, OTEL_NET_PEER_IP));
+            SpanAttributeUtils.getStringAttributeWithDefault(
+                event,
+                OTelSpanSemanticConventions.NET_SOCK_PEER_ADDR.getValue(),
+                SpanAttributeUtils.getStringAttribute(event, OTEL_NET_PEER_IP)));
     if (StringUtils.isBlank(host)) {
       return Optional.empty();
     }
@@ -58,7 +61,11 @@ public class SpanSemanticConventionUtils {
   public static Optional<String> getURIForOtelFormat(
       Map<String, AttributeValue> attributeValueMap) {
     AttributeValue hostAttribute =
-        attributeValueMap.getOrDefault(OTEL_NET_PEER_NAME, attributeValueMap.get(OTEL_NET_PEER_IP));
+        attributeValueMap.getOrDefault(
+            OTEL_NET_PEER_NAME,
+            attributeValueMap.getOrDefault(
+                OTelSpanSemanticConventions.NET_SOCK_PEER_ADDR.getValue(),
+                attributeValueMap.get(OTEL_NET_PEER_IP)));
     if (null == hostAttribute || StringUtils.isBlank(hostAttribute.getValue())) {
       return Optional.empty();
     }

--- a/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/db/DbSemanticConventionUtilsTest.java
+++ b/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/db/DbSemanticConventionUtilsTest.java
@@ -448,6 +448,33 @@ public class DbSemanticConventionUtilsTest {
             SemanticConventionTestUtil.buildAttributeValue("jdbc:mysql://mysql:3306/shop"));
     v = DbSemanticConventionUtils.getSqlUrlForOtelFormat(map);
     assertEquals("127.0.0.1", v.get());
+
+    map =
+        Map.of(
+            OTelSpanSemanticConventions.NET_SOCK_PEER_ADDR.getValue(),
+            SemanticConventionTestUtil.buildAttributeValue("127.0.0.1"),
+            OTelDbSemanticConventions.DB_SYSTEM.getValue(),
+            SemanticConventionTestUtil.buildAttributeValue(
+                OTelDbSemanticConventions.MYSQL_DB_SYSTEM_VALUE.getValue()),
+            OTelDbSemanticConventions.DB_CONNECTION_STRING.getValue(),
+            SemanticConventionTestUtil.buildAttributeValue("jdbc:mysql://mysql:3306/shop"));
+    v = DbSemanticConventionUtils.getSqlUrlForOtelFormat(map);
+    assertEquals("127.0.0.1", v.get());
+
+    // net.sock.peer.addr preferred over net.peer.ip
+    map =
+        Map.of(
+            OTelSpanSemanticConventions.NET_SOCK_PEER_ADDR.getValue(),
+            SemanticConventionTestUtil.buildAttributeValue("127.0.0.1"),
+            OTelSpanSemanticConventions.NET_PEER_IP.getValue(),
+            SemanticConventionTestUtil.buildAttributeValue("127.0.0.2"),
+            OTelDbSemanticConventions.DB_SYSTEM.getValue(),
+            SemanticConventionTestUtil.buildAttributeValue(
+                OTelDbSemanticConventions.MYSQL_DB_SYSTEM_VALUE.getValue()),
+            OTelDbSemanticConventions.DB_CONNECTION_STRING.getValue(),
+            SemanticConventionTestUtil.buildAttributeValue("jdbc:mysql://mysql:3306/shop"));
+    v = DbSemanticConventionUtils.getSqlUrlForOtelFormat(map);
+    assertEquals("127.0.0.1", v.get());
   }
 
   @Test

--- a/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtilsTest.java
+++ b/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtilsTest.java
@@ -113,6 +113,22 @@ public class HttpSemanticConventionUtilsTest {
     url = HttpSemanticConventionUtils.getHttpUrlForOTelFormat(map).get();
     assertEquals("http://172.0.8.11:1211/webshop/articles/4?s=1", url);
 
+    map.clear();
+    map.put(HTTP_SCHEME.getValue(), buildAttributeValue("https"));
+    map.put(
+        HttpSemanticConventions.HTTP_REQUEST_FORWARDED.getValue(),
+        buildAttributeValue("by=random;proto=http"));
+    map.put(
+        OTelSpanSemanticConventions.NET_SOCK_PEER_ADDR.getValue(),
+        buildAttributeValue("172.0.8.11"));
+    map.put(OTelSpanSemanticConventions.NET_PEER_IP.getValue(), buildAttributeValue("172.0.8.12"));
+    map.put(OTelSpanSemanticConventions.NET_PEER_PORT.getValue(), buildAttributeValue("1211"));
+    map.put(HTTP_TARGET.getValue(), buildAttributeValue("/webshop/articles/4?s=1"));
+    map.put(SPAN_KIND.getValue(), buildAttributeValue(SPAN_KIND_CLIENT_VALUE.getValue()));
+    url = HttpSemanticConventionUtils.getHttpUrlForOTelFormat(map).get();
+    // net.sock.peer.addr picked over net.peer.ip
+    assertEquals("http://172.0.8.11:1211/webshop/articles/4?s=1", url);
+
     // client span, span.kind present
     map.clear();
     map.put(HTTP_SCHEME.getValue(), buildAttributeValue("https"));

--- a/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/span/SpanSemanticConventionUtilsTest.java
+++ b/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/span/SpanSemanticConventionUtilsTest.java
@@ -34,7 +34,17 @@ public class SpanSemanticConventionUtilsTest {
     Optional<String> v = SpanSemanticConventionUtils.getURIForOtelFormat(e);
     assertEquals("example.com", v.get());
 
-    // ip present
+    // net.sock.peer.addr present
+    attributes =
+        SemanticConventionTestUtil.buildAttributes(
+            Map.of(
+                OTelSpanSemanticConventions.NET_SOCK_PEER_ADDR.getValue(),
+                SemanticConventionTestUtil.buildAttributeValue("172.0.1.17")));
+    when(e.getAttributes()).thenReturn(attributes);
+    v = SpanSemanticConventionUtils.getURIForOtelFormat(e);
+    assertEquals("172.0.1.17", v.get());
+
+    // net.peer.ip present
     attributes =
         SemanticConventionTestUtil.buildAttributes(
             Map.of(
@@ -43,6 +53,18 @@ public class SpanSemanticConventionUtilsTest {
     when(e.getAttributes()).thenReturn(attributes);
     v = SpanSemanticConventionUtils.getURIForOtelFormat(e);
     assertEquals("172.0.1.17", v.get());
+
+    // both net.sock.peer.addr and net.peer.ip present but pref given to net.sock.peer.addr
+    attributes =
+        SemanticConventionTestUtil.buildAttributes(
+            Map.of(
+                OTelSpanSemanticConventions.NET_PEER_IP.getValue(),
+                SemanticConventionTestUtil.buildAttributeValue("172.0.1.17"),
+                OTelSpanSemanticConventions.NET_SOCK_PEER_ADDR.getValue(),
+                SemanticConventionTestUtil.buildAttributeValue("172.0.1.18")));
+    when(e.getAttributes()).thenReturn(attributes);
+    v = SpanSemanticConventionUtils.getURIForOtelFormat(e);
+    assertEquals("172.0.1.18", v.get());
 
     // host & port
     attributes =

--- a/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/span/OTelSpanSemanticConventions.java
+++ b/span-normalizer/span-normalizer-constants/src/main/java/org/hypertrace/core/semantic/convention/constants/span/OTelSpanSemanticConventions.java
@@ -8,6 +8,7 @@ public enum OTelSpanSemanticConventions {
   NET_PEER_IP("net.peer.ip"),
   NET_PEER_PORT("net.peer.port"),
   NET_PEER_NAME("net.peer.name"),
+  NET_SOCK_PEER_ADDR("net.sock.peer.addr"),
   NET_TRANSPORT("net.transport"),
   HTTP_CLIENT_IP("http.client_ip");
 


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
net.peer.ip has been renamed to net.sock.peer.addr. See changelog:
[opentelemetry-specification/CHANGELOG.md at ac639af144fbb3875af921d5ba30ad04417564de · open-telemetry/opentelemetry-specification](https://github.com/open-telemetry/opentelemetry-specification/blob/ac639af144fbb3875af921d5ba30ad04417564de/CHANGELOG.md)

Made changes to support the new net.sock.peer.addr tag

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
