### PR TITLE
fix: re-registring of cache metrics

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/cache/EntityCache.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/cache/EntityCache.java
@@ -1,6 +1,5 @@
 package org.hypertrace.traceenricher.enrichment.enrichers.cache;
 
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -102,21 +101,26 @@ public class EntityCache {
                     CacheLoader.from(this::loadBackendFromIdentifyingAttributes),
                     asyncCacheLoaderExecutor));
 
-    registerCacheMetrics(
-        "fqnToServiceEntityCache", fqnToServiceEntityCache, DEFAULT_CACHE_MAX_SIZE);
-    registerCacheMetrics(
-        "nameToServiceEntitiesCache", nameToServiceEntitiesCache, DEFAULT_CACHE_MAX_SIZE);
-    registerCacheMetrics(
-        "nameToNamespaceEntitiesCache", nameToNamespaceEntitiesCache, DEFAULT_CACHE_MAX_SIZE);
-    registerCacheMetrics(
-        "backendIdAttrsToEntityCache", backendIdAttrsToEntityCache, DEFAULT_CACHE_MAX_SIZE);
-  }
-
-  private void registerCacheMetrics(String cacheNameSuffix, Cache cache, int cacheMaxSize) {
-    String cacheName = this.getClass().getName() + DOT + cacheNameSuffix;
-    PlatformMetricsRegistry.registerCache(cacheName, cache, Collections.emptyMap());
     PlatformMetricsRegistry.registerCacheTrackingOccupancy(
-        cacheName, cache, Collections.emptyMap(), cacheMaxSize);
+        "fqnToServiceEntityCache",
+        fqnToServiceEntityCache,
+        Collections.emptyMap(),
+        DEFAULT_CACHE_MAX_SIZE);
+    PlatformMetricsRegistry.registerCacheTrackingOccupancy(
+        "nameToServiceEntitiesCache",
+        nameToServiceEntitiesCache,
+        Collections.emptyMap(),
+        DEFAULT_CACHE_MAX_SIZE);
+    PlatformMetricsRegistry.registerCacheTrackingOccupancy(
+        "nameToNamespaceEntitiesCache",
+        nameToNamespaceEntitiesCache,
+        Collections.emptyMap(),
+        DEFAULT_CACHE_MAX_SIZE);
+    PlatformMetricsRegistry.registerCacheTrackingOccupancy(
+        "backendIdAttrsToEntityCache",
+        backendIdAttrsToEntityCache,
+        Collections.emptyMap(),
+        DEFAULT_CACHE_MAX_SIZE);
   }
 
   public LoadingCache<Pair<String, String>, Optional<Entity>> getFqnToServiceEntityCache() {

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/space/SpaceRulesCachingClient.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/space/SpaceRulesCachingClient.java
@@ -1,6 +1,5 @@
 package org.hypertrace.traceenricher.enrichment.enrichers.space;
 
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -30,14 +29,8 @@ class SpaceRulesCachingClient {
         SpacesConfigServiceGrpc.newBlockingStub(spacesConfigChannel)
             .withCallCredentials(
                 RequestContextClientCallCredsProviderFactory.getClientCallCredsProvider().get());
-    registerCacheMetrics("spaceRulesCache", spaceRulesCache, DEFAULT_CACHE_MAX_SIZE);
-  }
-
-  private void registerCacheMetrics(String cacheNameSuffix, Cache cache, int cacheMaxSize) {
-    String cacheName = this.getClass().getName() + DOT + cacheNameSuffix;
-    PlatformMetricsRegistry.registerCache(cacheName, cache, Collections.emptyMap());
     PlatformMetricsRegistry.registerCacheTrackingOccupancy(
-        cacheName, cache, Collections.emptyMap(), cacheMaxSize);
+        "spaceRulesCache", spaceRulesCache, Collections.emptyMap(), DEFAULT_CACHE_MAX_SIZE);
   }
 
   private final LoadingCache<String, List<SpaceConfigRule>> spaceRulesCache =

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/util/UserAgentParser.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/util/UserAgentParser.java
@@ -1,6 +1,5 @@
 package org.hypertrace.traceenricher.util;
 
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -38,14 +37,8 @@ public class UserAgentParser {
             .expireAfterAccess(cacheConfig.getDuration(CACHE_CONFIG_ACCESS_EXPIRATION_DURATION))
             .recordStats()
             .build(CacheLoader.from(userAgentStringParser::parse));
-    registerCacheMetrics("userAgentCache", userAgentCache, cacheMaxSize);
-  }
-
-  private void registerCacheMetrics(String cacheNameSuffix, Cache cache, int cacheMaxSize) {
-    String cacheName = this.getClass().getName() + "." + cacheNameSuffix;
-    PlatformMetricsRegistry.registerCache(cacheName, cache, Collections.emptyMap());
     PlatformMetricsRegistry.registerCacheTrackingOccupancy(
-        cacheName, cache, Collections.emptyMap(), cacheMaxSize);
+        "userAgentCache", userAgentCache, Collections.emptyMap(), cacheMaxSize);
   }
 
   public Optional<ReadableUserAgent> getUserAgent(Event event) {

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ExcludeSpanRulesCache.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/ExcludeSpanRulesCache.java
@@ -1,6 +1,5 @@
 package org.hypertrace.core.spannormalizer.jaeger;
 
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -80,13 +79,8 @@ public class ExcludeSpanRulesCache {
                       }
                     },
                     Executors.newSingleThreadExecutor()));
-    registerCacheMetrics(CACHE_NAME, excludeSpanRulesCache, DEFAULT_CACHE_MAX_SIZE);
-  }
-
-  private void registerCacheMetrics(String cacheName, Cache cache, int cacheMaxSize) {
-    PlatformMetricsRegistry.registerCache(cacheName, cache, Collections.emptyMap());
     PlatformMetricsRegistry.registerCacheTrackingOccupancy(
-        cacheName, cache, Collections.emptyMap(), cacheMaxSize);
+        CACHE_NAME, excludeSpanRulesCache, Collections.emptyMap(), DEFAULT_CACHE_MAX_SIZE);
   }
 
   // TODO: Find an alternative approach to avoid use of singleton instance


### PR DESCRIPTION
As part of my previous PR: https://github.com/hypertrace/hypertrace-ingester/pull/453, I assumed that the api `registerCacheTrackingOccupancy` only register max cache size gauge metrics. But, as pointed out in PR comment, it also register input cache for metrics. 

As part of this PR, addressing the comment of registration of same cache twice.