### PR TITLE
fix: bypass.override.tenants config to be non quoted

### DIFF
--- a/.github/workflows/hypertrace-ingester/docker-compose.yml
+++ b/.github/workflows/hypertrace-ingester/docker-compose.yml
@@ -80,7 +80,7 @@ services:
     container_name: mongo
 
   pinot:
-    image: hypertrace/pinot-servicemanager:main
+    image: hypertrace/pinot-servicemanager:0.6.10
     container_name: pinot
     environment:
       - LOG_LEVEL=error

--- a/.github/workflows/hypertrace-ingester/postgres/docker-compose.yml
+++ b/.github/workflows/hypertrace-ingester/postgres/docker-compose.yml
@@ -95,7 +95,7 @@ services:
 
   # Stores spans and traces and provides aggregation functions
   pinot:
-    image: hypertrace/pinot-servicemanager:main
+    image: hypertrace/pinot-servicemanager:0.6.10
     container_name: pinot
     environment:
       - LOG_LEVEL=error

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -67,14 +67,14 @@
     <packageUrl regex="true">^pkg:maven/org\.hypertrace\.core\.kafkastreams\.framework/avro\-partitioners@.*$</packageUrl>
     <cve>CVE-2023-37475</cve>
   </suppress>
-  <suppress until="2024-01-31Z">
+  <suppress until="2024-02-29Z">
     <notes><![CDATA[
    Not yet fixed in quartz. file name: quartz-2.3.2.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.quartz\-scheduler/quartz@.*$</packageUrl>
     <cve>CVE-2023-39017</cve>
   </suppress>
-  <suppress until="2024-01-30Z">
+  <suppress until="2024-02-29Z">
     <notes><![CDATA[
    file name: json-20230618.jar
    ]]></notes>
@@ -102,11 +102,11 @@
     <packageUrl regex="true">^pkg:maven/io\.netty/netty.*@.*$</packageUrl>
     <vulnerabilityName>CVE-2023-4586</vulnerabilityName>
   </suppress>
-  <suppress until="2024-01-30Z">
+  <suppress until="2024-02-29Z">
     <packageUrl regex="true">^pkg:maven/io\.netty/netty.*@.*$</packageUrl>
     <vulnerabilityName>CVE-2023-44487</vulnerabilityName>
   </suppress>
-  <suppress until="2024-01-31Z">
+  <suppress until="2024-02-29Z">
     <notes><![CDATA[
    This CVE (rapid RST) is already mitigated as our servers aren't directly exposed, but it's also
    addressed in 1.59.1, which the CVE doesn't reflect (not all grpc impls versions are exactly aligned).

--- a/span-normalizer/helm/templates/span-normalizer-config.yaml
+++ b/span-normalizer/helm/templates/span-normalizer-config.yaml
@@ -72,7 +72,7 @@ data:
       {{- end }}
       
       {{- if hasKey .Values.spanNormalizerConfig.processor "bypassOverrideTenants" }}
-      bypass.override.tenants = "{{ .Values.spanNormalizerConfig.processor.bypassOverrideTenants | toJson }}"
+      bypass.override.tenants = {{ .Values.spanNormalizerConfig.processor.bypassOverrideTenants | toJson }}
       {{- end }}
 
       {{- if hasKey .Values.spanNormalizerConfig.processor "lateArrivalThresholdDuration" }}

--- a/span-normalizer/span-normalizer/src/test/resources/configs/span-normalizer/application.conf
+++ b/span-normalizer/span-normalizer/src/test/resources/configs/span-normalizer/application.conf
@@ -72,6 +72,7 @@ processor {
 
 processor {
   bypass.key = "test.bypass"
+  bypass.override.tenants = ["a", "b"]
   late.arrival.threshold.duration = "1d"
 
   # Configuration for dropping certain attributes that are captured by agent, but doesn't require in


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
