### PR TITLE
make port optional to build full url, exclusion rule eval fallback on url path

### DIFF
--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -2,6 +2,7 @@ package org.hypertrace.semantic.convention.utils.http;
 
 import static com.google.common.net.HttpHeaders.COOKIE;
 import static com.google.common.net.HttpHeaders.SET_COOKIE;
+import static java.util.Objects.nonNull;
 import static org.hypertrace.core.semantic.convention.constants.http.HttpSemanticConventions.HTTP_REQUEST_FORWARDED;
 import static org.hypertrace.core.semantic.convention.constants.http.OTelHttpSemanticConventions.HTTP_HOST;
 import static org.hypertrace.core.semantic.convention.constants.http.OTelHttpSemanticConventions.HTTP_NET_HOST_NAME;
@@ -287,17 +288,11 @@ public class HttpSemanticConventionUtils {
       final String httpTarget = attributeValueMap.get(HTTP_TARGET.getValue()).getValue();
       final String netPeerName =
           attributeValueMap.get(OTelSpanSemanticConventions.NET_PEER_NAME.getValue()).getValue();
-
+      final AttributeValue netPeerPortAttributeValue =
+          attributeValueMap.get(OTelSpanSemanticConventions.NET_PEER_PORT.getValue());
       String url;
-      if (attributeValueMap.containsKey(OTelSpanSemanticConventions.NET_PEER_PORT.getValue())) {
-        url =
-            buildUrl(
-                httpScheme,
-                netPeerName,
-                attributeValueMap
-                    .get(OTelSpanSemanticConventions.NET_PEER_PORT.getValue())
-                    .getValue(),
-                httpTarget);
+      if (nonNull(netPeerPortAttributeValue)) {
+        url = buildUrl(httpScheme, netPeerName, netPeerPortAttributeValue.getValue(), httpTarget);
       } else {
         url = buildUrl(httpScheme, netPeerName, httpTarget);
       }
@@ -314,16 +309,11 @@ public class HttpSemanticConventionUtils {
                   OTelSpanSemanticConventions.NET_SOCK_PEER_ADDR.getValue(),
                   attributeValueMap.get(OTelSpanSemanticConventions.NET_PEER_IP.getValue()))
               .getValue();
+      final AttributeValue netPeerPortAttributeValue =
+          attributeValueMap.get(OTelSpanSemanticConventions.NET_PEER_PORT.getValue());
       String url;
-      if (attributeValueMap.containsKey(OTelSpanSemanticConventions.NET_PEER_PORT.getValue())) {
-        url =
-            buildUrl(
-                httpScheme,
-                netPeerIp,
-                attributeValueMap
-                    .get(OTelSpanSemanticConventions.NET_PEER_PORT.getValue())
-                    .getValue(),
-                httpTarget);
+      if (nonNull(netPeerPortAttributeValue)) {
+        url = buildUrl(httpScheme, netPeerIp, netPeerPortAttributeValue.getValue(), httpTarget);
       } else {
         url = buildUrl(httpScheme, netPeerIp, httpTarget);
       }
@@ -340,14 +330,12 @@ public class HttpSemanticConventionUtils {
       final String httpScheme = getHttpSchemeFromRawAttributes(attributeValueMap).get();
       final String serverName = attributeValueMap.get(HTTP_SERVER_NAME.getValue()).getValue();
       final String httpTarget = attributeValueMap.get(HTTP_TARGET.getValue()).getValue();
+      final AttributeValue httpNetHostPortAttributeValue =
+          attributeValueMap.get(HTTP_NET_HOST_PORT.getValue());
       String url;
-      if (attributeValueMap.containsKey(HTTP_NET_HOST_PORT.getValue())) {
+      if (nonNull(httpNetHostPortAttributeValue)) {
         url =
-            buildUrl(
-                httpScheme,
-                serverName,
-                attributeValueMap.get(HTTP_NET_HOST_PORT.getValue()).getValue(),
-                httpTarget);
+            buildUrl(httpScheme, serverName, httpNetHostPortAttributeValue.getValue(), httpTarget);
       } else {
         url = buildUrl(httpScheme, serverName, httpTarget);
       }
@@ -358,15 +346,12 @@ public class HttpSemanticConventionUtils {
       final String httpScheme = getHttpSchemeFromRawAttributes(attributeValueMap).get();
       final String netHostName = attributeValueMap.get(HTTP_NET_HOST_NAME.getValue()).getValue();
       final String httpTarget = attributeValueMap.get(HTTP_TARGET.getValue()).getValue();
-
+      final AttributeValue httpNetHostPortAttributeValue =
+          attributeValueMap.get(HTTP_NET_HOST_PORT.getValue());
       String url;
-      if (attributeValueMap.containsKey(HTTP_NET_HOST_PORT.getValue())) {
+      if (nonNull(httpNetHostPortAttributeValue)) {
         url =
-            buildUrl(
-                httpScheme,
-                netHostName,
-                attributeValueMap.get(HTTP_NET_HOST_PORT.getValue()).getValue(),
-                httpTarget);
+            buildUrl(httpScheme, netHostName, httpNetHostPortAttributeValue.getValue(), httpTarget);
       } else {
         url = buildUrl(httpScheme, netHostName, httpTarget);
       }

--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -259,8 +259,7 @@ public class HttpSemanticConventionUtils {
         && attributeValueMap.containsKey(HTTP_HOST.getValue())
         && attributeValueMap.containsKey(HTTP_TARGET.getValue())) {
       String url =
-          String.format(
-              "%s://%s%s",
+          buildUrl(
               getHttpSchemeFromRawAttributes(attributeValueMap).get(),
               attributeValueMap.get(HTTP_HOST.getValue()).getValue(),
               attributeValueMap.get(HTTP_TARGET.getValue()).getValue());
@@ -283,38 +282,51 @@ public class HttpSemanticConventionUtils {
       Map<String, AttributeValue> attributeValueMap) {
     if (attributeValueMap.containsKey(HTTP_SCHEME.getValue())
         && attributeValueMap.containsKey(OTelSpanSemanticConventions.NET_PEER_NAME.getValue())
-        && attributeValueMap.containsKey(OTelSpanSemanticConventions.NET_PEER_PORT.getValue())
         && attributeValueMap.containsKey(HTTP_TARGET.getValue())) {
-      String url =
-          String.format(
-              "%s://%s:%s%s",
-              getHttpSchemeFromRawAttributes(attributeValueMap).get(),
-              attributeValueMap
-                  .get(OTelSpanSemanticConventions.NET_PEER_NAME.getValue())
-                  .getValue(),
-              attributeValueMap
-                  .get(OTelSpanSemanticConventions.NET_PEER_PORT.getValue())
-                  .getValue(),
-              attributeValueMap.get(HTTP_TARGET.getValue()).getValue());
+      final String httpScheme = getHttpSchemeFromRawAttributes(attributeValueMap).get();
+      final String httpTarget = attributeValueMap.get(HTTP_TARGET.getValue()).getValue();
+      final String netPeerName =
+          attributeValueMap.get(OTelSpanSemanticConventions.NET_PEER_NAME.getValue()).getValue();
+
+      String url;
+      if (attributeValueMap.containsKey(OTelSpanSemanticConventions.NET_PEER_PORT.getValue())) {
+        url =
+            buildUrl(
+                httpScheme,
+                netPeerName,
+                attributeValueMap
+                    .get(OTelSpanSemanticConventions.NET_PEER_PORT.getValue())
+                    .getValue(),
+                httpTarget);
+      } else {
+        url = buildUrl(httpScheme, netPeerName, httpTarget);
+      }
       return Optional.of(url);
     } else if (attributeValueMap.containsKey(HTTP_SCHEME.getValue())
         && (attributeValueMap.containsKey(OTelSpanSemanticConventions.NET_SOCK_PEER_ADDR.getValue())
             || attributeValueMap.containsKey(OTelSpanSemanticConventions.NET_PEER_IP.getValue()))
-        && attributeValueMap.containsKey(OTelSpanSemanticConventions.NET_PEER_PORT.getValue())
         && attributeValueMap.containsKey(HTTP_TARGET.getValue())) {
-      String url =
-          String.format(
-              "%s://%s:%s%s",
-              getHttpSchemeFromRawAttributes(attributeValueMap).get(),
-              attributeValueMap
-                  .getOrDefault(
-                      OTelSpanSemanticConventions.NET_SOCK_PEER_ADDR.getValue(),
-                      attributeValueMap.get(OTelSpanSemanticConventions.NET_PEER_IP.getValue()))
-                  .getValue(),
-              attributeValueMap
-                  .get(OTelSpanSemanticConventions.NET_PEER_PORT.getValue())
-                  .getValue(),
-              attributeValueMap.get(HTTP_TARGET.getValue()).getValue());
+      final String httpScheme = getHttpSchemeFromRawAttributes(attributeValueMap).get();
+      final String httpTarget = attributeValueMap.get(HTTP_TARGET.getValue()).getValue();
+      final String netPeerIp =
+          attributeValueMap
+              .getOrDefault(
+                  OTelSpanSemanticConventions.NET_SOCK_PEER_ADDR.getValue(),
+                  attributeValueMap.get(OTelSpanSemanticConventions.NET_PEER_IP.getValue()))
+              .getValue();
+      String url;
+      if (attributeValueMap.containsKey(OTelSpanSemanticConventions.NET_PEER_PORT.getValue())) {
+        url =
+            buildUrl(
+                httpScheme,
+                netPeerIp,
+                attributeValueMap
+                    .get(OTelSpanSemanticConventions.NET_PEER_PORT.getValue())
+                    .getValue(),
+                httpTarget);
+      } else {
+        url = buildUrl(httpScheme, netPeerIp, httpTarget);
+      }
       return Optional.of(url);
     }
     return Optional.empty();
@@ -324,30 +336,52 @@ public class HttpSemanticConventionUtils {
       Map<String, AttributeValue> attributeValueMap) {
     if (attributeValueMap.containsKey(HTTP_SCHEME.getValue())
         && attributeValueMap.containsKey(HTTP_SERVER_NAME.getValue())
-        && attributeValueMap.containsKey(HTTP_NET_HOST_PORT.getValue())
         && attributeValueMap.containsKey(HTTP_TARGET.getValue())) {
-      String url =
-          String.format(
-              "%s://%s:%s%s",
-              getHttpSchemeFromRawAttributes(attributeValueMap).get(),
-              attributeValueMap.get(HTTP_SERVER_NAME.getValue()).getValue(),
-              attributeValueMap.get(HTTP_NET_HOST_PORT.getValue()).getValue(),
-              attributeValueMap.get(HTTP_TARGET.getValue()).getValue());
+      final String httpScheme = getHttpSchemeFromRawAttributes(attributeValueMap).get();
+      final String serverName = attributeValueMap.get(HTTP_SERVER_NAME.getValue()).getValue();
+      final String httpTarget = attributeValueMap.get(HTTP_TARGET.getValue()).getValue();
+      String url;
+      if (attributeValueMap.containsKey(HTTP_NET_HOST_PORT.getValue())) {
+        url =
+            buildUrl(
+                httpScheme,
+                serverName,
+                attributeValueMap.get(HTTP_NET_HOST_PORT.getValue()).getValue(),
+                httpTarget);
+      } else {
+        url = buildUrl(httpScheme, serverName, httpTarget);
+      }
       return Optional.of(url);
     } else if (attributeValueMap.containsKey(HTTP_SCHEME.getValue())
         && attributeValueMap.containsKey(HTTP_NET_HOST_NAME.getValue())
-        && attributeValueMap.containsKey(HTTP_NET_HOST_PORT.getValue())
         && attributeValueMap.containsKey(HTTP_TARGET.getValue())) {
-      String url =
-          String.format(
-              "%s://%s:%s%s",
-              getHttpSchemeFromRawAttributes(attributeValueMap).get(),
-              attributeValueMap.get(HTTP_NET_HOST_NAME.getValue()).getValue(),
-              attributeValueMap.get(HTTP_NET_HOST_PORT.getValue()).getValue(),
-              attributeValueMap.get(HTTP_TARGET.getValue()).getValue());
+      final String httpScheme = getHttpSchemeFromRawAttributes(attributeValueMap).get();
+      final String netHostName = attributeValueMap.get(HTTP_NET_HOST_NAME.getValue()).getValue();
+      final String httpTarget = attributeValueMap.get(HTTP_TARGET.getValue()).getValue();
+
+      String url;
+      if (attributeValueMap.containsKey(HTTP_NET_HOST_PORT.getValue())) {
+        url =
+            buildUrl(
+                httpScheme,
+                netHostName,
+                attributeValueMap.get(HTTP_NET_HOST_PORT.getValue()).getValue(),
+                httpTarget);
+      } else {
+        url = buildUrl(httpScheme, netHostName, httpTarget);
+      }
       return Optional.of(url);
     }
     return Optional.empty();
+  }
+
+  private static String buildUrl(
+      final String scheme, final String host, final String port, final String path) {
+    return String.format("%s://%s:%s%s", scheme, host, port, path);
+  }
+
+  private static String buildUrl(final String scheme, final String host, final String path) {
+    return String.format("%s://%s%s", scheme, host, path);
   }
 
   public static Optional<AttributeValue> getValidHttpUrl(Event event) {

--- a/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtilsTest.java
+++ b/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtilsTest.java
@@ -154,6 +154,18 @@ public class HttpSemanticConventionUtilsTest {
     url = HttpSemanticConventionUtils.getHttpUrlForOTelFormat(map).get();
     assertEquals("https://172.0.8.11:1211/webshop/articles/4?s=1", url);
 
+    // client span, span.kind present, port absent
+    map.clear();
+    map.put(HTTP_SCHEME.getValue(), buildAttributeValue("https"));
+    map.put(
+        OTelSpanSemanticConventions.NET_PEER_NAME.getValue(), buildAttributeValue("example.com"));
+    map.put(HTTP_TARGET.getValue(), buildAttributeValue("/webshop/articles/4?s=1"));
+    map.put(
+        RawSpanConstants.getValue(OCAttribute.OC_ATTRIBUTE_SPAN_KIND),
+        buildAttributeValue(RawSpanConstants.getValue(OCSpanKind.OC_SPAN_KIND_CLIENT)));
+    url = HttpSemanticConventionUtils.getHttpUrlForOTelFormat(map).get();
+    assertEquals("https://example.com/webshop/articles/4?s=1", url);
+
     // server span, span_kind present
     map.clear();
     map.put(HTTP_SCHEME.getValue(), buildAttributeValue("https"));
@@ -195,6 +207,15 @@ public class HttpSemanticConventionUtilsTest {
         buildAttributeValue(RawSpanConstants.getValue(OCSpanKind.OC_SPAN_KIND_SERVER)));
     url = HttpSemanticConventionUtils.getHttpUrlForOTelFormat(map).get();
     assertEquals("https://example.com:1211/webshop/articles/4?s=1", url);
+
+    // server span, span_kind present, port absent
+    map.clear();
+    map.put(HTTP_SCHEME.getValue(), buildAttributeValue("https"));
+    map.put(HTTP_NET_HOST_NAME.getValue(), buildAttributeValue("example.com"));
+    map.put(HTTP_TARGET.getValue(), buildAttributeValue("/webshop/articles/4?s=1"));
+    map.put(SPAN_KIND.getValue(), buildAttributeValue(SPAN_KIND_SERVER_VALUE.getValue()));
+    url = HttpSemanticConventionUtils.getHttpUrlForOTelFormat(map).get();
+    assertEquals("https://example.com/webshop/articles/4?s=1", url);
   }
 
   @Test

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ExcludeSpanRuleEvaluator.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ExcludeSpanRuleEvaluator.java
@@ -144,11 +144,8 @@ public class ExcludeSpanRuleEvaluator {
    * @return full url if available, else the url path
    */
   private Optional<String> getUrl(final Event event) {
-    Optional<String> fullUrlMaybe = HttpSemanticConventionUtils.getFullHttpUrl(event);
-    if (fullUrlMaybe.isPresent()) {
-      return fullUrlMaybe;
-    }
-    return HttpSemanticConventionUtils.getHttpPath(event);
+    return HttpSemanticConventionUtils.getFullHttpUrl(event)
+        .or(() -> HttpSemanticConventionUtils.getHttpPath(event));
   }
 
   private boolean matches(

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ExcludeSpanRuleEvaluator.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ExcludeSpanRuleEvaluator.java
@@ -112,27 +112,43 @@ public class ExcludeSpanRuleEvaluator {
         case FIELD_ENVIRONMENT_NAME:
           Optional<String> environmentMaybe =
               HttpSemanticConventionUtils.getEnvironmentForSpan(event);
-          if (environmentMaybe.isEmpty()) {
-            return false;
-          }
-          return spanFilterMatcher.matches(
-              environmentMaybe.get(),
-              relationalSpanFilterExpression.getRightOperand(),
-              relationalSpanFilterExpression.getOperator());
+          return environmentMaybe
+              .filter(
+                  environment ->
+                      spanFilterMatcher.matches(
+                          environment,
+                          relationalSpanFilterExpression.getRightOperand(),
+                          relationalSpanFilterExpression.getOperator()))
+              .isPresent();
         case FIELD_URL:
-          Optional<String> fullHttpUrlMaybe = HttpSemanticConventionUtils.getFullHttpUrl(event);
-          if (fullHttpUrlMaybe.isEmpty()) {
-            return false;
-          }
-          return spanFilterMatcher.matches(
-              fullHttpUrlMaybe.get(),
-              relationalSpanFilterExpression.getRightOperand(),
-              relationalSpanFilterExpression.getOperator());
+          Optional<String> urlMaybe = getUrl(event);
+          return urlMaybe
+              .filter(
+                  url ->
+                      spanFilterMatcher.matches(
+                          url,
+                          relationalSpanFilterExpression.getRightOperand(),
+                          relationalSpanFilterExpression.getOperator()))
+              .isPresent();
         default:
           log.error("Unknown filter field: {}", field);
           return false;
       }
     }
+  }
+
+  /**
+   * Build the full url if possible, else fall back on the url path
+   *
+   * @param event Event
+   * @return full url if available, else the url path
+   */
+  private Optional<String> getUrl(final Event event) {
+    Optional<String> fullUrlMaybe = HttpSemanticConventionUtils.getFullHttpUrl(event);
+    if (fullUrlMaybe.isPresent()) {
+      return fullUrlMaybe;
+    }
+    return HttpSemanticConventionUtils.getHttpPath(event);
   }
 
   private boolean matches(

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanDropManager.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/SpanDropManager.java
@@ -20,7 +20,6 @@ import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
 
 @Slf4j
 public class SpanDropManager {
-  private final TenantIdHandler tenantIdHandler;
   private final SpanFilter spanFilter;
   private final ExcludeSpanRuleEvaluator excludeSpanRuleEvaluator;
   private static final String LATE_ARRIVAL_THRESHOLD_CONFIG_KEY =
@@ -34,13 +33,12 @@ public class SpanDropManager {
   // list of tenant ids to exclude
   private static final String TENANT_IDS_TO_EXCLUDE_CONFIG = "processor.excludeTenantIds";
 
-  private List<String> tenantIdsToExclude;
+  private final List<String> tenantIdsToExclude;
   private static final Duration minArrivalThreshold = Duration.of(30, ChronoUnit.SECONDS);
   private final Duration lateArrivalThresholdDuration;
-  private RateLimitingSpanFilter rateLimitingSpanFilter;
+  private final RateLimitingSpanFilter rateLimitingSpanFilter;
 
   public SpanDropManager(Config config, GrpcChannelRegistry grpcChannelRegistry) {
-    tenantIdHandler = new TenantIdHandler(config);
     spanFilter = new SpanFilter(config);
     excludeSpanRuleEvaluator = new ExcludeSpanRuleEvaluator(config, grpcChannelRegistry);
     rateLimitingSpanFilter = new RateLimitingSpanFilter(config);
@@ -56,7 +54,6 @@ public class SpanDropManager {
 
   @VisibleForTesting
   SpanDropManager(Config config, ExcludeSpanRulesCache excludeSpanRulesCache) {
-    tenantIdHandler = new TenantIdHandler(config);
     spanFilter = new SpanFilter(config);
     excludeSpanRuleEvaluator = new ExcludeSpanRuleEvaluator(excludeSpanRulesCache);
     lateArrivalThresholdDuration = configureLateArrivalThreshold(config);


### PR DESCRIPTION
## Description
This PR updates the logic of building the full url to make port optional. It also updates the exclusion rule url filter eval to use url path as fallback in case the full url does not exist.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules


<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
