### PR TITLE
chore: fixed the naming of entity cache

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/cache/EntityCache.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/cache/EntityCache.java
@@ -102,22 +102,22 @@ public class EntityCache {
                     asyncCacheLoaderExecutor));
 
     PlatformMetricsRegistry.registerCacheTrackingOccupancy(
-        "fqnToServiceEntityCache",
+        this.getClass().getName() + DOT + "fqnToServiceEntityCache",
         fqnToServiceEntityCache,
         Collections.emptyMap(),
         DEFAULT_CACHE_MAX_SIZE);
     PlatformMetricsRegistry.registerCacheTrackingOccupancy(
-        "nameToServiceEntitiesCache",
+        this.getClass().getName() + DOT + "nameToServiceEntitiesCache",
         nameToServiceEntitiesCache,
         Collections.emptyMap(),
         DEFAULT_CACHE_MAX_SIZE);
     PlatformMetricsRegistry.registerCacheTrackingOccupancy(
-        "nameToNamespaceEntitiesCache",
+        this.getClass().getName() + DOT + "nameToNamespaceEntitiesCache",
         nameToNamespaceEntitiesCache,
         Collections.emptyMap(),
         DEFAULT_CACHE_MAX_SIZE);
     PlatformMetricsRegistry.registerCacheTrackingOccupancy(
-        "backendIdAttrsToEntityCache",
+        this.getClass().getName() + DOT + "backendIdAttrsToEntityCache",
         backendIdAttrsToEntityCache,
         Collections.emptyMap(),
         DEFAULT_CACHE_MAX_SIZE);

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/space/SpaceRulesCachingClient.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/space/SpaceRulesCachingClient.java
@@ -30,7 +30,10 @@ class SpaceRulesCachingClient {
             .withCallCredentials(
                 RequestContextClientCallCredsProviderFactory.getClientCallCredsProvider().get());
     PlatformMetricsRegistry.registerCacheTrackingOccupancy(
-        "spaceRulesCache", spaceRulesCache, Collections.emptyMap(), DEFAULT_CACHE_MAX_SIZE);
+        this.getClass().getName() + DOT + "spaceRulesCache",
+        spaceRulesCache,
+        Collections.emptyMap(),
+        DEFAULT_CACHE_MAX_SIZE);
   }
 
   private final LoadingCache<String, List<SpaceConfigRule>> spaceRulesCache =

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/util/UserAgentParser.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/util/UserAgentParser.java
@@ -38,7 +38,10 @@ public class UserAgentParser {
             .recordStats()
             .build(CacheLoader.from(userAgentStringParser::parse));
     PlatformMetricsRegistry.registerCacheTrackingOccupancy(
-        "userAgentCache", userAgentCache, Collections.emptyMap(), cacheMaxSize);
+        this.getClass().getName() + ".userAgentCache",
+        userAgentCache,
+        Collections.emptyMap(),
+        cacheMaxSize);
   }
 
   public Optional<ReadableUserAgent> getUserAgent(Event event) {

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -115,4 +115,13 @@
     <packageUrl regex="true">^pkg:maven/io\.grpc/grpc\-.*@.*$</packageUrl>
     <cve>CVE-2023-44487</cve>
   </suppress>
+  <suppress until="2024-03-30Z">
+    <notes><![CDATA[
+   The fix might be available in 1.26.0, we will upgrade to it when its available
+   file name: commons-compress-1.24.0.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons\-compress@.*$</packageUrl>
+    <cve>CVE-2024-25710</cve>
+    <cve>CVE-2024-26308</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
- Prefixing the class name as part of entity cache
- Reference PR: https://github.com/hypertrace/hypertrace-ingester/pull/453/files