### PR TITLE
feat: add ability to configure a preferred service name attr

### DIFF
--- a/hypertrace-ingester/src/test/java/org/hypertrace/migration/MigrationTestHttp.java
+++ b/hypertrace-ingester/src/test/java/org/hypertrace/migration/MigrationTestHttp.java
@@ -42,6 +42,7 @@ import org.hypertrace.core.semantic.convention.constants.http.OTelHttpSemanticCo
 import org.hypertrace.core.semantic.convention.constants.span.OTelSpanSemanticConventions;
 import org.hypertrace.core.span.constants.RawSpanConstants;
 import org.hypertrace.core.spannormalizer.jaeger.JaegerSpanNormalizer;
+import org.hypertrace.core.spannormalizer.jaeger.ServiceNamer;
 import org.hypertrace.semantic.convention.utils.http.HttpSemanticConventionUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -99,7 +100,11 @@ public class MigrationTestHttp {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -140,7 +145,11 @@ public class MigrationTestHttp {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -156,7 +165,11 @@ public class MigrationTestHttp {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -171,7 +184,11 @@ public class MigrationTestHttp {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -186,7 +203,11 @@ public class MigrationTestHttp {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -204,7 +225,11 @@ public class MigrationTestHttp {
                 RawSpanConstants.getValue(HTTP_REQUEST_PATH), "path1",
                 RawSpanConstants.getValue(HTTP_PATH), "  "));
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     assertFalse(HttpSemanticConventionUtils.getHttpPath(rawSpan.getEvent()).isPresent());
 
@@ -214,7 +239,11 @@ public class MigrationTestHttp {
                 RawSpanConstants.getValue(HTTP_REQUEST_PATH), "/path1",
                 RawSpanConstants.getValue(HTTP_PATH), "/"));
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     assertEquals("/path1", HttpSemanticConventionUtils.getHttpPath(rawSpan.getEvent()).get());
   }
@@ -226,7 +255,11 @@ public class MigrationTestHttp {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -241,7 +274,11 @@ public class MigrationTestHttp {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -257,7 +294,11 @@ public class MigrationTestHttp {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -272,7 +313,11 @@ public class MigrationTestHttp {
     Span span =
         createSpanFromTags(Map.of(RawSpanConstants.getValue(HTTP_URL), "/dispatch/test?a=b&k1=v1"));
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
     assertFalse(HttpSemanticConventionUtils.getHttpUrl(rawSpan.getEvent()).isPresent());
   }
 
@@ -283,7 +328,11 @@ public class MigrationTestHttp {
         createSpanFromTags(
             Map.of(RawSpanConstants.getValue(HTTP_URL), "http://abc.xyz/dispatch/test?a=b&k1=v1"));
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -307,7 +356,11 @@ public class MigrationTestHttp {
             .build();
 
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -329,7 +382,11 @@ public class MigrationTestHttp {
             .build();
 
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -351,7 +408,11 @@ public class MigrationTestHttp {
             .build();
 
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -372,7 +433,11 @@ public class MigrationTestHttp {
             .build();
 
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -392,7 +457,11 @@ public class MigrationTestHttp {
             .build();
 
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -415,7 +484,11 @@ public class MigrationTestHttp {
             .build();
 
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -446,7 +519,11 @@ public class MigrationTestHttp {
             .build();
 
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -479,7 +556,11 @@ public class MigrationTestHttp {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -513,7 +594,11 @@ public class MigrationTestHttp {
   public void testPopulateOtherFieldsOTelSpan() throws Exception {
     Span span = Span.newBuilder().build();
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     assertFalse(HttpSemanticConventionUtils.getHttpUrl(rawSpan.getEvent()).isPresent());
     assertFalse(HttpSemanticConventionUtils.getHttpScheme(rawSpan.getEvent()).isPresent());
@@ -530,7 +615,11 @@ public class MigrationTestHttp {
             .build();
 
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -552,7 +641,11 @@ public class MigrationTestHttp {
             .build();
 
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
 
@@ -573,7 +666,11 @@ public class MigrationTestHttp {
             .build();
 
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
@@ -594,7 +691,11 @@ public class MigrationTestHttp {
             .build();
 
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
 
@@ -613,7 +714,11 @@ public class MigrationTestHttp {
             .build();
 
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
 
@@ -635,7 +740,11 @@ public class MigrationTestHttp {
             .build();
 
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
 
@@ -665,7 +774,11 @@ public class MigrationTestHttp {
             .build();
 
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
     assertEquals(
@@ -704,7 +817,11 @@ public class MigrationTestHttp {
             .build();
 
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
     assertEquals(
@@ -721,7 +838,11 @@ public class MigrationTestHttp {
                 OTelHttpSemanticConventions.HTTP_TARGET.getValue(),
                 "/api/v1/gatekeeper/check?url=%2Fpixel%2Factivities%3Fadvertisable%3DTRHRT&method=GET&service=pixel"));
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getHttp());
 

--- a/hypertrace-ingester/src/test/java/org/hypertrace/migration/MigrationTestRpc.java
+++ b/hypertrace-ingester/src/test/java/org/hypertrace/migration/MigrationTestRpc.java
@@ -35,6 +35,7 @@ import org.hypertrace.core.semantic.convention.constants.error.OTelErrorSemantic
 import org.hypertrace.core.semantic.convention.constants.rpc.OTelRpcSemanticConventions;
 import org.hypertrace.core.span.constants.RawSpanConstants;
 import org.hypertrace.core.spannormalizer.jaeger.JaegerSpanNormalizer;
+import org.hypertrace.core.spannormalizer.jaeger.ServiceNamer;
 import org.hypertrace.semantic.convention.utils.rpc.RpcSemanticConventionUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -90,7 +91,11 @@ public class MigrationTestRpc {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
@@ -125,7 +130,11 @@ public class MigrationTestRpc {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
@@ -142,7 +151,11 @@ public class MigrationTestRpc {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
@@ -161,7 +174,11 @@ public class MigrationTestRpc {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     assertNull(rawSpan.getEvent().getGrpc());
     assertTrue(RpcSemanticConventionUtils.getGrpcUserAgent(rawSpan.getEvent()).isEmpty());
@@ -175,7 +192,11 @@ public class MigrationTestRpc {
 
     span = createSpanFromTags(tagsMap);
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
     assertEquals(
@@ -191,7 +212,11 @@ public class MigrationTestRpc {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     assertNull(rawSpan.getEvent().getGrpc());
     assertTrue(RpcSemanticConventionUtils.getGrpcAuthority(rawSpan.getEvent()).isEmpty());
@@ -205,7 +230,11 @@ public class MigrationTestRpc {
 
     span = createSpanFromTags(tagsMap);
     rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
@@ -244,7 +273,11 @@ public class MigrationTestRpc {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
@@ -281,7 +314,11 @@ public class MigrationTestRpc {
 
     Span span = createSpanFromTags(tagMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     assertEquals(
         "resource not found", RpcSemanticConventionUtils.getGrpcErrorMsg(rawSpan.getEvent()));
@@ -295,7 +332,11 @@ public class MigrationTestRpc {
 
     Span span = createSpanFromTags(tagMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
@@ -314,7 +355,11 @@ public class MigrationTestRpc {
 
     Span span = createSpanFromTags(tagMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     // now, we are not populating first class fields. So, it should be null.
     assertNull(rawSpan.getEvent().getGrpc());
@@ -337,7 +382,11 @@ public class MigrationTestRpc {
 
     Span span = createSpanFromTags(tagsMap);
     RawSpan rawSpan =
-        normalizer.convert("tenant-key", span, buildEvent("tenant-key", span, Optional.empty()));
+        normalizer.convert(
+            "tenant-key",
+            span,
+            buildEvent(
+                "tenant-key", span, new ServiceNamer(ConfigFactory.empty()), Optional.empty()));
 
     assertAll(
         () ->

--- a/span-normalizer/helm/templates/span-normalizer-config.yaml
+++ b/span-normalizer/helm/templates/span-normalizer-config.yaml
@@ -90,6 +90,10 @@ data:
       {{- if hasKey .Values.spanNormalizerConfig.processor "excludeLogsTenantIds" }}
       excludeLogsTenantIds = {{ .Values.spanNormalizerConfig.processor.excludeLogsTenantIds | toJson }}
       {{- end }}
+    
+      {{- if hasKey .Values.spanNormalizerConfig.processor "serviceNameOverrides" }}
+      serviceNameOverrides = {{ .Values.spanNormalizerConfig.processor.serviceNameOverrides | toJson }}
+      {{- end }}
     }
     {{- end }}
 

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -29,9 +29,6 @@ import org.slf4j.LoggerFactory;
 public class JaegerSpanNormalizer {
   private static final Logger LOG = LoggerFactory.getLogger(JaegerSpanNormalizer.class);
 
-  /** Service name can be sent against this key as well */
-  public static final String OLD_JAEGER_SERVICENAME_KEY = "jaeger.servicename";
-
   private static final String SPAN_NORMALIZATION_TIME_METRIC = "span.normalization.time";
 
   private static JaegerSpanNormalizer INSTANCE;

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanPreProcessor.java
@@ -35,6 +35,7 @@ public class JaegerSpanPreProcessor
   private TenantIdHandler tenantIdHandler;
   private SpanDropManager spanDropManager;
   private TagsFilter tagsFilter;
+  private ServiceNamer serviceNamer;
 
   public JaegerSpanPreProcessor(GrpcChannelRegistry grpcChannelRegistry) {
     this.grpcChannelRegistry = grpcChannelRegistry;
@@ -49,6 +50,7 @@ public class JaegerSpanPreProcessor
     tenantIdHandler = new TenantIdHandler(jobConfig);
     spanDropManager = new SpanDropManager(jobConfig, excludeSpanRulesCache);
     tagsFilter = new TagsFilter(jobConfig);
+    serviceNamer = new ServiceNamer(jobConfig);
   }
 
   @Override
@@ -57,6 +59,7 @@ public class JaegerSpanPreProcessor
     tenantIdHandler = new TenantIdHandler(jobConfig);
     spanDropManager = new SpanDropManager(jobConfig, grpcChannelRegistry);
     tagsFilter = new TagsFilter(jobConfig);
+    serviceNamer = new ServiceNamer(jobConfig);
   }
 
   @Override
@@ -112,7 +115,10 @@ public class JaegerSpanPreProcessor
     Span processedSpan = tagsFilter.apply(tenantId, span);
     Event event =
         buildEvent(
-            tenantId, processedSpan, tenantIdHandler.getTenantIdProvider().getTenantIdTagKey());
+            tenantId,
+            processedSpan,
+            serviceNamer,
+            tenantIdHandler.getTenantIdProvider().getTenantIdTagKey());
 
     if (spanDropManager.shouldDropSpan(span, event, tenantId)) {
       return null;

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ServiceNamer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ServiceNamer.java
@@ -1,0 +1,49 @@
+package org.hypertrace.core.spannormalizer.jaeger;
+
+import static java.util.function.Predicate.not;
+
+import com.typesafe.config.Config;
+import io.jaegertracing.api_v2.JaegerSpanInternalModel;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.hypertrace.core.datamodel.AttributeValue;
+
+public class ServiceNamer {
+  public static final String OLD_JAEGER_SERVICENAME_KEY = "jaeger.servicename";
+  private static final String SERVICE_NAME_OVERRIDES_KEY = "processor.serviceNameOverrides";
+
+  // Not making this configurable until needed
+  private final List<String> fallbackAttributeNames = List.of(OLD_JAEGER_SERVICENAME_KEY);
+  private final List<String> overrideAttributeNames;
+
+  public ServiceNamer(Config config) {
+    if (config.hasPath(SERVICE_NAME_OVERRIDES_KEY)) {
+      this.overrideAttributeNames = config.getStringList(SERVICE_NAME_OVERRIDES_KEY);
+    } else {
+      this.overrideAttributeNames = Collections.emptyList();
+    }
+  }
+
+  public Optional<String> findServiceName(
+      JaegerSpanInternalModel.Span jaegerSpan, Map<String, AttributeValue> newAttributeMap) {
+    return this.getFirstValueFromAttributeKeys(overrideAttributeNames, newAttributeMap)
+        .or(() -> this.getProcessServiceName(jaegerSpan))
+        .or(() -> this.getFirstValueFromAttributeKeys(fallbackAttributeNames, newAttributeMap));
+  }
+
+  private Optional<String> getFirstValueFromAttributeKeys(
+      List<String> attributeKeys, Map<String, AttributeValue> newAttributeMap) {
+
+    return attributeKeys.stream()
+        .filter(newAttributeMap::containsKey)
+        .findFirst()
+        .map(newAttributeMap::get)
+        .map(AttributeValue::getValue);
+  }
+
+  private Optional<String> getProcessServiceName(JaegerSpanInternalModel.Span jaegerSpan) {
+    return Optional.of(jaegerSpan.getProcess().getServiceName()).filter(not(String::isEmpty));
+  }
+}

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanToLogRecordsTransformerTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanToLogRecordsTransformerTest.java
@@ -52,7 +52,11 @@ public class JaegerSpanToLogRecordsTransformerTest {
             new PreProcessedSpan(
                 "tenant-1",
                 getTestSpan(),
-                buildEvent("tenant-1", getTestSpan(), Optional.of("tenant-key"))));
+                buildEvent(
+                    "tenant-1",
+                    getTestSpan(),
+                    new ServiceNamer(ConfigFactory.empty()),
+                    Optional.of("tenant-key"))));
     Assertions.assertNull(keyValue);
   }
 

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/ServiceNamerTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/ServiceNamerTest.java
@@ -1,0 +1,78 @@
+package org.hypertrace.core.spannormalizer.jaeger;
+
+import static org.hypertrace.core.spannormalizer.jaeger.ServiceNamer.OLD_JAEGER_SERVICENAME_KEY;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import io.jaegertracing.api_v2.JaegerSpanInternalModel;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;
+import org.junit.jupiter.api.Test;
+
+class ServiceNamerTest {
+
+  @Test
+  void testOverridingServiceName() {
+    Config config =
+        ConfigFactory.parseMap(
+            Map.of(
+                "processor.serviceNameOverrides",
+                List.of("override.name.first", "override.name.second")));
+    ServiceNamer namer = new ServiceNamer(config);
+    JaegerSpanInternalModel.Span span =
+        JaegerSpanInternalModel.Span.newBuilder()
+            .setProcess(JaegerSpanInternalModel.Process.newBuilder().setServiceName("default-name"))
+            .build();
+
+    assertEquals(
+        Optional.of("first-override"),
+        namer.findServiceName(
+            span,
+            Map.of(
+                "override.name.first",
+                AttributeValueCreator.create("first-override"),
+                "override.name.second",
+                AttributeValueCreator.create("second-override"),
+                OLD_JAEGER_SERVICENAME_KEY,
+                AttributeValueCreator.create("old-name"))));
+
+    assertEquals(
+        Optional.of("second-override"),
+        namer.findServiceName(
+            span, Map.of("override.name.second", AttributeValueCreator.create("second-override"))));
+
+    assertEquals(Optional.of("default-name"), namer.findServiceName(span, Map.of()));
+  }
+
+  @Test
+  void testFallbackServiceName() {
+    Config config = ConfigFactory.empty();
+    ServiceNamer namer = new ServiceNamer(config);
+
+    assertEquals(
+        Optional.of("default-name"),
+        namer.findServiceName(
+            JaegerSpanInternalModel.Span.newBuilder()
+                .setProcess(
+                    JaegerSpanInternalModel.Process.newBuilder().setServiceName("default-name"))
+                .build(),
+            Map.of(OLD_JAEGER_SERVICENAME_KEY, AttributeValueCreator.create("old-name"))));
+    assertEquals(
+        Optional.of("old-name"),
+        namer.findServiceName(
+            JaegerSpanInternalModel.Span.getDefaultInstance(),
+            Map.of(OLD_JAEGER_SERVICENAME_KEY, AttributeValueCreator.create("old-name"))));
+  }
+
+  @Test
+  void testNoServiceName() {
+    Config config = ConfigFactory.empty();
+    ServiceNamer namer = new ServiceNamer(config);
+    JaegerSpanInternalModel.Span span = JaegerSpanInternalModel.Span.getDefaultInstance();
+
+    assertEquals(Optional.empty(), namer.findServiceName(span, Map.of()));
+  }
+}


### PR DESCRIPTION
## Description
Separated the service naming evaluation to new class, and added the ability for a config-driven list of attributes to check for a service name before using the resource service name, and then finally, if both the override and resource name are empty, a fallback list to check.

### Testing
Added unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

