### PR TITLE
refactor: fix expiration of ua cache

### DIFF
--- a/hypertrace-trace-enricher/helm/templates/trace-enricher-config.yaml
+++ b/hypertrace-trace-enricher/helm/templates/trace-enricher-config.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.traceEnricherConfig.name }}
+  name: { { .Values.traceEnricherConfig.name } }
   labels:
-    release: {{ .Release.Name }}
+    release: { { .Release.Name } }
 data:
   application.conf: |-
     kafka.streams.config {
@@ -50,13 +50,11 @@ data:
           host = {{ .Values.traceEnricherConfig.configServiceHost }}
           port = {{ .Values.traceEnricherConfig.configServicePort }}
         }
-      }
-    }
-    
-    enricher.UserAgentSpanEnricher {
-      cache = {
-        maxSize = {{ .Values.traceEnricherConfig.userAgentSpanEnricherConfig.cacheSize }}
-        write.expire.duration = {{ .Values.traceEnricherConfig.userAgentSpanEnricherConfig.expiryTime }}
-        refresh.expire.duration = {{ .Values.traceEnricherConfig.userAgentSpanEnricherConfig.refreshTime }}      
+        useragent.parser = {
+          cache = {
+            maxSize = {{ .Values.traceEnricherConfig.userAgentParserConfig.cacheSize }}
+            access.expire.duration = {{ .Values.traceEnricherConfig.userAgentParserConfig.expireAfterAccess }}    
+          }
+        }
       }
     }

--- a/hypertrace-trace-enricher/helm/templates/trace-enricher-config.yaml
+++ b/hypertrace-trace-enricher/helm/templates/trace-enricher-config.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: { { .Values.traceEnricherConfig.name } }
+  name: {{ .Values.traceEnricherConfig.name }}
   labels:
