### PR TITLE
fix: path fetching for home paths Urls

### DIFF
--- a/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
+++ b/semantic-convention-utils/src/main/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtils.java
@@ -438,7 +438,7 @@ public class HttpSemanticConventionUtils {
   }
 
   public static URL getNormalizedUrl(String url) throws MalformedURLException, URISyntaxException {
-    String sanitizedUrl = StringUtils.stripStart(url, SLASH);
+    String sanitizedUrl = removeInitialSlashes(url);
     URL absoluteUrl = new URL(new URL(RELATIVE_URL_CONTEXT), sanitizedUrl);
     return absoluteUrl.toURI().normalize().toURL();
   }
@@ -510,7 +510,7 @@ public class HttpSemanticConventionUtils {
         if (StringUtils.isBlank(pathVal)) {
           pathVal = SLASH;
         }
-        return Optional.of(removeTrailingSlash(pathVal));
+        return Optional.of(removeTrailingSlashes(pathVal));
       } catch (MalformedURLException | URISyntaxException e) {
         LOGGER.debug(
             "On extracting httpPath, received an invalid URL: {}, {}", url.get(), e.getMessage());
@@ -530,7 +530,7 @@ public class HttpSemanticConventionUtils {
       if (attributeValueMap.get(path) != null) {
         String s = attributeValueMap.get(path).getValue();
         if (StringUtils.isNotBlank(s) && s.startsWith(SLASH)) {
-          return getPathFromUrlObject(s).map(HttpSemanticConventionUtils::removeTrailingSlash);
+          return getPathFromUrlObject(s).map(HttpSemanticConventionUtils::removeTrailingSlashes);
         }
       }
     }
@@ -897,9 +897,22 @@ public class HttpSemanticConventionUtils {
     return Optional.empty();
   }
 
-  private static String removeTrailingSlash(String s) {
-    // Ends with "/" and it's not home page path
-    return s.endsWith(SLASH) && s.length() > 1 ? s.substring(0, s.length() - 1) : s;
+  private static String removeTrailingSlashes(String url) {
+    // if it's home page path, then return /
+    String updatedUrl = StringUtils.stripEnd(url, SLASH);
+    if (updatedUrl.isEmpty()) {
+      return SLASH;
+    }
+    return updatedUrl;
+  }
+
+  private static String removeInitialSlashes(String url) {
+    // if it's home page path, then return /
+    String updatedUrl = StringUtils.stripStart(url, SLASH);
+    if (updatedUrl.isEmpty()) {
+      return SLASH;
+    }
+    return updatedUrl;
   }
 
   @Nullable

--- a/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtilsTest.java
+++ b/semantic-convention-utils/src/test/java/org/hypertrace/semantic/convention/utils/http/HttpSemanticConventionUtilsTest.java
@@ -665,4 +665,20 @@ public class HttpSemanticConventionUtilsTest {
 
     Assertions.assertEquals(HttpSemanticConventionUtils.getPrimaryDomain("10.0.0.0"), "10.0.0.0");
   }
+
+  @Test
+  void testGetPathFromUrlObject() {
+    Optional<String> path =
+        HttpSemanticConventionUtils.getPathFromUrlObject("http://app.test.com:9191/");
+    Assertions.assertTrue(path.isPresent());
+    Assertions.assertEquals("/", path.get());
+
+    path = HttpSemanticConventionUtils.getPathFromUrlObject("http://app.test.com:9191//");
+    Assertions.assertTrue(path.isPresent());
+    Assertions.assertEquals("/", path.get());
+
+    path = HttpSemanticConventionUtils.getPathFromUrlObject("http://app.test.com:9191//abc/def");
+    Assertions.assertTrue(path.isPresent());
+    Assertions.assertEquals("/abc/def", path.get());
+  }
 }


### PR DESCRIPTION
## Description
fix for creation of APIs from url like: `http://www.google.com/` and `http://www.google.com`

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
