### PR TITLE
adding support of using charts as library for certain components

### DIFF
--- a/raw-spans-grouper/helm/templates/headless-service.yaml
+++ b/raw-spans-grouper/helm/templates/headless-service.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.chartType "application" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +15,4 @@ spec:
       port: {{ .Values.containerAdminPort }}
   selector:
     {{- toYaml .Values.serviceSelectorMatchLabels | nindent 4 }}
+{{- end }}

--- a/raw-spans-grouper/helm/templates/logconfig.yaml
+++ b/raw-spans-grouper/helm/templates/logconfig.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.chartType "application" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -39,3 +40,4 @@ data:
     {{- if .Values.logConfig.appender.rolling.enabled }}
     rootLogger.appenderRef.rolling.ref = ROLLING_FILE
     {{- end }}
+{{- end }}

--- a/raw-spans-grouper/helm/templates/raw-spans-grouper-config.yaml
+++ b/raw-spans-grouper/helm/templates/raw-spans-grouper-config.yaml
@@ -35,7 +35,7 @@ data:
       replication.factor = "{{ int .Values.rawSpansGrouperConfig.kafkaStreamsConfig.replicationFactor }}"
       topic.cleanup.policy = "delete,compact"
       # RocksDB state store configs
-      state.dir = "/var/data/"
+      state.dir = {{ .Values.rawSpansGrouperConfig.kafkaStreamsConfig.stateDir }}
       rocksdb.cache.total.capacity: "{{ int .Values.rawSpansGrouperConfig.kafkaStreamsConfig.rocksdbCacheTotalCapacity }}"
       rocksdb.cache.write.buffers.ratio: "{{ .Values.rawSpansGrouperConfig.kafkaStreamsConfig.rocksdbCacheWriteBuffersRatio }}"
       rocksdb.cache.high.priority.pool.ratio: "{{ .Values.rawSpansGrouperConfig.kafkaStreamsConfig.rocksdbCacheHighPriorityPoolRatio }}"

--- a/raw-spans-grouper/helm/templates/raw-spans-grouper-config.yaml
+++ b/raw-spans-grouper/helm/templates/raw-spans-grouper-config.yaml
@@ -35,7 +35,7 @@ data:
       replication.factor = "{{ int .Values.rawSpansGrouperConfig.kafkaStreamsConfig.replicationFactor }}"
       topic.cleanup.policy = "delete,compact"
       # RocksDB state store configs
-      state.dir = {{ .Values.rawSpansGrouperConfig.kafkaStreamsConfig.stateDir }}
+      state.dir = "{{ .Values.rawSpansGrouperConfig.kafkaStreamsConfig.stateDir }}"
       rocksdb.cache.total.capacity: "{{ int .Values.rawSpansGrouperConfig.kafkaStreamsConfig.rocksdbCacheTotalCapacity }}"
       rocksdb.cache.write.buffers.ratio: "{{ .Values.rawSpansGrouperConfig.kafkaStreamsConfig.rocksdbCacheWriteBuffersRatio }}"
       rocksdb.cache.high.priority.pool.ratio: "{{ .Values.rawSpansGrouperConfig.kafkaStreamsConfig.rocksdbCacheHighPriorityPoolRatio }}"

--- a/raw-spans-grouper/helm/templates/statefulset.yaml
+++ b/raw-spans-grouper/helm/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.chartType "application" }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -126,3 +127,4 @@ spec:
               port: {{ .Values.containerAdminPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+{{- end }}

--- a/raw-spans-grouper/helm/values.yaml
+++ b/raw-spans-grouper/helm/values.yaml
@@ -7,6 +7,8 @@
 # You can always specify a different namespace for a resource by setting it directly in it's yaml file or
 # making it configurable by defining it in this file.
 
+chartType: "application"
+
 ###########
 # Deployment
 ###########

--- a/raw-spans-grouper/helm/values.yaml
+++ b/raw-spans-grouper/helm/values.yaml
@@ -93,6 +93,7 @@ rawSpansGrouperConfig:
     bootstrapServers: "bootstrap:9092"
     schemaRegistryUrl: "http://schema-registry-service:8081"
     #  Core configs
+    stateDir: "/var/data/"
     numStreamThreads: 4 # default = 1
     commitIntervalMs: 30000 # default = 30000
     cacheMaxBytesBuffering: 134217728 # default = 10485760 (10MB)

--- a/span-normalizer/helm/templates/deployment.yaml
+++ b/span-normalizer/helm/templates/deployment.yaml
@@ -95,4 +95,4 @@ spec:
               port: {{ .Values.containerAdminPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-{{-end }}
+{{- end }}

--- a/span-normalizer/helm/templates/deployment.yaml
+++ b/span-normalizer/helm/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.chartType "application" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -94,3 +95,4 @@ spec:
               port: {{ .Values.containerAdminPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+{{-end }}

--- a/span-normalizer/helm/templates/hpa.yaml
+++ b/span-normalizer/helm/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hpa.enabled }}
+{{- if and (.Values.hpa.enabled) ((eq .Values.chartType "application")) }}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/span-normalizer/helm/templates/logconfig.yaml
+++ b/span-normalizer/helm/templates/logconfig.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.chartType "application" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -39,3 +40,4 @@ data:
     {{- if .Values.logConfig.appender.rolling.enabled }}
     rootLogger.appenderRef.rolling.ref = ROLLING_FILE
     {{- end }}
+{{- end }}

--- a/span-normalizer/helm/values.yaml
+++ b/span-normalizer/helm/values.yaml
@@ -10,6 +10,8 @@
 # You can always specify a different namespace for a resource by setting it directly in it's yaml file or
 # making it configurable by defining it in this file.
 
+chartType: "application"
+
 ###########
 # Deployment
 ###########


### PR DESCRIPTION
## Description
Wrapping the charts of span-normalizer and raw-spans-grouper under charType, so it can be used as library charts as dependency.

### Testing
Locally ran the helm template. No change in current vs Prior.