-    release: { { .Release.Name } }
+    release: {{ .Release.Name }}
 data:
   application.conf: |-
     kafka.streams.config {

--- a/hypertrace-trace-enricher/helm/values.yaml
+++ b/hypertrace-trace-enricher/helm/values.yaml
@@ -99,10 +99,9 @@ traceEnricherConfig:
   attributeServicePort: 9012
   configServiceHost: config-service
   configServicePort: 50101
-  userAgentSpanEnricherConfig:
+  userAgentParserConfig:
     cacheSize: 20000
-    refreshTime: 5m
-    expiryTime: 10m
+    expireAfterAccess: 10m
 
 logConfig:
   name: hypertrace-trace-enricher-log-config

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/clients/ClientRegistry.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/clients/ClientRegistry.java
@@ -11,6 +11,7 @@ import org.hypertrace.entity.query.service.v1.EntityQueryServiceGrpc.EntityQuery
 import org.hypertrace.trace.accessor.entities.TraceEntityAccessor;
 import org.hypertrace.trace.reader.attributes.TraceAttributeReader;
 import org.hypertrace.traceenricher.enrichment.enrichers.cache.EntityCache;
+import org.hypertrace.traceenricher.util.UserAgentParser;
 
 public interface ClientRegistry {
 
@@ -35,4 +36,6 @@ public interface ClientRegistry {
   EntityCache getEntityCache();
 
   CachingAttributeClient getCachingAttributeClient();
+
+  UserAgentParser getUserAgentParser();
 }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/UserAgentSpanEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/UserAgentSpanEnricher.java
@@ -1,75 +1,26 @@
 package org.hypertrace.traceenricher.enrichment.enrichers;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.typesafe.config.Config;
-import java.time.Duration;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Nullable;
 import net.sf.uadetector.ReadableUserAgent;
-import net.sf.uadetector.UserAgentStringParser;
-import net.sf.uadetector.service.UADetectorServiceFactory;
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.StructuredTrace;
 import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;
-import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
-import org.hypertrace.semantic.convention.utils.http.HttpSemanticConventionUtils;
-import org.hypertrace.semantic.convention.utils.rpc.RpcSemanticConventionUtils;
 import org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants;
-import org.hypertrace.traceenricher.enrichedspan.constants.utils.EnrichedSpanUtils;
-import org.hypertrace.traceenricher.enrichedspan.constants.v1.Protocol;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.UserAgent;
 import org.hypertrace.traceenricher.enrichment.AbstractTraceEnricher;
 import org.hypertrace.traceenricher.enrichment.clients.ClientRegistry;
+import org.hypertrace.traceenricher.util.UserAgentParser;
 
 public class UserAgentSpanEnricher extends AbstractTraceEnricher {
 
-  private static final String CACHE_CONFIG_KEY = "cache";
-  private static final String CACHE_CONFIG_MAX_SIZE = "maxSize";
-  public static final String CACHE_CONFIG_ACCESS_EXPIRATION_DURATION = "access.expire.duration";
-  private static final int CACHE_MAX_SIZE_DEFAULT = 20000;
-  private static final Duration DEFAULT_ACCESS_EXPIRATION_DURATION = Duration.ofMinutes(5);
-  private static final String USER_AGENT_MAX_LENGTH_KEY = "user.agent.max.length";
-  private static final int DEFAULT_USER_AGENT_MAX_LENGTH = 1000;
-  private static final String DOT = ".";
-  private final UserAgentStringParser userAgentStringParser =
-      UADetectorServiceFactory.getResourceModuleParser();
-  @Nullable private LoadingCache<String, ReadableUserAgent> userAgentCache;
-  private int userAgentMaxLength;
+  private UserAgentParser userAgentParser;
 
   @Override
   public void init(Config enricherConfig, ClientRegistry clientRegistry) {
-    if (enricherConfig.hasPath(CACHE_CONFIG_KEY)) {
-      Config enricherCacheConfig = enricherConfig.getConfig(CACHE_CONFIG_KEY);
-      int cacheSize =
-          enricherCacheConfig.hasPath(CACHE_CONFIG_MAX_SIZE)
-              ? enricherCacheConfig.getInt(CACHE_CONFIG_MAX_SIZE)
-              : CACHE_MAX_SIZE_DEFAULT;
-      Duration accessExpirationDuration =
-          enricherCacheConfig.hasPath(CACHE_CONFIG_ACCESS_EXPIRATION_DURATION)
-              ? enricherCacheConfig.getDuration(CACHE_CONFIG_ACCESS_EXPIRATION_DURATION)
-              : DEFAULT_ACCESS_EXPIRATION_DURATION;
-
-      userAgentCache =
-          CacheBuilder.newBuilder()
-              .maximumSize(cacheSize)
-              .expireAfterAccess(accessExpirationDuration)
-              .recordStats()
-              .build(CacheLoader.from(userAgentStringParser::parse));
-      PlatformMetricsRegistry.registerCache(
-          this.getClass().getName() + DOT + "userAgentCache",
-          userAgentCache,
-          Collections.emptyMap());
-    }
-    if (enricherConfig.hasPath(USER_AGENT_MAX_LENGTH_KEY)) {
-      userAgentMaxLength = enricherConfig.getInt(USER_AGENT_MAX_LENGTH_KEY);
-    } else {
-      userAgentMaxLength = DEFAULT_USER_AGENT_MAX_LENGTH;
-    }
+    this.userAgentParser = clientRegistry.getUserAgentParser();
   }
 
   @Override
@@ -84,56 +35,34 @@ public class UserAgentSpanEnricher extends AbstractTraceEnricher {
     }
 
     // extract the user-agent header
-    Optional<String> mayBeUserAgent = getUserAgent(event);
-
-    if (mayBeUserAgent.isPresent()) {
-      String userAgentStr = mayBeUserAgent.get();
-      if (userAgentStr.length() > userAgentMaxLength) {
-        userAgentStr = userAgentStr.substring(0, userAgentMaxLength);
-      }
-      ReadableUserAgent userAgent =
-          userAgentCache != null
-              ? userAgentCache.getUnchecked(userAgentStr)
-              : userAgentStringParser.parse(userAgentStr);
-      addEnrichedAttribute(
-          event,
-          EnrichedSpanConstants.getValue(UserAgent.USER_AGENT_NAME),
-          AttributeValueCreator.create(userAgent.getName()));
-      addEnrichedAttribute(
-          event,
-          EnrichedSpanConstants.getValue(UserAgent.USER_AGENT_TYPE),
-          AttributeValueCreator.create(userAgent.getType().getName()));
-      addEnrichedAttribute(
-          event,
-          EnrichedSpanConstants.getValue(UserAgent.USER_AGENT_DEVICE_CATEGORY),
-          AttributeValueCreator.create(userAgent.getDeviceCategory().getName()));
-      addEnrichedAttribute(
-          event,
-          EnrichedSpanConstants.getValue(UserAgent.USER_AGENT_OS_NAME),
-          AttributeValueCreator.create(userAgent.getOperatingSystem().getName()));
-      addEnrichedAttribute(
-          event,
-          EnrichedSpanConstants.getValue(UserAgent.USER_AGENT_OS_VERSION),
-          AttributeValueCreator.create(
-              userAgent.getOperatingSystem().getVersionNumber().toVersionString()));
-      addEnrichedAttribute(
-          event,
-          EnrichedSpanConstants.getValue(UserAgent.USER_AGENT_BROWSER_VERSION),
-          AttributeValueCreator.create(userAgent.getVersionNumber().toVersionString()));
-    }
-  }
-
-  private Optional<String> getUserAgent(Event event) {
-    Protocol protocol = EnrichedSpanUtils.getProtocol(event);
-    if (Protocol.PROTOCOL_HTTP == protocol || Protocol.PROTOCOL_HTTPS == protocol) {
-      Optional<String> userAgent = HttpSemanticConventionUtils.getHttpUserAgentFromHeader(event);
-      return userAgent.isPresent()
-          ? userAgent
-          : HttpSemanticConventionUtils.getHttpUserAgent(event);
-    } else if (Protocol.PROTOCOL_GRPC == protocol) {
-      return RpcSemanticConventionUtils.getGrpcUserAgent(event);
-    }
-
-    return Optional.empty();
+    Optional<ReadableUserAgent> maybeUserAgent = this.userAgentParser.getUserAgent(event);
+    maybeUserAgent.ifPresent(
+        userAgent -> {
+          addEnrichedAttribute(
+              event,
+              EnrichedSpanConstants.getValue(UserAgent.USER_AGENT_NAME),
+              AttributeValueCreator.create(userAgent.getName()));
+          addEnrichedAttribute(
+              event,
+              EnrichedSpanConstants.getValue(UserAgent.USER_AGENT_TYPE),
+              AttributeValueCreator.create(userAgent.getType().getName()));
+          addEnrichedAttribute(
+              event,
+              EnrichedSpanConstants.getValue(UserAgent.USER_AGENT_DEVICE_CATEGORY),
+              AttributeValueCreator.create(userAgent.getDeviceCategory().getName()));
+          addEnrichedAttribute(
+              event,
+              EnrichedSpanConstants.getValue(UserAgent.USER_AGENT_OS_NAME),
+              AttributeValueCreator.create(userAgent.getOperatingSystem().getName()));
+          addEnrichedAttribute(
+              event,
+              EnrichedSpanConstants.getValue(UserAgent.USER_AGENT_OS_VERSION),
+              AttributeValueCreator.create(
+                  userAgent.getOperatingSystem().getVersionNumber().toVersionString()));
+          addEnrichedAttribute(
+              event,
+              EnrichedSpanConstants.getValue(UserAgent.USER_AGENT_BROWSER_VERSION),
+              AttributeValueCreator.create(userAgent.getVersionNumber().toVersionString()));
+        });
   }
 }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/util/UserAgentParser.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/util/UserAgentParser.java
@@ -1,0 +1,66 @@
+package org.hypertrace.traceenricher.util;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.typesafe.config.Config;
+import java.util.Collections;
+import java.util.Optional;
+import net.sf.uadetector.ReadableUserAgent;
+import net.sf.uadetector.UserAgentStringParser;
+import net.sf.uadetector.service.UADetectorServiceFactory;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
+import org.hypertrace.semantic.convention.utils.http.HttpSemanticConventionUtils;
+import org.hypertrace.semantic.convention.utils.rpc.RpcSemanticConventionUtils;
+import org.hypertrace.traceenricher.enrichedspan.constants.utils.EnrichedSpanUtils;
+import org.hypertrace.traceenricher.enrichedspan.constants.v1.Protocol;
+
+public class UserAgentParser {
+  private static final String CACHE_CONFIG_KEY = "cache";
+  private static final String CACHE_CONFIG_MAX_SIZE = "maxSize";
+  public static final String CACHE_CONFIG_ACCESS_EXPIRATION_DURATION = "access.expire.duration";
+  private static final String USER_AGENT_MAX_LENGTH_KEY = "max.length";
+  private final UserAgentStringParser userAgentStringParser =
+      UADetectorServiceFactory.getResourceModuleParser();
+
+  private final LoadingCache<String, ReadableUserAgent> userAgentCache;
+  private final int userAgentMaxLength;
+
+  public UserAgentParser(Config config) {
+    Config cacheConfig = config.getConfig(CACHE_CONFIG_KEY);
+    this.userAgentMaxLength = config.getInt(USER_AGENT_MAX_LENGTH_KEY);
+    this.userAgentCache =
+        CacheBuilder.newBuilder()
+            .maximumSize(cacheConfig.getInt(CACHE_CONFIG_MAX_SIZE))
+            .expireAfterAccess(cacheConfig.getDuration(CACHE_CONFIG_ACCESS_EXPIRATION_DURATION))
+            .recordStats()
+            .build(CacheLoader.from(userAgentStringParser::parse));
+
+    PlatformMetricsRegistry.registerCache(
+        this.getClass().getName() + ".userAgentCache", userAgentCache, Collections.emptyMap());
+  }
+
+  public Optional<ReadableUserAgent> getUserAgent(Event event) {
+    return this.getUserAgentString(event)
+        .map(
+            userAgent ->
+                userAgent.length() > userAgentMaxLength
+                    ? userAgent.substring(0, userAgentMaxLength)
+                    : userAgent)
+        .map(this.userAgentCache::getUnchecked);
+  }
+
+  private Optional<String> getUserAgentString(Event event) {
+    Protocol protocol = EnrichedSpanUtils.getProtocol(event);
+    if (Protocol.PROTOCOL_HTTP == protocol || Protocol.PROTOCOL_HTTPS == protocol) {
+      return HttpSemanticConventionUtils.getHttpUserAgentFromHeader(event)
+          .or(() -> HttpSemanticConventionUtils.getHttpUserAgent(event));
+    }
+    if (Protocol.PROTOCOL_GRPC == protocol) {
+      return RpcSemanticConventionUtils.getGrpcUserAgent(event);
+    }
+
+    return Optional.empty();
+  }
+}

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/UserAgentSpanEnricherTest.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/UserAgentSpanEnricherTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import java.util.Map;
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Event;
@@ -23,17 +23,24 @@ import org.hypertrace.traceenricher.enrichedspan.constants.v1.Protocol;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.UserAgent;
 import org.hypertrace.traceenricher.enrichment.clients.ClientRegistry;
 import org.hypertrace.traceenricher.util.Constants;
+import org.hypertrace.traceenricher.util.UserAgentParser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class UserAgentSpanEnricherTest extends AbstractAttributeEnricherTest {
-
+class UserAgentSpanEnricherTest extends AbstractAttributeEnricherTest {
   private UserAgentSpanEnricher enricher;
 
   @BeforeEach
   public void setUp() {
+    UserAgentParser parser =
+        new UserAgentParser(
+            ConfigFactory.parseMap(
+                Map.of(
+                    "cache.maxSize", 0, "cache.access.expire.duration", "0s", "max.length", 1000)));
+    ClientRegistry mockClientRegistry = mock(ClientRegistry.class);
+    when(mockClientRegistry.getUserAgentParser()).thenReturn(parser);
     enricher = new UserAgentSpanEnricher();
-    enricher.init(mock(Config.class), mock(ClientRegistry.class));
+    enricher.init(ConfigFactory.empty(), mockClientRegistry);
   }
 
   @Test

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/src/main/resources/configs/common/application.conf
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/src/main/resources/configs/common/application.conf
@@ -45,6 +45,13 @@ enricher {
         port = 50101
         port = ${?CONFIG_SERVICE_PORT_CONFIG}
       }
+      useragent.parser = {
+        max.length = 1000
+        cache = {
+          maxSize = 20000
+          access.expire.duration = 10m
+        }
+      }
   }
 
   DefaultServiceEntityEnricher {
@@ -86,11 +93,6 @@ enricher {
 
   UserAgentSpanEnricher {
     class = "org.hypertrace.traceenricher.enrichment.enrichers.UserAgentSpanEnricher"
-    cache = {
-      maxSize = 20000
-      write.expire.duration = 10m
-      refresh.expire.duration = 5m
-    }
   }
 
   EndpointEnricher {

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/src/test/resources/configs/hypertrace-trace-enricher/application.conf
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/src/test/resources/configs/hypertrace-trace-enricher/application.conf
@@ -34,6 +34,13 @@ enricher {
         host = localhost
         port = 50101
       }
+      useragent.parser = {
+        max.length = 1000
+        cache = {
+          maxSize = 20000
+          access.expire.duration = 10m
+        }
+      }
   }
 
   DefaultServiceEntityEnricher {


### PR DESCRIPTION
## Description

Change user agent caching strategy to not refresh (because the value is static) and evict based on access rather than origin.

Also moved user agent parser into standalone class with its own cache so it can be shared across stream threads (unlike the enrichers).
