### PR TITLE
chore: add category info to fix trivy build issue

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -35,54 +35,63 @@ jobs:
         with:
           image: hypertrace/hypertrace-ingester
           output-mode: github
+          category: hypertrace-ingester
 
       - name: Run Trivy vulnerability scanner for span-normalizer
         uses: hypertrace/github-actions/trivy-image-scan@main
         with:
           image: hypertrace/span-normalizer
           output-mode: github
+          category: span-normalizer
 
       - name: Run Trivy vulnerability scanner for raw-spans-grouper
         uses: hypertrace/github-actions/trivy-image-scan@main
         with:
           image: hypertrace/raw-spans-grouper
           output-mode: github
+          category: raw-spans-grouper
 
       - name: Run Trivy vulnerability scanner for trace-enricher
         uses: hypertrace/github-actions/trivy-image-scan@main
         with:
           image: hypertrace/hypertrace-trace-enricher
           output-mode: github
+          category: hypertrace-trace-enricher
 
       - name: Run Trivy vulnerability scanner for view creator
         uses: hypertrace/github-actions/trivy-image-scan@main
         with:
           image: hypertrace/hypertrace-view-creator
           output-mode: github
+          category: hypertrace-view-creator
 
       - name: Run Trivy vulnerability scanner for view-generator
         uses: hypertrace/github-actions/trivy-image-scan@main
         with:
           image: hypertrace/hypertrace-view-generator
           output-mode: github
+          category: hypertrace-view-generator
 
       - name: Run Trivy vulnerability scanner for metrics generator
         uses: hypertrace/github-actions/trivy-image-scan@main
         with:
           image: hypertrace/hypertrace-metrics-generator
           output-mode: github
+          category: hypertrace-metrics-generator
 
       - name: Run Trivy vulnerability scanner for metrics processor
         uses: hypertrace/github-actions/trivy-image-scan@main
         with:
           image: hypertrace/hypertrace-metrics-processor
           output-mode: github
+          category: hypertrace-metrics-processor
 
       - name: Run Trivy vulnerability scanner for metrics exporter
         uses: hypertrace/github-actions/trivy-image-scan@main
         with:
           image: hypertrace/hypertrace-metrics-exporter
           output-mode: github
+          category: hypertrace-metrics-exporter
 
   validate-helm-charts:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
To fix: https://github.com/hypertrace/hypertrace-ingester/actions/runs/5452280343/jobs/9919573254?pr=396
<img width="1314" alt="Screenshot 2023-07-04 at 3 43 41 PM" src="https://github.com/hypertrace/hypertrace-ingester/assets/53209990/1a242649-78e8-42e5-8a15-f2ce732cb9de">
