### PR TITLE
chore: remove subscribeOn on a scheduler

### DIFF
--- a/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/accessor/entities/DefaultTraceEntityAccessor.java
+++ b/hypertrace-trace-enricher/trace-reader/src/main/java/org/hypertrace/trace/accessor/entities/DefaultTraceEntityAccessor.java
@@ -4,7 +4,6 @@ import static io.reactivex.rxjava3.core.Maybe.zip;
 import static java.util.function.Predicate.not;
 
 import io.reactivex.rxjava3.core.Maybe;
-import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -73,7 +72,6 @@ class DefaultTraceEntityAccessor implements TraceEntityAccessor {
 
   private void writeEntityIfExists(EntityType entityType, StructuredTrace trace, Event span) {
     this.buildEntity(entityType, trace, span)
-        .subscribeOn(Schedulers.io())
         .subscribe(
             entity -> {
               UpsertCondition upsertCondition =


### PR DESCRIPTION
Let the rxjava call run in the same thread. With async, it will run in threads part of async executor pool.